### PR TITLE
make `dbms.connector.bolt.enabled` configurable

### DIFF
--- a/src/3.0/docker-entrypoint.sh
+++ b/src/3.0/docker-entrypoint.sh
@@ -76,7 +76,7 @@ if [ "$1" == "neo4j" ]; then
     setting "dbms.connector.http.address" "0.0.0.0:7474"
     setting "dbms.connector.https.address" "0.0.0.0:7473"
     setting "dbms.connector.bolt.address" "0.0.0.0:7687"
-    setting "dbms.connector.bolt.enabled" "${NEO4J_dbms_connector_bolt_enabled:-}"
+    setting "dbms.connector.bolt.enabled" "${NEO4J_dbms_connector_bolt_enabled:-true}"
     setting "dbms.mode" "${NEO4J_dbms_mode:-}"
     setting "ha.server_id" "${NEO4J_ha_serverId:-}"
     setting "ha.host.data" "${NEO4J_ha_host_data:-}"

--- a/src/3.0/docker-entrypoint.sh
+++ b/src/3.0/docker-entrypoint.sh
@@ -76,6 +76,7 @@ if [ "$1" == "neo4j" ]; then
     setting "dbms.connector.http.address" "0.0.0.0:7474"
     setting "dbms.connector.https.address" "0.0.0.0:7473"
     setting "dbms.connector.bolt.address" "0.0.0.0:7687"
+    setting "dbms.connector.bolt.enabled" "${NEO4J_dbms_connector_bolt_enabled:-}"
     setting "dbms.mode" "${NEO4J_dbms_mode:-}"
     setting "ha.server_id" "${NEO4J_ha_serverId:-}"
     setting "ha.host.data" "${NEO4J_ha_host_data:-}"

--- a/src/3.1/docker-entrypoint.sh
+++ b/src/3.1/docker-entrypoint.sh
@@ -41,7 +41,7 @@ if [ "$1" == "neo4j" ]; then
     setting "dbms.connector.http.listen_address" "0.0.0.0:7474"
     setting "dbms.connector.https.listen_address" "0.0.0.0:7473"
     setting "dbms.connector.bolt.listen_address" "0.0.0.0:7687"
-    setting "dbms.connector.bolt.enabled" "${NEO4J_dbms_connector_bolt_enabled:-}"
+    setting "dbms.connector.bolt.enabled" "${NEO4J_dbms_connector_bolt_enabled:-true}"
     setting "dbms.mode" "${NEO4J_dbms_mode:-}"
     setting "ha.server_id" "${NEO4J_ha_serverId:-}"
     setting "ha.host.data" "${NEO4J_ha_host_data:-}"

--- a/src/3.1/docker-entrypoint.sh
+++ b/src/3.1/docker-entrypoint.sh
@@ -41,6 +41,7 @@ if [ "$1" == "neo4j" ]; then
     setting "dbms.connector.http.listen_address" "0.0.0.0:7474"
     setting "dbms.connector.https.listen_address" "0.0.0.0:7473"
     setting "dbms.connector.bolt.listen_address" "0.0.0.0:7687"
+    setting "dbms.connector.bolt.enabled" "${NEO4J_dbms_connector_bolt_enabled:-}"
     setting "dbms.mode" "${NEO4J_dbms_mode:-}"
     setting "ha.server_id" "${NEO4J_ha_serverId:-}"
     setting "ha.host.data" "${NEO4J_ha_host_data:-}"

--- a/src/3.2/docker-entrypoint.sh
+++ b/src/3.2/docker-entrypoint.sh
@@ -41,7 +41,7 @@ if [ "$1" == "neo4j" ]; then
     setting "dbms.connector.http.listen_address" "0.0.0.0:7474"
     setting "dbms.connector.https.listen_address" "0.0.0.0:7473"
     setting "dbms.connector.bolt.listen_address" "0.0.0.0:7687"
-    setting "dbms.connector.bolt.enabled" "${NEO4J_dbms_connector_bolt_enabled:-}"
+    setting "dbms.connector.bolt.enabled" "${NEO4J_dbms_connector_bolt_enabled:-true}"
     setting "dbms.mode" "${NEO4J_dbms_mode:-}"
     setting "ha.server_id" "${NEO4J_ha_serverId:-}"
     setting "ha.host.data" "${NEO4J_ha_host_data:-}"

--- a/src/3.2/docker-entrypoint.sh
+++ b/src/3.2/docker-entrypoint.sh
@@ -41,6 +41,7 @@ if [ "$1" == "neo4j" ]; then
     setting "dbms.connector.http.listen_address" "0.0.0.0:7474"
     setting "dbms.connector.https.listen_address" "0.0.0.0:7473"
     setting "dbms.connector.bolt.listen_address" "0.0.0.0:7687"
+    setting "dbms.connector.bolt.enabled" "${NEO4J_dbms_connector_bolt_enabled:-}"
     setting "dbms.mode" "${NEO4J_dbms_mode:-}"
     setting "ha.server_id" "${NEO4J_ha_serverId:-}"
     setting "ha.host.data" "${NEO4J_ha_host_data:-}"


### PR DESCRIPTION
In order to disable bolt for demo purpose it would be nice to be able to disable this. Enabled is true by default to keep current behavior.