### PR TITLE
Add Core-Edge support to Docker image

### DIFF
--- a/src/3.1/docker-entrypoint.sh
+++ b/src/3.1/docker-entrypoint.sh
@@ -43,6 +43,7 @@ if [ "$1" == "neo4j" ]; then
         exit 1
     fi
 
+    setting "dbms.connectors.default_listen_address" "0.0.0.0"
     setting "dbms.connector.http.listen_address" "0.0.0.0:7474"
     setting "dbms.connector.https.listen_address" "0.0.0.0:7473"
     setting "dbms.connector.bolt.listen_address" "0.0.0.0:7687"
@@ -51,6 +52,10 @@ if [ "$1" == "neo4j" ]; then
     setting "ha.host.data" "${NEO4J_ha_host_data:-}"
     setting "ha.host.coordination" "${NEO4J_ha_host_coordination:-}"
     setting "ha.initial_hosts" "${NEO4J_ha_initialHosts:-}"
+    setting "core_edge.expected_core_cluster_size" "${NEO4J_coreEdge_expectedCoreClusterSize:-}"
+    setting "core_edge.initial_discovery_members" "${NEO4J_coreEdge_initialDiscoveryMembers:-}"
+    setting "core_edge.transaction_advertised_address" "${NEO4J_coreEdge_transactionAdvertisedAddress:-$(hostname):6000}"
+    setting "core_edge.raft_advertised_address" "${NEO4J_coreEdge_raftAdvertisedAddress:-$(hostname):7000}"
 
     [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
 


### PR DESCRIPTION
A minimal `docker-compose.yml` file (image names should be changed to `neo4j/3.1` or similarly):

```yaml
version: '2'

networks:
  cluster-lan:

services:

  core1:
    image: test/18984
    ports:
      - "7474:7474"
      - "7473:7473"
      - "7687:7687"
    networks:
      - cluster-lan
    environment:
      - NEO4J_AUTH=neo4j/neo
      - NEO4J_dbms_mode=CORE
      - NEO4J_coreEdge_expectedCoreClusterSize=3
      - NEO4J_coreEdge_initialDiscoveryMembers=core1:5000,core2:5000,core3:5000

  core2:
    image: test/18984
    networks:
      - cluster-lan
    environment:
      - NEO4J_AUTH=neo4j/neo
      - NEO4J_dbms_mode=CORE
      - NEO4J_coreEdge_expectedCoreClusterSize=3
      - NEO4J_coreEdge_initialDiscoveryMembers=core1:5000,core2:5000,core3:5000

  core3:
    image: test/18984
    networks:
      - cluster-lan
    environment:
      - NEO4J_AUTH=neo4j/neo
      - NEO4J_dbms_mode=CORE
      - NEO4J_coreEdge_transactionAdvertisedAddress=core3:5000
      - NEO4J_coreEdge_raftAdvertisedAddress=core3:7000
      - NEO4J_coreEdge_expectedCoreClusterSize=3
      - NEO4J_coreEdge_initialDiscoveryMembers=core1:5000,core2:5000,core3:5000
```

The first two cores specify the minimum number of configs for use in
docker networks. The third core specifies the `advertisedAddress`
settings as well, which are required if you do NOT use docker networks.

If you want edges, you can add them (notice how only the names need to be different):

```yaml
    edge1:
    image: test/18984
    networks:
      - cluster-lan
    environment:
      - NEO4J_AUTH=neo4j/neo
      - NEO4J_dbms_mode=EDGE
      - NEO4J_coreEdge_initialDiscoveryMembers=core1:5000,core2:5000,core3:5000

    edge2:
    image: test/18984
    networks:
      - cluster-lan
    environment:
      - NEO4J_AUTH=neo4j/neo
      - NEO4J_dbms_mode=EDGE
      - NEO4J_coreEdge_initialDiscoveryMembers=core1:5000,core2:5000,core3:5000
```