### PR TITLE
Updated default host of neo4j

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The image exposes two ports (`7474` and `7473`) for HTTP and HTTPS access to the
 	    --volume=$HOME/neo4j-data:/data \
 	    neo4j/neo4j
 
-Point your browser at `http://192.168.99.100:7474`. Where here `192.168.99.100` is the ip of the Docker hosts.
+Point your browser at `http://192.168.99.100:7474`. Where here `192.168.99.100` is the ip of the Docker host.
 
 Please note that by default Neo4j requires authentication. You have to login with `neo4j/neo4j` at the first connection and set a new password.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The image exposes two ports (`7474` and `7473`) for HTTP and HTTPS access to the
 	    --volume=$HOME/neo4j-data:/data \
 	    neo4j/neo4j
 
-Point your browser at `http://192.168.99.100:7474`. Where here `192.168.99.100` is the ip of the Docker host.
+Point your browser at `http://localhost:7474`. Replace `localhost` with your Docker Machine IP address on OS X and Windows.
 
 Please note that by default Neo4j requires authentication. You have to login with `neo4j/neo4j` at the first connection and set a new password.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The image exposes two ports (`7474` and `7473`) for HTTP and HTTPS access to the
 	    --volume=$HOME/neo4j-data:/data \
 	    neo4j/neo4j
 
-Point your browser at `http://localhost:7474`.
+Point your browser at `http://192.168.99.100:7474`. Where here `192.168.99.100` is the ip of the Docker hosts.
 
 Please note that by default Neo4j requires authentication. You have to login with `neo4j/neo4j` at the first connection and set a new password.
 


### PR DESCRIPTION
Docker doesn't run on localhost. I don't know however if `192.168.99.100` is the default docker host ip on all platforms.