### PR TITLE
Fix custom password still requiring a change

### DIFF
--- a/src/3.1/docker-entrypoint.sh
+++ b/src/3.1/docker-entrypoint.sh
@@ -37,7 +37,7 @@ if [ "$1" == "neo4j" ]; then
             echo "Invalid value for password. It cannot be 'neo4j', which is the default."
             exit 1
         fi
-        bin/neo4j-admin users set-password neo4j "${password}"
+        bin/neo4j-admin users set-password neo4j "${password}" --requires-password-change=false
     elif [ -n "${NEO4J_AUTH:-}" ]; then
         echo "Invalid value for NEO4J_AUTH: '${NEO4J_AUTH}'"
         exit 1

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -30,3 +30,11 @@ neo4j_wait() {
     sleep 1
   done
 }
+
+neo4j_createnode() {
+  local l_ip="$1" end="$((SECONDS+30))"
+  if [[ -n "${2:-}" ]]; then
+    local auth="--user $2"
+  fi
+  [[ "201" = "$(curl --silent --write-out '%{http_code}' --request POST --output /dev/null ${auth:-} http://${l_ip}:7474/db/data/node)" ]] || exit 1
+}

--- a/test/test-sets-password
+++ b/test/test-sets-password
@@ -9,3 +9,4 @@ readonly cname="neo4j-$(uuidgen)"
 
 docker_run "$image" "$cname" "NEO4J_AUTH=neo4j/foo"
 neo4j_wait "$(docker_ip "${cname}")" "neo4j:foo"
+neo4j_createnode "$(docker_ip "${cname}")" "neo4j:foo"


### PR DESCRIPTION
Starting the database with a custom password previously required the
user to change said password on first start.