### PR TITLE
Switch to the openjdk repository

### DIFF
--- a/src/2.3/Dockerfile
+++ b/src/2.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 RUN apt-get update --quiet --quiet \
     && apt-get install --quiet --quiet --no-install-recommends lsof \

--- a/src/3.0/Dockerfile
+++ b/src/3.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 ENV NEO4J_SHA256 %%NEO4J_SHA%%
 ENV NEO4J_TARBALL %%NEO4J_TARBALL%%

--- a/src/3.1/Dockerfile
+++ b/src/3.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre-alpine
+FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache --quiet \
     bash \

--- a/src/3.2/Dockerfile
+++ b/src/3.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre-alpine
+FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache --quiet \
     bash \


### PR DESCRIPTION
From the java repository:

This image is officially deprecated in favor of the openjdk image, and will receive no further updates after 2016-12-31 (Dec 31, 2016). Please adjust your usage accordingly.

https://hub.docker.com/_/java/