### PR TITLE
Some nice to haves

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,6 +10,10 @@ other Linuxes. Pull requests welcomed for other platforms.
 1. install GNU Make (>=4.0)
 1. install the Docker Toolbox
 
+## Debian
+
+1. install `uuid-runtime`
+
 ## All platforms
 
 1. download the Neo4j Community unix tarball

--- a/Makefile
+++ b/Makefile
@@ -68,11 +68,17 @@ tmp/image-%/.sentinel: src/$(series)/Dockerfile src/$(series)/docker-entrypoint.
 run = trapping-sigint \
     docker run --publish 7474:7474 --publish 7687:7687 \
     --env=NEO4J_AUTH=neo4j/foo --rm $$(cat $1)
+build-enterprise: tmp/.image-id-enterprise
+> @echo "Neo4j $(NEO4J_VERSION)-enterprise available as: $$(cat $<)"
+build-community: tmp/.image-id-community
+> @echo "Neo4j $(NEO4J_VERSION)-community available as: $$(cat $<)"
 run-enterprise: tmp/.image-id-enterprise
 > $(call run,$<)
 run-community: tmp/.image-id-community
 > $(call run,$<)
-.PHONY: run-enterprise run-community
+test-enterprise: tmp/.tests-pass-enterprise
+test-community: tmp/.tests-pass-community
+.PHONY: run-enterprise run-community build-enterprise build-community test-enterprise test-community
 
 fetch_tarball = curl --fail --silent --show-error --location --remote-name \
     $(dist_site)/$(call tarball,$(1),$(NEO4J_VERSION))


### PR DESCRIPTION
- `uuid` was not already installed on my system, so I added it to the list of requirements
- I didn't know what I could type to just build (or test) the image as I developed stuff so I added some shortcuts with clear names for that