### PR TITLE
Expose hook for downstream consumers of image

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,17 @@ For more complex customization of the image you can create a new image based on 
 
 	FROM neo4j/neo4j
 
+If you need to make your own configuration changes, we provide a hook so you can do that in a script:
+
+	COPY extra_conf.sh /extra_conf.sh
+
+Then you can pass in the `EXTENSION_SCRIPT` environment variable at runtime to source the script:
+
+	docker run -e "EXTENSION_SCRIPT=/extra_conf.sh" cafe12345678
+
+When the extension script is sourced, the current working directory will be the root of the Neo4j installation.
+
+
 ## Neo4j HA
 
 (This feature is only available in Neo4j Enterprise Edition.)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -43,6 +43,8 @@ if [ "$1" == "neo4j" ]; then
     setting "ha.cluster_server" "${NEO4J_HA_ADDRESS:-}:5001" neo4j.properties
     setting "ha.initial_hosts" "${NEO4J_INITIAL_HOSTS:-}" neo4j.properties
 
+    [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
+
     if [ -d /conf ]; then
         find /conf -type f -exec cp {} conf \;
     fi


### PR DESCRIPTION
If you're creating an image based on this one, you might want to
override 1 or 2 configuration values without duplicating the entire
entrypoint script.

This commit enables image builders to call an additional script via an
environment variable (if they add the script to their image).