### PR TITLE
added possibility to set default_advertised_address through  environment variable

### DIFF
--- a/src/3.1/docker-entrypoint.sh
+++ b/src/3.1/docker-entrypoint.sh
@@ -42,6 +42,9 @@ if [ "$1" == "neo4j" ]; then
     setting "dbms.connector.https.listen_address" "0.0.0.0:7473"
     setting "dbms.connector.bolt.listen_address" "0.0.0.0:7687"
     setting "dbms.mode" "${NEO4J_dbms_mode:-}"
+    if [ -z "$NEO4J_dbms_advertisedAddress" ]; then
+        setting "dbms.connectors.default_advertised_address" "$NEO4J_dbms_advertisedAddress"
+    fi
     setting "ha.server_id" "${NEO4J_ha_serverId:-}"
     setting "ha.host.data" "${NEO4J_ha_host_data:-}"
     setting "ha.host.coordination" "${NEO4J_ha_host_coordination:-}"

--- a/src/3.1/docker-entrypoint.sh
+++ b/src/3.1/docker-entrypoint.sh
@@ -42,9 +42,7 @@ if [ "$1" == "neo4j" ]; then
     setting "dbms.connector.https.listen_address" "0.0.0.0:7473"
     setting "dbms.connector.bolt.listen_address" "0.0.0.0:7687"
     setting "dbms.mode" "${NEO4J_dbms_mode:-}"
-    if [ -n "$NEO4J_dbms_advertisedAddress" ]; then
-        setting "dbms.connectors.default_advertised_address" "$NEO4J_dbms_advertisedAddress"
-    fi
+    setting "dbms.connectors.default_advertised_address" "${NEO4J_dbms_connectors_defaultAdvertisedAddress:-}"
     setting "ha.server_id" "${NEO4J_ha_serverId:-}"
     setting "ha.host.data" "${NEO4J_ha_host_data:-}"
     setting "ha.host.coordination" "${NEO4J_ha_host_coordination:-}"

--- a/src/3.1/docker-entrypoint.sh
+++ b/src/3.1/docker-entrypoint.sh
@@ -42,7 +42,7 @@ if [ "$1" == "neo4j" ]; then
     setting "dbms.connector.https.listen_address" "0.0.0.0:7473"
     setting "dbms.connector.bolt.listen_address" "0.0.0.0:7687"
     setting "dbms.mode" "${NEO4J_dbms_mode:-}"
-    if [ -z "$NEO4J_dbms_advertisedAddress" ]; then
+    if [ -n "$NEO4J_dbms_advertisedAddress" ]; then
         setting "dbms.connectors.default_advertised_address" "$NEO4J_dbms_advertisedAddress"
     fi
     setting "ha.server_id" "${NEO4J_ha_serverId:-}"

--- a/src/3.2/docker-entrypoint.sh
+++ b/src/3.2/docker-entrypoint.sh
@@ -42,6 +42,9 @@ if [ "$1" == "neo4j" ]; then
     setting "dbms.connector.https.listen_address" "0.0.0.0:7473"
     setting "dbms.connector.bolt.listen_address" "0.0.0.0:7687"
     setting "dbms.mode" "${NEO4J_dbms_mode:-}"
+    if [ -z "$NEO4J_dbms_advertisedAddress" ]; then
+        setting "dbms.connectors.default_advertised_address" "$NEO4J_dbms_advertisedAddress"
+    fi
     setting "ha.server_id" "${NEO4J_ha_serverId:-}"
     setting "ha.host.data" "${NEO4J_ha_host_data:-}"
     setting "ha.host.coordination" "${NEO4J_ha_host_coordination:-}"

--- a/src/3.2/docker-entrypoint.sh
+++ b/src/3.2/docker-entrypoint.sh
@@ -42,9 +42,7 @@ if [ "$1" == "neo4j" ]; then
     setting "dbms.connector.https.listen_address" "0.0.0.0:7473"
     setting "dbms.connector.bolt.listen_address" "0.0.0.0:7687"
     setting "dbms.mode" "${NEO4J_dbms_mode:-}"
-    if [ -n "$NEO4J_dbms_advertisedAddress" ]; then
-        setting "dbms.connectors.default_advertised_address" "$NEO4J_dbms_advertisedAddress"
-    fi
+    setting "dbms.connectors.default_advertised_address" "${NEO4J_dbms_connectors_defaultAdvertisedAddress:-}"
     setting "ha.server_id" "${NEO4J_ha_serverId:-}"
     setting "ha.host.data" "${NEO4J_ha_host_data:-}"
     setting "ha.host.coordination" "${NEO4J_ha_host_coordination:-}"

--- a/src/3.2/docker-entrypoint.sh
+++ b/src/3.2/docker-entrypoint.sh
@@ -42,7 +42,7 @@ if [ "$1" == "neo4j" ]; then
     setting "dbms.connector.https.listen_address" "0.0.0.0:7473"
     setting "dbms.connector.bolt.listen_address" "0.0.0.0:7687"
     setting "dbms.mode" "${NEO4J_dbms_mode:-}"
-    if [ -z "$NEO4J_dbms_advertisedAddress" ]; then
+    if [ -n "$NEO4J_dbms_advertisedAddress" ]; then
         setting "dbms.connectors.default_advertised_address" "$NEO4J_dbms_advertisedAddress"
     fi
     setting "ha.server_id" "${NEO4J_ha_serverId:-}"


### PR DESCRIPTION
Fixes #67

My intention:
In order to support networking features like overlay networks and virtual IPs, it would be great if `dbms.connectors.default_advertised_address` would be configurable. It would be great, if it would be possible to inject the advertised addressed from the outside, for example using `NEO4J_dbms_advertisedAddress` environment variable.
This property should only be set, if the environment variable is set.

I compared the neo4j.conf in 2.3 and 3.0 branch and did not found `dbms.connectors.default_advertised_address` property, therefore I only added this configuration only in 3.1 and 3.2.