### PR TITLE
Possibility to provide custom password

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,11 @@
 FROM java:openjdk-8-jdk
 MAINTAINER Michael Hunger, <michael.hunger@neotechnology.com>
 
-# Install latest Neo4j Community Stable Version from http://debian.neo4j.org
+# Install 2.2.2 Enterprise Version available from http://debian.neo4j.org
+RUN apt-get update
 RUN apt-get install -y curl
+RUN apt-get install -y lsof
+RUN apt-get install -y net-tools
 RUN curl http://dist.neo4j.org/neo4j-community-2.2.3-unix.tar.gz -o - | tar xzf - -C /var/lib && ln -s /var/lib/neo4j-* /var/lib/neo4j
 
 ## add launcher and set execute property

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Note: this is just _work in progress_ alpha state, not suited for production/serious use**
 
-Neo4j is an highly scalable, robust (fully ACID) native graph database. 
+Neo4j is an highly scalable, robust (fully ACID) native graph database.
 It is used in mission-critical apps by thousands of leading, startups, enterprises, and governments around the world.
 
 Learn more on http://neo4j.com and get started with http://neo4j.com/developer
@@ -31,7 +31,7 @@ docker run -i -t --rm --name neo4j -v $HOME/neo4j-data:/data -p 8476:7474 <image
 
 2. Open in browser
 
-     `http://localhost:8474` 
+     `http://localhost:8474`
 
 On OSX use http://boot2docker.io/[boot2docker] and replace localhost with the IP from `$DOCKERHOST` instead.
 
@@ -39,7 +39,14 @@ On OSX use http://boot2docker.io/[boot2docker] and replace localhost with the IP
 
 
 Please note that Neo4j 2.2.2 requires authentication.
-You have to login with `neo4j/neo4j` at the first connection and set a new password.
+
+Providing your own password :
+
+You can provide your own password when starting the container with the `NEO4J_AUTH` environment variable :
+
+docker run -i -t --rm --name neo4j -v $HOME/neo4j-data:/data -p 8476:7474 -e NEO4J_AUTH=myPassword <image-id>
+
+If you don't provided a password as environment variable when starting the container, you'll have to login with `neo4j/neo4j` at the first connection and set a new password.
 The auth credentials are stored in the `/data/dbms/auth` file, which will reside in your external directory.
 
 You can also access the Neo4j log-files in `data/log` and `data/graph.db/messages.log`

--- a/neo4j.sh
+++ b/neo4j.sh
@@ -8,7 +8,7 @@ echo "wrapper.java.additional=-Djava.rmi.server.hostname=$HOSTNAME" >> $NEO4J_HO
 #echo "wrapper.java.additional=-Dcom.sun.management.jmxremote.rmi.port=1099" >> $NEO4J_HOME/conf/neo4j-wrapper.conf
 
 if [ $NEO4J_NO_AUTH ]; then
-   sed -i -e "s/dbms.security.auth_enabled=.*/dbms.security.auth_enabled=false/g" $NEO4J_HOME/conf/neo4j-server.properties
+   sed -i -e "s|dbms.security.auth_enabled=.*|dbms.security.auth_enabled=false|g" $NEO4J_HOME/conf/neo4j-server.properties
 fi
 
 limit=`ulimit -n`

--- a/neo4j.sh
+++ b/neo4j.sh
@@ -8,7 +8,7 @@ echo "wrapper.java.additional=-Djava.rmi.server.hostname=$HOSTNAME" >> $NEO4J_HO
 #echo "wrapper.java.additional=-Dcom.sun.management.jmxremote.rmi.port=1099" >> $NEO4J_HOME/conf/neo4j-wrapper.conf
 
 if [ $NEO4J_NO_AUTH ]; then
-   sed -i -e "s/dbms.security.auth_enabled=true/dbms.security.auth_enabled=false/g" $NEO4J_HOME/conf/neo4j-server.properties
+   sed -i -e "s/dbms.security.auth_enabled=.*/dbms.security.auth_enabled=false/g" $NEO4J_HOME/conf/neo4j-server.properties
 fi
 
 limit=`ulimit -n`

--- a/neo4j.sh
+++ b/neo4j.sh
@@ -2,13 +2,13 @@
 
 NEO4J_HOME=/var/lib/neo4j
 
-sed -i "s|#org.neo4j.server.webserver.address=0.0.0.0|org.neo4j.server.webserver.address=$HOSTNAME|g" $NEO4J_HOME/conf/neo4j-server.properties
+sed -i "s|#org.neo4j.server.webserver.address=0.0.0.0|org.neo4j.server.webserver.address=0.0.0.0|g" $NEO4J_HOME/conf/neo4j-server.properties
 echo "wrapper.java.additional=-Djava.rmi.server.hostname=$HOSTNAME" >> $NEO4J_HOME/conf/neo4j-wrapper.conf
 #echo "wrapper.java.additional=-Dcom.sun.management.jmxremote.port=1099" >> $NEO4J_HOME/conf/neo4j-wrapper.conf
 #echo "wrapper.java.additional=-Dcom.sun.management.jmxremote.rmi.port=1099" >> $NEO4J_HOME/conf/neo4j-wrapper.conf
 
 if [ $NEO4J_NO_AUTH ]; then
-   sed -i -e "s|dbms.security.auth_enabled=.*|dbms.security.auth_enabled=false|g" $NEO4J_HOME/conf/neo4j-server.properties
+   sed -i -e "s/dbms.security.auth_enabled=true/dbms.security.auth_enabled=false/g" $NEO4J_HOME/conf/neo4j-server.properties
 fi
 
 limit=`ulimit -n`
@@ -23,4 +23,11 @@ ln -s /data $NEO4J_HOME/data
 # override what's needed
 cp /conf/* $NEO4J_HOME/conf/
 
-$NEO4J_HOME/bin/neo4j console
+$NEO4J_HOME/bin/neo4j start
+
+if [ $NEO4J_AUTH ] && ! [ $NEO4J_NO_AUTH ]; then
+  IPADDR="$(hostname -i)"
+  curl -X POST --user neo4j:neo4j -d '{"password": "'${NEO4J_AUTH:-password}'"}' -H 'Content-Type: application/json' -i http://${IPADDR}:7474/user/neo4j/password
+fi
+
+tail -f $NEO4J_HOME/data/log/console.log


### PR DESCRIPTION
This changes the webserver address to 0.0.0.0. Also I needed to get the hostname, because in docker containers localhost connections are not possible (a long discussion to read on docker github).

Added changes in README too.

Usage : 

```
docker run -i -t --rm --name neo4j -v $HOME/neo4j-data:/data -p 8476:7474 -e NEO4J_AUTH=myPassword <image-id>
```

NB: If you combine `NEO4J_AUTH` and `NEO4J_NOAUTH` it will disable auth by defaut.