### PR TITLE
Listen on localhost only when setting credentials

### DIFF
--- a/src/2.3/docker-entrypoint.sh
+++ b/src/2.3/docker-entrypoint.sh
@@ -27,6 +27,7 @@ if [ "$1" == "neo4j" ]; then
         setting "dbms.security.auth_enabled" "false" neo4j-server.properties
     elif [[ "${NEO4J_AUTH:-}" == neo4j/* ]]; then
         password="${NEO4J_AUTH#neo4j/}"
+        setting "org.neo4j.server.webserver.address" "127.0.0.1" neo4j-server.properties
         bin/neo4j start || \
             (cat data/log/console.log && echo "Neo4j failed to start" && exit 1)
         if ! curl --fail --silent --user "neo4j:${password}" http://localhost:7474/db/data/ >/dev/null ; then

--- a/src/3.0/docker-entrypoint.sh
+++ b/src/3.0/docker-entrypoint.sh
@@ -38,6 +38,9 @@ if [ "$1" == "neo4j" ]; then
             exit 1
         fi
 
+        setting "dbms.connector.http.address" "127.0.0.1:7474"
+        setting "dbms.connector.https.address" "127.0.0.1:7473"
+        setting "dbms.connector.bolt.address" "127.0.0.1:7687"
         bin/neo4j start || \
             (cat logs/neo4j.log && echo "Neo4j failed to start" && exit 1)
 


### PR DESCRIPTION
When `NEO4J_AUTH` is set, the server is started to set the credentials, then stopped and started again with the final configuration. When a container is restarted, this initial server listens on `0.0.0.0` causing other dependent containers to see the Neo4j container as ready before it actually is. This PR fixes the issue by explicitly setting the address to `127.0.0.1` for the server pre-run.

Previous discussion at https://github.com/neo4j/neo4j/issues/7203