### PR TITLE
Ensure config only has single entries

### DIFF
--- a/src/3.0/docker-entrypoint.sh
+++ b/src/3.0/docker-entrypoint.sh
@@ -133,10 +133,11 @@ if [ "$1" == "neo4j" ]; then
         value=$(echo ${!i})
         if [[ -n ${value} ]]; then
             if grep -q -F "${setting}=" conf/neo4j.conf; then
-                sed --in-place "s|.*${setting}=.*|${setting}=${value}|" conf/neo4j.conf
-            else
-               echo "${setting}=${value}" >> conf/neo4j.conf
+                # Remove any lines containing the setting already
+                sed --in-place "/${setting}=.*/d" conf/neo4j.conf
             fi
+            # Then always append setting to file
+            echo "${setting}=${value}" >> conf/neo4j.conf
         fi
     done
 

--- a/src/3.0/docker-entrypoint.sh
+++ b/src/3.0/docker-entrypoint.sh
@@ -27,11 +27,11 @@ if [ "$1" == "neo4j" ]; then
     # - double underscore char '__' instead of single underscore '_' char in the setting name
     # - underscore char '_' instead of dot '.' char in the setting name
     # Example:
-    # NEO4J_dbms_tx__log_rotation_retention_policy env variable to set
+    # NEO4J_dbms_tx__log_rotation_retention__policy env variable to set
     #       dbms.tx_log.rotation.retention_policy setting
 
     # Backward compatibility - map old hardcoded env variables into new naming convention
-    NEO4J_dbms_tx__log_rotation_retention_policy=${NEO4J_dbms_txLog_rotation_retentionPolicy:-}
+    NEO4J_dbms_tx__log_rotation_retention__policy=${NEO4J_dbms_txLog_rotation_retentionPolicy:-}
     NEO4J_wrapper_java_additional=${NEO4J_UDC_SOURCE:-}
     NEO4J_dbms_memory_heap_initial__size=${NEO4J_dbms_memory_heap_maxSize:-}
     NEO4J_dbms_memory_heap_max__size=${NEO4J_dbms_memory_heap_maxSize:-}

--- a/src/3.1/docker-entrypoint.sh
+++ b/src/3.1/docker-entrypoint.sh
@@ -108,10 +108,11 @@ if [ "$1" == "neo4j" ]; then
         value=$(echo ${!i})
         if [[ -n ${value} ]]; then
             if grep -q -F "${setting}=" conf/neo4j.conf; then
-                sed --in-place "s|.*${setting}=.*|${setting}=${value}|" conf/neo4j.conf
-            else
-               echo "${setting}=${value}" >> conf/neo4j.conf
+                # Remove any lines containing the setting already
+                sed --in-place "/${setting}=.*/d" conf/neo4j.conf
             fi
+            # Then always append setting to file
+            echo "${setting}=${value}" >> conf/neo4j.conf
         fi
     done
 

--- a/src/3.1/docker-entrypoint.sh
+++ b/src/3.1/docker-entrypoint.sh
@@ -7,11 +7,11 @@ if [ "$1" == "neo4j" ]; then
     # - double underscore char '__' instead of single underscore '_' char in the setting name
     # - underscore char '_' instead of dot '.' char in the setting name
     # Example:
-    # NEO4J_dbms_tx__log_rotation_retention_policy env variable to set
+    # NEO4J_dbms_tx__log_rotation_retention__policy env variable to set
     #       dbms.tx_log.rotation.retention_policy setting
 
     # Backward compatibility - map old hardcoded env variables into new naming convention
-    NEO4J_dbms_tx__log_rotation_retention_policy=${NEO4J_dbms_txLog_rotation_retentionPolicy:-}
+    NEO4J_dbms_tx__log_rotation_retention__policy=${NEO4J_dbms_txLog_rotation_retentionPolicy:-}
     NEO4J_wrapper_java_additional=${NEO4J_UDC_SOURCE:-}
     NEO4J_dbms_memory_heap_initial__size=${NEO4J_dbms_memory_heap_maxSize:-}
     NEO4J_dbms_memory_heap_max__size=${NEO4J_dbms_memory_heap_maxSize:-}

--- a/src/3.2/docker-entrypoint.sh
+++ b/src/3.2/docker-entrypoint.sh
@@ -108,10 +108,11 @@ if [ "$1" == "neo4j" ]; then
         value=$(echo ${!i})
         if [[ -n ${value} ]]; then
             if grep -q -F "${setting}=" conf/neo4j.conf; then
-                sed --in-place "s|.*${setting}=.*|${setting}=${value}|" conf/neo4j.conf
-            else
-               echo "${setting}=${value}" >> conf/neo4j.conf
+                # Remove any lines containing the setting already
+                sed --in-place "/${setting}=.*/d" conf/neo4j.conf
             fi
+            # Then always append setting to file
+            echo "${setting}=${value}" >> conf/neo4j.conf
         fi
     done
 

--- a/src/3.2/docker-entrypoint.sh
+++ b/src/3.2/docker-entrypoint.sh
@@ -7,11 +7,11 @@ if [ "$1" == "neo4j" ]; then
     # - double underscore char '__' instead of single underscore '_' char in the setting name
     # - underscore char '_' instead of dot '.' char in the setting name
     # Example:
-    # NEO4J_dbms_tx__log_rotation_retention_policy env variable to set
+    # NEO4J_dbms_tx__log_rotation_retention__policy env variable to set
     #       dbms.tx_log.rotation.retention_policy setting
 
     # Backward compatibility - map old hardcoded env variables into new naming convention
-    NEO4J_dbms_tx__log_rotation_retention_policy=${NEO4J_dbms_txLog_rotation_retentionPolicy:-}
+    NEO4J_dbms_tx__log_rotation_retention__policy=${NEO4J_dbms_txLog_rotation_retentionPolicy:-}
     NEO4J_wrapper_java_additional=${NEO4J_UDC_SOURCE:-}
     NEO4J_dbms_memory_heap_initial__size=${NEO4J_dbms_memory_heap_maxSize:-}
     NEO4J_dbms_memory_heap_max__size=${NEO4J_dbms_memory_heap_maxSize:-}

--- a/src/3.3/docker-entrypoint.sh
+++ b/src/3.3/docker-entrypoint.sh
@@ -108,10 +108,11 @@ if [ "$1" == "neo4j" ]; then
         value=$(echo ${!i})
         if [[ -n ${value} ]]; then
             if grep -q -F "${setting}=" conf/neo4j.conf; then
-                sed --in-place "s|.*${setting}=.*|${setting}=${value}|" conf/neo4j.conf
-            else
-               echo "${setting}=${value}" >> conf/neo4j.conf
+                # Remove any lines containing the setting already
+                sed --in-place "/${setting}=.*/d" conf/neo4j.conf
             fi
+            # Then always append setting to file
+            echo "${setting}=${value}" >> conf/neo4j.conf
         fi
     done
 

--- a/src/3.3/docker-entrypoint.sh
+++ b/src/3.3/docker-entrypoint.sh
@@ -7,11 +7,11 @@ if [ "$1" == "neo4j" ]; then
     # - double underscore char '__' instead of single underscore '_' char in the setting name
     # - underscore char '_' instead of dot '.' char in the setting name
     # Example:
-    # NEO4J_dbms_tx__log_rotation_retention_policy env variable to set
+    # NEO4J_dbms_tx__log_rotation_retention__policy env variable to set
     #       dbms.tx_log.rotation.retention_policy setting
 
     # Backward compatibility - map old hardcoded env variables into new naming convention
-    NEO4J_dbms_tx__log_rotation_retention_policy=${NEO4J_dbms_txLog_rotation_retentionPolicy:-}
+    NEO4J_dbms_tx__log_rotation_retention__policy=${NEO4J_dbms_txLog_rotation_retentionPolicy:-}
     NEO4J_wrapper_java_additional=${NEO4J_UDC_SOURCE:-}
     NEO4J_dbms_memory_heap_initial__size=${NEO4J_dbms_memory_heap_maxSize:-}
     NEO4J_dbms_memory_heap_max__size=${NEO4J_dbms_memory_heap_maxSize:-}


### PR DESCRIPTION
This fixes a bug where dbms.mode would be set multiple times in the
config. Turns out that this is fine for all values EXCEPT
dbms.mode=ARBITER.

In that case we rely on parsing the config from bash which runs into a
problem due to:
https://github.com/neo4j/neo4j/blob/6cc2ebb93b39405976801f57173079deea45fd11/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shared.m4#L157

If an entry is defined multiple times, it is regarded as a cumulative
option. This is used for JAVA_OPTS and similarly. But for Arbiter we
set a different main class. So having multiple dmbs.mode entries will
set an incorrect value which means the default main class is called,
instead of the Arbiter's.

So this fix makes sure to only replace uncommented values in the
config, and otherwise always append to the end. Previously we would
replace even commented values, but since dmbs.mode is listed twice
in the 3.1/3.2/3.3 config (once in the HA-section, once in CC-section)
it would get set twice.

changelog: Fixed issue which prevented `dbms.mode=ARBITER` from working