### PR TITLE
Add Vagrantfile for building on OS X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/.vagrant/
 /dev/
 devenv.local

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,10 @@
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/vivid64"
+
+  config.vm.provision "shell", inline: <<-SHELL
+    sudo apt-get update
+    sudo apt-get install -y docker.io
+    sudo service docker start
+    sudo adduser vagrant docker
+  SHELL
+end


### PR DESCRIPTION
I put this Vagrantfile together to make the build process easier on OS X (my main dev environment for my fork of this repo). All it does is install and start the Docker service on an Ubuntu Vivid base, but from there it only takes a `vagrant ssh` and `cd /vagrant; make` to build the Dockerfiles.