### PR TITLE
Example fix for grep failures causing early exit

### DIFF
--- a/src/2.3/docker-entrypoint.sh
+++ b/src/2.3/docker-entrypoint.sh
@@ -6,11 +6,17 @@ setting() {
     file="${3}"
 
     if [ -n "${value}" ]; then
+        # I think the intent is to always set *something*, disable exit on error which allows:
+        # 1) Success if the file doesn't exist
+        # 2) Success if grep exits with non-0 for any other reason
+        set +e
         if grep --quiet --fixed-strings "${setting}=" conf/"${file}"; then
             sed --in-place "s|.*${setting}=.*|${setting}=${value}|" conf/"${file}"
         else
             echo "${setting}=${value}" >>conf/"${file}"
         fi
+        # restore it
+        set -e
     fi
 }
 


### PR DESCRIPTION
Hey Ben!

I've encountered an error when building an image derived from the published Neo4j image. 

Specifically, my attempt to replace config files seems to interfere with the files which are expected to exist. This, in turn, causes grep to fail (file not found) when the setting function is called and aborts the execution of docker-entrypoint.sh.

I've changed one of the docker-entrypoint.sh scripts. If you think this is a reasonable approach (one possible improvement might be put an explicit check for file existence) I will be happy to change the other scripts as well.

Thank you!
Matt