### PR TITLE
Configuration from not hardcoded env variables

### DIFF
--- a/src/3.2/Dockerfile
+++ b/src/3.2/Dockerfile
@@ -4,8 +4,8 @@ RUN apk add --no-cache --quiet \
     bash \
     curl
 
-ENV NEO4J_SHA256 %%NEO4J_SHA%%
-ENV NEO4J_TARBALL %%NEO4J_TARBALL%%
+ENV NEO4J_SHA256 %%NEO4J_SHA%% \
+    NEO4J_TARBALL %%NEO4J_TARBALL%%
 ARG NEO4J_URI=%%NEO4J_DIST_SITE%%/%%NEO4J_TARBALL%%
 
 COPY ./local-package/* /tmp/
@@ -14,12 +14,11 @@ RUN curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && echo "${NEO4J_SHA256}  ${NEO4J_TARBALL}" | sha256sum -csw - \
     && tar --extract --file ${NEO4J_TARBALL} --directory /var/lib \
     && mv /var/lib/neo4j-* /var/lib/neo4j \
-    && rm ${NEO4J_TARBALL}
+    && rm ${NEO4J_TARBALL} \
+    && mv /var/lib/neo4j/data /data \
+    && ln -s /data /var/lib/neo4j/data
 
 WORKDIR /var/lib/neo4j
-
-RUN mv data /data \
-    && ln -s /data
 
 VOLUME /data
 

--- a/src/3.2/Dockerfile
+++ b/src/3.2/Dockerfile
@@ -4,8 +4,8 @@ RUN apk add --no-cache --quiet \
     bash \
     curl
 
-ENV NEO4J_SHA256 %%NEO4J_SHA%% \
-    NEO4J_TARBALL %%NEO4J_TARBALL%%
+ENV NEO4J_SHA256=%%NEO4J_SHA%% \
+    NEO4J_TARBALL=%%NEO4J_TARBALL%%
 ARG NEO4J_URI=%%NEO4J_DIST_SITE%%/%%NEO4J_TARBALL%%
 
 COPY ./local-package/* /tmp/
@@ -16,7 +16,8 @@ RUN curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && mv /var/lib/neo4j-* /var/lib/neo4j \
     && rm ${NEO4J_TARBALL} \
     && mv /var/lib/neo4j/data /data \
-    && ln -s /data /var/lib/neo4j/data
+    && ln -s /data /var/lib/neo4j/data \
+    && apk del curl
 
 WORKDIR /var/lib/neo4j
 

--- a/src/3.2/docker-entrypoint.sh
+++ b/src/3.2/docker-entrypoint.sh
@@ -80,6 +80,10 @@ if [ "$1" == "neo4j" ]; then
         NEO4J_dbms_directories_import="/import"
     fi
 
+    if [ -d /metrics ]; then
+        NEO4J_dbms_directories_metrics="/metrics"
+    fi
+
     if [ "${NEO4J_AUTH:-}" == "none" ]; then
         NEO4J_dbms_security_auth__enabled=false
     elif [[ "${NEO4J_AUTH:-}" == neo4j/* ]]; then

--- a/src/3.2/docker-entrypoint.sh
+++ b/src/3.2/docker-entrypoint.sh
@@ -44,21 +44,21 @@ if [ "$1" == "neo4j" ]; then
         NEO4J_causalClustering_raftAdvertisedAddress
 
     # Custom settings for dockerized neo4j
-    NEO4J_dbms_tx__log_rotation_retention_policy=${NEO4J_dbms_tx__log_rotation_retention_policy:-100M size}
-    NEO4J_dbms_memory_pagecache_size=${NEO4J_dbms_memory_pagecache_size:-512M}
-    NEO4J_wrapper_java_additional=${NEO4J_wrapper_java_additional:--Dneo4j.ext.udc.source=docker}
-    NEO4J_dbms_memory_heap_initial__size=${NEO4J_dbms_memory_heap_initial__size:-512M}
-    NEO4J_dbms_memory_heap_max__size=${NEO4J_dbms_memory_heap_max__size:-512M}
-    NEO4J_dbms_connectors_default__listen__address=${NEO4J_dbms_connectors_default__listen__address:-0.0.0.0}
-    NEO4J_dbms_connector_http_listen__address=${NEO4J_dbms_connector_http_listen__address:-0.0.0.0:7474}
-    NEO4J_dbms_connector_https_listen__address=${NEO4J_dbms_connector_https_listen__address:-0.0.0.0:7473}
-    NEO4J_dbms_connector_bolt_listen__address=${NEO4J_dbms_connector_bolt_listen__address:-0.0.0.0:7687}
-    NEO4J_causal__clustering_discovery__listen__address=${NEO4J_causal__clustering_discovery__listen__address:-0.0.0.0:5000}
-    NEO4J_causal__clustering_discovery__advertised__address=${NEO4J_causal__clustering_discovery__advertised__address:-$(hostname):5000}
-    NEO4J_causal__clustering_transaction__listen__address=${NEO4J_causal__clustering_transaction__listen__address:-0.0.0.0:6000}
-    NEO4J_causal__clustering_transaction__advertised__address=${NEO4J_causal__clustering_transaction__advertised__address:-$(hostname):6000}
-    NEO4J_causal__clustering_raft__listen__address=${NEO4J_causal__clustering_raft__listen__address:-0.0.0.0:7000}
-    NEO4J_causal__clustering_raft__advertised__address=${NEO4J_causal__clustering_raft__advertised__address:-$(hostname):7000}
+    : ${NEO4J_dbms_tx__log_rotation_retention_policy:-100M size}
+    : ${NEO4J_dbms_memory_pagecache_size:-512M}
+    : ${NEO4J_wrapper_java_additional:--Dneo4j.ext.udc.source=docker}
+    : ${NEO4J_dbms_memory_heap_initial__size:-512M}
+    : ${NEO4J_dbms_memory_heap_max__size:-512M}
+    : ${NEO4J_dbms_connectors_default__listen__address:-0.0.0.0}
+    : ${NEO4J_dbms_connector_http_listen__address:-0.0.0.0:7474}
+    : ${NEO4J_dbms_connector_https_listen__address:-0.0.0.0:7473}
+    : ${NEO4J_dbms_connector_bolt_listen__address:-0.0.0.0:7687}
+    : ${NEO4J_causal__clustering_discovery__listen__address:-0.0.0.0:5000}
+    : ${NEO4J_causal__clustering_discovery__advertised__address:-$(hostname):5000}
+    : ${NEO4J_causal__clustering_transaction__listen__address:-0.0.0.0:6000}
+    : ${NEO4J_causal__clustering_transaction__advertised__address:-$(hostname):6000}
+    : ${NEO4J_causal__clustering_raft__listen__address:-0.0.0.0:7000}
+    : ${NEO4J_causal__clustering_raft__advertised__address:-$(hostname):7000}
 
     if [ -d /conf ]; then
         find /conf -type f -exec cp {} conf \;
@@ -97,13 +97,15 @@ if [ "$1" == "neo4j" ]; then
 
     # list env variables with prefix NEO4J_ and create settings from them
     unset NEO4J_AUTH NEO4J_SHA256 NEO4J_TARBALL
-    for i in $( printenv | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
+    for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
         setting=$(echo ${i} | sed 's|^NEO4J_||' | sed 's|_|.|g' | sed 's|\.\.|_|g')
         value=$(echo ${!i})
-        if grep -q -F "${setting}=" conf/neo4j.conf; then
-            sed --in-place "s|.*${setting}=.*|${setting}=${value}|" conf/neo4j.conf
-        else
-            echo "${setting}=${value}" >> conf/neo4j.conf
+        if [[ -n ${value} ]]; then
+            if grep -q -F "${setting}=" conf/neo4j.conf; then
+                sed --in-place "s|.*${setting}=.*|${setting}=${value}|" conf/neo4j.conf
+            else
+               echo "${setting}=${value}" >> conf/neo4j.conf
+            fi
         fi
     done
 

--- a/src/3.2/docker-entrypoint.sh
+++ b/src/3.2/docker-entrypoint.sh
@@ -11,11 +11,11 @@ if [ "$1" == "neo4j" ]; then
     #       dbms.tx_log.rotation.retention_policy setting
 
     # Backward compatibility - map old hardcoded env variables into new naming convention
-    NEO4J_dbms_tx__log_rotation_retention_policy=${NEO4J_dbms_txLog_rotation_retentionPolicy:-100M size}
-    NEO4J_dbms_memory_pagecache_size=${NEO4J_dbms_memory_pagecache_size:-512M}
-    #??? setting "wrapper.java.additional=-Dneo4j.ext.udc.source" "${NEO4J_UDC_SOURCE:-docker}"
-    NEO4J_dbms_memory_heap_initial__size=${NEO4J_dbms_memory_heap_maxSize:-512M}
-    NEO4J_dbms_memory_heap_max__size=${NEO4J_dbms_memory_heap_maxSize:-512M}
+    NEO4J_dbms_tx__log_rotation_retention_policy=${NEO4J_dbms_txLog_rotation_retentionPolicy:-}
+    NEO4J_dbms_memory_pagecache_size=${NEO4J_dbms_memory_pagecache_size:-}
+    NEO4J_wrapper_java_additional=${NEO4J_UDC_SOURCE:-}
+    NEO4J_dbms_memory_heap_initial__size=${NEO4J_dbms_memory_heap_maxSize:-}
+    NEO4J_dbms_memory_heap_max__size=${NEO4J_dbms_memory_heap_maxSize:-}
     NEO4J_dbms_unmanaged__extension__classes=${NEO4J_dbms_unmanagedExtensionClasses:-}
     NEO4J_dbms_allow__format__migration=${NEO4J_dbms_allowFormatMigration:-}
     NEO4J_dbms_mode=${NEO4J_dbms_mode:-}
@@ -26,17 +26,17 @@ if [ "$1" == "neo4j" ]; then
     NEO4J_ha_initial__hosts=${NEO4J_ha_initialHosts:-}
     NEO4J_causal__clustering_expected__core__cluster__size=${NEO4J_causalClustering_expectedCoreClusterSize:-}
     NEO4J_causal__clustering_initial__discovery__members=${NEO4J_causalClustering_initialDiscoveryMembers:-}
-    NEO4J_causal__clustering_discovery__listen__address=${NEO4J_causalClustering_discoveryListenAddress:-0.0.0.0:5000}
-    NEO4J_causal__clustering_discovery__advertised__address=${NEO4J_causalClustering_discoveryAdvertisedAddress:-$(hostname):5000}
-    NEO4J_causal__clustering_transaction__listen__address=${NEO4J_causalClustering_transactionListenAddress:-0.0.0.0:6000}
-    NEO4J_causal__clustering_transaction__advertised__address=${NEO4J_causalClustering_transactionAdvertisedAddress:-$(hostname):6000}
-    NEO4J_causal__clustering_raft__listen__address=${NEO4J_causalClustering_raftListenAddress:-0.0.0.0:7000}
-    NEO4J_causal__clustering_raft__advertised__address=${NEO4J_causalClustering_raftAdvertisedAddress:-$(hostname):7000}
+    NEO4J_causal__clustering_discovery__listen__address=${NEO4J_causalClustering_discoveryListenAddress:-}
+    NEO4J_causal__clustering_discovery__advertised__address=${NEO4J_causalClustering_discoveryAdvertisedAddress:-}
+    NEO4J_causal__clustering_transaction__listen__address=${NEO4J_causalClustering_transactionListenAddress:-}
+    NEO4J_causal__clustering_transaction__advertised__address=${NEO4J_causalClustering_transactionAdvertisedAddress:-}
+    NEO4J_causal__clustering_raft__listen__address=${NEO4J_causalClustering_raftListenAddress:-}
+    NEO4J_causal__clustering_raft__advertised__address=${NEO4J_causalClustering_raftAdvertisedAddress:-}
 
     # Custom settings for dockerized neo4j
     NEO4J_dbms_tx__log_rotation_retention_policy=${NEO4J_dbms_tx__log_rotation_retention_policy:-100M size}
     NEO4J_dbms_memory_pagecache_size=${NEO4J_dbms_memory_pagecache_size:-512M}
-    #??? setting "wrapper.java.additional=-Dneo4j.ext.udc.source" "${NEO4J_UDC_SOURCE:-docker}"
+    NEO4J_wrapper_java_additional=${NEO4J_wrapper_java_additional:--Dneo4j.ext.udc.source=docker}
     NEO4J_dbms_memory_heap_initial__size=${NEO4J_dbms_memory_heap_initial__size:-512M}
     NEO4J_dbms_memory_heap_max__size=${NEO4J_dbms_memory_heap_max__size:-512M}
     NEO4J_dbms_connectors_default__listen__address=${NEO4J_dbms_connectors_default__listen__address:-0.0.0.0}

--- a/src/3.2/docker-entrypoint.sh
+++ b/src/3.2/docker-entrypoint.sh
@@ -1,27 +1,85 @@
 #!/bin/bash -eu
 
-setting() {
-    setting="${1}"
-    value="${2}"
-    file="neo4j.conf"
-
-    if [ -n "${value}" ]; then
-        if grep -q -F "${setting}=" conf/"${file}"; then
-            sed --in-place "s|.*${setting}=.*|${setting}=${value}|" conf/"${file}"
-        else
-            echo "${setting}=${value}" >>conf/"${file}"
-        fi
-    fi
-}
-
 if [ "$1" == "neo4j" ]; then
-    setting "dbms.tx_log.rotation.retention_policy" "${NEO4J_dbms_txLog_rotation_retentionPolicy:-100M size}"
-    setting "dbms.memory.pagecache.size" "${NEO4J_dbms_memory_pagecache_size:-512M}"
-    setting "wrapper.java.additional=-Dneo4j.ext.udc.source" "${NEO4J_UDC_SOURCE:-docker}"
-    setting "dbms.memory.heap.initial_size" "${NEO4J_dbms_memory_heap_maxSize:-512M}"
-    setting "dbms.memory.heap.max_size" "${NEO4J_dbms_memory_heap_maxSize:-512M}"
-    setting "dbms.unmanaged_extension_classes" "${NEO4J_dbms_unmanagedExtensionClasses:-}"
-    setting "dbms.allow_format_migration" "${NEO4J_dbms_allowFormatMigration:-}"
+
+    # Env variable naming convention:
+    # - prefix NEO4J_
+    # - double underscore char '__' instead of single underscore '_' char in the setting name
+    # - underscore char '_' instead of dot '.' char in the setting name
+    # Example:
+    # NEO4J_dbms_tx__log_rotation_retention_policy env variable to set
+    #       dbms.tx_log.rotation.retention_policy setting
+
+    # Backward compatibility - map old hardcoded env variables into new naming convention
+    NEO4J_dbms_tx__log_rotation_retention_policy=${NEO4J_dbms_txLog_rotation_retentionPolicy:-100M size}
+    NEO4J_dbms_memory_pagecache_size=${NEO4J_dbms_memory_pagecache_size:-512M}
+    #??? setting "wrapper.java.additional=-Dneo4j.ext.udc.source" "${NEO4J_UDC_SOURCE:-docker}"
+    NEO4J_dbms_memory_heap_initial__size=${NEO4J_dbms_memory_heap_maxSize:-512M}
+    NEO4J_dbms_memory_heap_max__size=${NEO4J_dbms_memory_heap_maxSize:-512M}
+    NEO4J_dbms_unmanaged__extension__classes=${NEO4J_dbms_unmanagedExtensionClasses:-}
+    NEO4J_dbms_allow__format__migration=${NEO4J_dbms_allowFormatMigration:-}
+    NEO4J_dbms_mode=${NEO4J_dbms_mode:-}
+    NEO4J_dbms_connectors_default__advertised__address=${NEO4J_dbms_connectors_defaultAdvertisedAddress:-}
+    NEO4J_ha_server__id=${NEO4J_ha_serverId:-}
+    NEO4J_ha_host_data=${NEO4J_ha_host_data:-}
+    NEO4J_ha_host_coordination=${NEO4J_ha_host_coordination:-}
+    NEO4J_ha_initial__hosts=${NEO4J_ha_initialHosts:-}
+    NEO4J_causal__clustering_expected__core__cluster__size=${NEO4J_causalClustering_expectedCoreClusterSize:-}
+    NEO4J_causal__clustering_initial__discovery__members=${NEO4J_causalClustering_initialDiscoveryMembers:-}
+    NEO4J_causal__clustering_discovery__listen__address=${NEO4J_causalClustering_discoveryListenAddress:-0.0.0.0:5000}
+    NEO4J_causal__clustering_discovery__advertised__address=${NEO4J_causalClustering_discoveryAdvertisedAddress:-$(hostname):5000}
+    NEO4J_causal__clustering_transaction__listen__address=${NEO4J_causalClustering_transactionListenAddress:-0.0.0.0:6000}
+    NEO4J_causal__clustering_transaction__advertised__address=${NEO4J_causalClustering_transactionAdvertisedAddress:-$(hostname):6000}
+    NEO4J_causal__clustering_raft__listen__address=${NEO4J_causalClustering_raftListenAddress:-0.0.0.0:7000}
+    NEO4J_causal__clustering_raft__advertised__address=${NEO4J_causalClustering_raftAdvertisedAddress:-$(hostname):7000}
+
+    # Custom settings for dockerized neo4j
+    NEO4J_dbms_tx__log_rotation_retention_policy=${NEO4J_dbms_tx__log_rotation_retention_policy:-100M size}
+    NEO4J_dbms_memory_pagecache_size=${NEO4J_dbms_memory_pagecache_size:-512M}
+    #??? setting "wrapper.java.additional=-Dneo4j.ext.udc.source" "${NEO4J_UDC_SOURCE:-docker}"
+    NEO4J_dbms_memory_heap_initial__size=${NEO4J_dbms_memory_heap_initial__size:-512M}
+    NEO4J_dbms_memory_heap_max__size=${NEO4J_dbms_memory_heap_max__size:-512M}
+    NEO4J_dbms_connectors_default__listen__address=${NEO4J_dbms_connectors_default__listen__address:-0.0.0.0}
+    NEO4J_dbms_connector_http_listen__address=${NEO4J_dbms_connector_http_listen__address:-0.0.0.0:7474}
+    NEO4J_dbms_connector_https_listen__address=${NEO4J_dbms_connector_https_listen__address:-0.0.0.0:7473}
+    NEO4J_dbms_connector_bolt_listen__address=${NEO4J_dbms_connector_bolt_listen__address:-0.0.0.0:7687}
+    NEO4J_causal__clustering_discovery__listen__address=${NEO4J_causal__clustering_discovery__listen__address:-0.0.0.0:5000}
+    NEO4J_causal__clustering_discovery__advertised__address=${NEO4J_causal__clustering_discovery__advertised__address:-$(hostname):5000}"
+    NEO4J_causal__clustering_transaction__listen__address=${NEO4J_causal__clustering_transaction__listen__address:-0.0.0.0:6000}"
+    NEO4J_causal__clustering_transaction__advertised__address=${NEO4J_causal__clustering_transaction__advertised__address:-$(hostname):6000}"
+    NEO4J_causal__clustering_raft__listen__address=${NEO4J_causal__clustering_raft__listen__address:-0.0.0.0:7000}"
+    NEO4J_causal__clustering_raft__advertised__address=${NEO4J_causal__clustering_raft__advertised__address:-$(hostname):7000}"
+
+    if [ -d /conf ]; then
+        find /conf -type f -exec cp {} conf \;
+    fi
+
+    if [ -d /ssl ]; then
+        NEO4J_dbms_directories_certificates="/ssl"
+    fi
+
+    if [ -d /plugins ]; then
+        NEO4J_dbms_directories_plugins="/plugins"
+    fi
+
+    if [ -d /logs ]; then
+        NEO4J_dbms_directories_logs="/logs"
+    fi
+
+    if [ -d /import ]; then
+        NEO4J_dbms_directories_import="/import"
+    fi
+
+    # list env variables with prefix NEO4J_ and create settings from them
+    for i in $( printenv | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
+        setting=$(echo ${i} | sed 's|^NEO4J_||' | sed 's|_|.|g' | sed 's|\.\.|_|g')
+        value=$(echo ${!i})
+        if grep -q -F "^${setting}=" conf/"${file}"; then
+            sed --in-place "s|.*${setting}=.*|${setting}=${value}|" conf/neo4j.conf
+        else
+            echo "${setting}=${value}" >> conf/"${file}"
+        fi
+    done
 
     if [ "${NEO4J_AUTH:-}" == "none" ]; then
         setting "dbms.security.auth_enabled" "false"
@@ -38,46 +96,7 @@ if [ "$1" == "neo4j" ]; then
         exit 1
     fi
 
-    setting "dbms.connectors.default_listen_address" "0.0.0.0"
-    setting "dbms.connector.http.listen_address" "0.0.0.0:7474"
-    setting "dbms.connector.https.listen_address" "0.0.0.0:7473"
-    setting "dbms.connector.bolt.listen_address" "0.0.0.0:7687"
-    setting "dbms.mode" "${NEO4J_dbms_mode:-}"
-    setting "dbms.connectors.default_advertised_address" "${NEO4J_dbms_connectors_defaultAdvertisedAddress:-}"
-    setting "ha.server_id" "${NEO4J_ha_serverId:-}"
-    setting "ha.host.data" "${NEO4J_ha_host_data:-}"
-    setting "ha.host.coordination" "${NEO4J_ha_host_coordination:-}"
-    setting "ha.initial_hosts" "${NEO4J_ha_initialHosts:-}"
-    setting "causal_clustering.expected_core_cluster_size" "${NEO4J_causalClustering_expectedCoreClusterSize:-}"
-    setting "causal_clustering.initial_discovery_members" "${NEO4J_causalClustering_initialDiscoveryMembers:-}"
-    setting "causal_clustering.discovery_listen_address" "${NEO4J_causalClustering_discoveryListenAddress:-0.0.0.0:5000}"
-    setting "causal_clustering.discovery_advertised_address" "${NEO4J_causalClustering_discoveryAdvertisedAddress:-$(hostname):5000}"
-    setting "causal_clustering.transaction_listen_address" "${NEO4J_causalClustering_transactionListenAddress:-0.0.0.0:6000}"
-    setting "causal_clustering.transaction_advertised_address" "${NEO4J_causalClustering_transactionAdvertisedAddress:-$(hostname):6000}"
-    setting "causal_clustering.raft_listen_address" "${NEO4J_causalClustering_raftListenAddress:-0.0.0.0:7000}"
-    setting "causal_clustering.raft_advertised_address" "${NEO4J_causalClustering_raftAdvertisedAddress:-$(hostname):7000}"
-
     [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
-
-    if [ -d /conf ]; then
-        find /conf -type f -exec cp {} conf \;
-    fi
-
-    if [ -d /ssl ]; then
-        setting "dbms.directories.certificates" "/ssl" neo4j.conf
-    fi
-
-    if [ -d /plugins ]; then
-        setting "dbms.directories.plugins" "/plugins" neo4j.conf
-    fi
-
-    if [ -d /logs ]; then
-        setting "dbms.directories.logs" "/logs" neo4j.conf
-    fi
-    
-    if [ -d /import ]; then
-        setting "dbms.directories.import" "/import" neo4j.conf
-    fi
 
     exec bin/neo4j console
 elif [ "$1" == "dump-config" ]; then

--- a/src/3.2/docker-entrypoint.sh
+++ b/src/3.2/docker-entrypoint.sh
@@ -44,21 +44,21 @@ if [ "$1" == "neo4j" ]; then
         NEO4J_causalClustering_raftAdvertisedAddress
 
     # Custom settings for dockerized neo4j
-    : ${NEO4J_dbms_tx__log_rotation_retention_policy:-100M size}
-    : ${NEO4J_dbms_memory_pagecache_size:-512M}
-    : ${NEO4J_wrapper_java_additional:--Dneo4j.ext.udc.source=docker}
-    : ${NEO4J_dbms_memory_heap_initial__size:-512M}
-    : ${NEO4J_dbms_memory_heap_max__size:-512M}
-    : ${NEO4J_dbms_connectors_default__listen__address:-0.0.0.0}
-    : ${NEO4J_dbms_connector_http_listen__address:-0.0.0.0:7474}
-    : ${NEO4J_dbms_connector_https_listen__address:-0.0.0.0:7473}
-    : ${NEO4J_dbms_connector_bolt_listen__address:-0.0.0.0:7687}
-    : ${NEO4J_causal__clustering_discovery__listen__address:-0.0.0.0:5000}
-    : ${NEO4J_causal__clustering_discovery__advertised__address:-$(hostname):5000}
-    : ${NEO4J_causal__clustering_transaction__listen__address:-0.0.0.0:6000}
-    : ${NEO4J_causal__clustering_transaction__advertised__address:-$(hostname):6000}
-    : ${NEO4J_causal__clustering_raft__listen__address:-0.0.0.0:7000}
-    : ${NEO4J_causal__clustering_raft__advertised__address:-$(hostname):7000}
+    : ${NEO4J_dbms_tx__log_rotation_retention_policy:=100M size}
+    : ${NEO4J_dbms_memory_pagecache_size:=512M}
+    : ${NEO4J_wrapper_java_additional:=-Dneo4j.ext.udc.source=docker}
+    : ${NEO4J_dbms_memory_heap_initial__size:=512M}
+    : ${NEO4J_dbms_memory_heap_max__size:=512M}
+    : ${NEO4J_dbms_connectors_default__listen__address:=0.0.0.0}
+    : ${NEO4J_dbms_connector_http_listen__address:=0.0.0.0:7474}
+    : ${NEO4J_dbms_connector_https_listen__address:=0.0.0.0:7473}
+    : ${NEO4J_dbms_connector_bolt_listen__address:=0.0.0.0:7687}
+    : ${NEO4J_causal__clustering_discovery__listen__address:=0.0.0.0:5000}
+    : ${NEO4J_causal__clustering_discovery__advertised__address:=$(hostname):5000}
+    : ${NEO4J_causal__clustering_transaction__listen__address:=0.0.0.0:6000}
+    : ${NEO4J_causal__clustering_transaction__advertised__address:=$(hostname):6000}
+    : ${NEO4J_causal__clustering_raft__listen__address:=0.0.0.0:7000}
+    : ${NEO4J_causal__clustering_raft__advertised__address:=$(hostname):7000}
 
     if [ -d /conf ]; then
         find /conf -type f -exec cp {} conf \;

--- a/src/3.2/docker-entrypoint.sh
+++ b/src/3.2/docker-entrypoint.sh
@@ -70,19 +70,8 @@ if [ "$1" == "neo4j" ]; then
         NEO4J_dbms_directories_import="/import"
     fi
 
-    # list env variables with prefix NEO4J_ and create settings from them
-    for i in $( printenv | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
-        setting=$(echo ${i} | sed 's|^NEO4J_||' | sed 's|_|.|g' | sed 's|\.\.|_|g')
-        value=$(echo ${!i})
-        if grep -q -F "^${setting}=" conf/"${file}"; then
-            sed --in-place "s|.*${setting}=.*|${setting}=${value}|" conf/neo4j.conf
-        else
-            echo "${setting}=${value}" >> conf/"${file}"
-        fi
-    done
-
     if [ "${NEO4J_AUTH:-}" == "none" ]; then
-        setting "dbms.security.auth_enabled" "false"
+        NEO4J_dbms_security_auth__enabled=false
     elif [[ "${NEO4J_AUTH:-}" == neo4j/* ]]; then
         password="${NEO4J_AUTH#neo4j/}"
         if [ "${password}" == "neo4j" ]; then
@@ -95,6 +84,17 @@ if [ "$1" == "neo4j" ]; then
         echo "Invalid value for NEO4J_AUTH: '${NEO4J_AUTH}'"
         exit 1
     fi
+
+    # list env variables with prefix NEO4J_ and create settings from them
+    for i in $( printenv | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
+        setting=$(echo ${i} | sed 's|^NEO4J_||' | sed 's|_|.|g' | sed 's|\.\.|_|g')
+        value=$(echo ${!i})
+        if grep -q -F "^${setting}=" conf/"${file}"; then
+            sed --in-place "s|.*${setting}=.*|${setting}=${value}|" conf/neo4j.conf
+        else
+            echo "${setting}=${value}" >> conf/"${file}"
+        fi
+    done
 
     [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
 


### PR DESCRIPTION
Problem: only hardcoded env variables can be used to configure neo4j container. It's only subset of all possible settings

Solution: introduce specific env variable naming convention, which will be used for dynamic configuration

Some things to keep in mind:
- Some settings are commented by default and some are not
- Not all settings are actually present (commented or not) in the config file. So a sed by itself is not guaranteed to replace something
- A user might define a custom config volume AND some environment variables.
- Backward compatibility with old hardcoded env variables
- Update documentation/examples

WIP: it's only for 3.2 version at the moment; it needs review from somebody with proper neo4j config knowledge (cc: @spacecowboy); I was not able to build docker image on my localhost

This one can be a solution for: #52, #71.

Fixes #52 
Fixes #71 