### PR TITLE
Set settings that aren't already present

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,7 +5,11 @@ setting() {
     value="${2}"
     file="${3}"
     if [ -n "${value}" ]; then
-        sed --in-place "s|.*${setting}=.*|${setting}=${value}|" conf/"${file}"
+        if  grep -q ".*${setting}=" conf/"${file}" ; then
+            echo "${setting}=${value}" >> conf/"${file}"
+        else
+            sed --in-place "s|.*${setting}=.*|${setting}=${value}|" conf/"${file}"
+        fi
     fi
 }
 


### PR DESCRIPTION
The current version of setting() only edits settings already present in the config files. I discovered this while trying to set a read_only setting but it holds true in general. The version included sets appends settings if they are not already present in the config file. If this change is accepted it would have to be applied to all copies of the entrypoint script.

Peter