### PR TITLE
Fixed setting config values via environment values

### DIFF
--- a/src/3.0/docker-entrypoint.sh
+++ b/src/3.0/docker-entrypoint.sh
@@ -30,33 +30,28 @@ if [ "$1" == "neo4j" ]; then
     # NEO4J_dbms_tx__log_rotation_retention__policy env variable to set
     #       dbms.tx_log.rotation.retention_policy setting
 
-    # Backward compatibility - map old hardcoded env variables into new naming convention
-    NEO4J_dbms_tx__log_rotation_retention__policy=${NEO4J_dbms_txLog_rotation_retentionPolicy:-}
-    NEO4J_wrapper_java_additional=${NEO4J_UDC_SOURCE:-}
-    NEO4J_dbms_memory_heap_initial__size=${NEO4J_dbms_memory_heap_maxSize:-}
-    NEO4J_dbms_memory_heap_max__size=${NEO4J_dbms_memory_heap_maxSize:-}
-    NEO4J_dbms_unmanaged__extension__classes=${NEO4J_dbms_unmanagedExtensionClasses:-}
-    NEO4J_dbms_allow__format__migration=${NEO4J_dbms_allowFormatMigration:-}
-    NEO4J_ha_server__id=${NEO4J_ha_serverId:-}
-    NEO4J_ha_initial__hosts=${NEO4J_ha_initialHosts:-}
+    # Backward compatibility - map old hardcoded env variables into new naming convention (if they aren't set already)
+    # Set some to default values if unset
+    : ${NEO4J_dbms_tx__log_rotation_retention__policy:=${NEO4J_dbms_txLog_rotation_retentionPolicy:-"100M size"}}
+    : ${NEO4J_wrapper_java_additional:=${NEO4J_UDC_SOURCE:-"-Dneo4j.ext.udc.source=docker"}}
+    : ${NEO4J_dbms_memory_heap_initial__size:=${NEO4J_dbms_memory_heap_maxSize:-"512"}}
+    : ${NEO4J_dbms_memory_heap_max__size:=${NEO4J_dbms_memory_heap_maxSize:-"512"}}
+    : ${NEO4J_dbms_unmanaged__extension__classes:=${NEO4J_dbms_unmanagedExtensionClasses:-}}
+    : ${NEO4J_dbms_allow__format__migration:=${NEO4J_dbms_allowFormatMigration:-}}
+    : ${NEO4J_ha_server__id:=${NEO4J_ha_serverId:-}}
+    : ${NEO4J_ha_initial__hosts:=${NEO4J_ha_initialHosts:-}}
+
+    : ${NEO4J_dbms_connector_http_address:="0.0.0.0:7474"}
+    : ${NEO4J_dbms_connector_https_address:="0.0.0.0:7473"}
+    : ${NEO4J_dbms_connector_bolt_address:="0.0.0.0:7687"}
+    : ${NEO4J_ha_host_coordination:="$(hostname):5001"}
+    : ${NEO4J_ha_host_data:="$(hostname):6001"}
 
     # unset old hardcoded unsupported env variables
     unset NEO4J_dbms_txLog_rotation_retentionPolicy NEO4J_UDC_SOURCE \
         NEO4J_dbms_memory_heap_maxSize NEO4J_dbms_memory_heap_maxSize \
         NEO4J_dbms_unmanagedExtensionClasses NEO4J_dbms_allowFormatMigration \
         NEO4J_ha_initialHosts
-
-    # Custom settings for dockerized neo4j
-    : ${NEO4J_dbms_tx__log_rotation_retention__policy:=100M size}
-    : ${NEO4J_dbms_memory_pagecache_size:=512M}
-    : ${NEO4J_wrapper_java_additional:=-Dneo4j.ext.udc.source=docker}
-    : ${NEO4J_dbms_memory_heap_initial__size:=512}
-    : ${NEO4J_dbms_memory_heap_max__size:=512}
-    : ${NEO4J_dbms_connector_http_address:=0.0.0.0:7474}
-    : ${NEO4J_dbms_connector_https_address:=0.0.0.0:7473}
-    : ${NEO4J_dbms_connector_bolt_address:=0.0.0.0:7687}
-    : ${NEO4J_ha_host_coordination:=$(hostname):5001}
-    : ${NEO4J_ha_host_data:=$(hostname):6001}
 
     if [ -d /conf ]; then
         find /conf -type f -exec cp {} conf \;

--- a/src/3.1/docker-entrypoint.sh
+++ b/src/3.1/docker-entrypoint.sh
@@ -10,24 +10,32 @@ if [ "$1" == "neo4j" ]; then
     # NEO4J_dbms_tx__log_rotation_retention__policy env variable to set
     #       dbms.tx_log.rotation.retention_policy setting
 
-    # Backward compatibility - map old hardcoded env variables into new naming convention
-    NEO4J_dbms_tx__log_rotation_retention__policy=${NEO4J_dbms_txLog_rotation_retentionPolicy:-}
-    NEO4J_wrapper_java_additional=${NEO4J_UDC_SOURCE:-}
-    NEO4J_dbms_memory_heap_initial__size=${NEO4J_dbms_memory_heap_maxSize:-}
-    NEO4J_dbms_memory_heap_max__size=${NEO4J_dbms_memory_heap_maxSize:-}
-    NEO4J_dbms_unmanaged__extension__classes=${NEO4J_dbms_unmanagedExtensionClasses:-}
-    NEO4J_dbms_allow__format__migration=${NEO4J_dbms_allowFormatMigration:-}
-    NEO4J_dbms_connectors_default__advertised__address=${NEO4J_dbms_connectors_defaultAdvertisedAddress:-}
-    NEO4J_ha_server__id=${NEO4J_ha_serverId:-}
-    NEO4J_ha_initial__hosts=${NEO4J_ha_initialHosts:-}
-    NEO4J_causal__clustering_expected__core__cluster__size=${NEO4J_causalClustering_expectedCoreClusterSize:-}
-    NEO4J_causal__clustering_initial__discovery__members=${NEO4J_causalClustering_initialDiscoveryMembers:-}
-    NEO4J_causal__clustering_discovery__listen__address=${NEO4J_causalClustering_discoveryListenAddress:-}
-    NEO4J_causal__clustering_discovery__advertised__address=${NEO4J_causalClustering_discoveryAdvertisedAddress:-}
-    NEO4J_causal__clustering_transaction__listen__address=${NEO4J_causalClustering_transactionListenAddress:-}
-    NEO4J_causal__clustering_transaction__advertised__address=${NEO4J_causalClustering_transactionAdvertisedAddress:-}
-    NEO4J_causal__clustering_raft__listen__address=${NEO4J_causalClustering_raftListenAddress:-}
-    NEO4J_causal__clustering_raft__advertised__address=${NEO4J_causalClustering_raftAdvertisedAddress:-}
+    # Backward compatibility - map old hardcoded env variables into new naming convention (if they aren't set already)
+    # Set some to default values if unset
+    : ${NEO4J_dbms_tx__log_rotation_retention__policy:=${NEO4J_dbms_txLog_rotation_retentionPolicy:-"100M size"}}
+    : ${NEO4J_wrapper_java_additional:=${NEO4J_UDC_SOURCE:-"-Dneo4j.ext.udc.source=docker"}}
+    : ${NEO4J_dbms_memory_heap_initial__size:=${NEO4J_dbms_memory_heap_maxSize:-"512M"}}
+    : ${NEO4J_dbms_memory_heap_max__size:=${NEO4J_dbms_memory_heap_maxSize:-"512M"}}
+    : ${NEO4J_dbms_unmanaged__extension__classes:=${NEO4J_dbms_unmanagedExtensionClasses:-}}
+    : ${NEO4J_dbms_allow__format__migration:=${NEO4J_dbms_allowFormatMigration:-}}
+    : ${NEO4J_dbms_connectors_default__advertised__address:=${NEO4J_dbms_connectors_defaultAdvertisedAddress:-}}
+    : ${NEO4J_ha_server__id:=${NEO4J_ha_serverId:-}}
+    : ${NEO4J_ha_initial__hosts:=${NEO4J_ha_initialHosts:-}}
+    : ${NEO4J_causal__clustering_expected__core__cluster__size:=${NEO4J_causalClustering_expectedCoreClusterSize:-}}
+    : ${NEO4J_causal__clustering_initial__discovery__members:=${NEO4J_causalClustering_initialDiscoveryMembers:-}}
+    : ${NEO4J_causal__clustering_discovery__listen__address:=${NEO4J_causalClustering_discoveryListenAddress:-"0.0.0.0:5000"}}
+    : ${NEO4J_causal__clustering_discovery__advertised__address:=${NEO4J_causalClustering_discoveryAdvertisedAddress:-"$(hostname):5000"}}
+    : ${NEO4J_causal__clustering_transaction__listen__address:=${NEO4J_causalClustering_transactionListenAddress:-"0.0.0.0:6000"}}
+    : ${NEO4J_causal__clustering_transaction__advertised__address:=${NEO4J_causalClustering_transactionAdvertisedAddress:-"$(hostname):6000"}}
+    : ${NEO4J_causal__clustering_raft__listen__address:=${NEO4J_causalClustering_raftListenAddress:-"0.0.0.0:7000"}}
+    : ${NEO4J_causal__clustering_raft__advertised__address:=${NEO4J_causalClustering_raftAdvertisedAddress:-"$(hostname):7000"}}
+
+    : ${NEO4J_dbms_connectors_default__listen__address:="0.0.0.0"}
+    : ${NEO4J_dbms_connector_http_listen__address:="0.0.0.0:7474"}
+    : ${NEO4J_dbms_connector_https_listen__address:="0.0.0.0:7473"}
+    : ${NEO4J_dbms_connector_bolt_listen__address:="0.0.0.0:7687"}
+    : ${NEO4J_ha_host_coordination:="$(hostname):5001"}
+    : ${NEO4J_ha_host_data:="$(hostname):6001"}
 
     # unset old hardcoded unsupported env variables
     unset NEO4J_dbms_txLog_rotation_retentionPolicy NEO4J_UDC_SOURCE \
@@ -42,25 +50,6 @@ if [ "$1" == "neo4j" ]; then
         NEO4J_causalClustering_transactionAdvertisedAddress \
         NEO4J_causalClustering_raftListenAddress \
         NEO4J_causalClustering_raftAdvertisedAddress
-
-    # Custom settings for dockerized neo4j
-    : ${NEO4J_dbms_tx__log_rotation_retention__policy:=100M size}
-    : ${NEO4J_dbms_memory_pagecache_size:=512M}
-    : ${NEO4J_wrapper_java_additional:=-Dneo4j.ext.udc.source=docker}
-    : ${NEO4J_dbms_memory_heap_initial__size:=512M}
-    : ${NEO4J_dbms_memory_heap_max__size:=512M}
-    : ${NEO4J_dbms_connectors_default__listen__address:=0.0.0.0}
-    : ${NEO4J_dbms_connector_http_listen__address:=0.0.0.0:7474}
-    : ${NEO4J_dbms_connector_https_listen__address:=0.0.0.0:7473}
-    : ${NEO4J_dbms_connector_bolt_listen__address:=0.0.0.0:7687}
-    : ${NEO4J_ha_host_coordination:=$(hostname):5001}
-    : ${NEO4J_ha_host_data:=$(hostname):6001}
-    : ${NEO4J_causal__clustering_discovery__listen__address:=0.0.0.0:5000}
-    : ${NEO4J_causal__clustering_discovery__advertised__address:=$(hostname):5000}
-    : ${NEO4J_causal__clustering_transaction__listen__address:=0.0.0.0:6000}
-    : ${NEO4J_causal__clustering_transaction__advertised__address:=$(hostname):6000}
-    : ${NEO4J_causal__clustering_raft__listen__address:=0.0.0.0:7000}
-    : ${NEO4J_causal__clustering_raft__advertised__address:=$(hostname):7000}
 
     if [ -d /conf ]; then
         find /conf -type f -exec cp {} conf \;

--- a/src/3.2/docker-entrypoint.sh
+++ b/src/3.2/docker-entrypoint.sh
@@ -10,24 +10,32 @@ if [ "$1" == "neo4j" ]; then
     # NEO4J_dbms_tx__log_rotation_retention__policy env variable to set
     #       dbms.tx_log.rotation.retention_policy setting
 
-    # Backward compatibility - map old hardcoded env variables into new naming convention
-    NEO4J_dbms_tx__log_rotation_retention__policy=${NEO4J_dbms_txLog_rotation_retentionPolicy:-}
-    NEO4J_wrapper_java_additional=${NEO4J_UDC_SOURCE:-}
-    NEO4J_dbms_memory_heap_initial__size=${NEO4J_dbms_memory_heap_maxSize:-}
-    NEO4J_dbms_memory_heap_max__size=${NEO4J_dbms_memory_heap_maxSize:-}
-    NEO4J_dbms_unmanaged__extension__classes=${NEO4J_dbms_unmanagedExtensionClasses:-}
-    NEO4J_dbms_allow__format__migration=${NEO4J_dbms_allowFormatMigration:-}
-    NEO4J_dbms_connectors_default__advertised__address=${NEO4J_dbms_connectors_defaultAdvertisedAddress:-}
-    NEO4J_ha_server__id=${NEO4J_ha_serverId:-}
-    NEO4J_ha_initial__hosts=${NEO4J_ha_initialHosts:-}
-    NEO4J_causal__clustering_expected__core__cluster__size=${NEO4J_causalClustering_expectedCoreClusterSize:-}
-    NEO4J_causal__clustering_initial__discovery__members=${NEO4J_causalClustering_initialDiscoveryMembers:-}
-    NEO4J_causal__clustering_discovery__listen__address=${NEO4J_causalClustering_discoveryListenAddress:-}
-    NEO4J_causal__clustering_discovery__advertised__address=${NEO4J_causalClustering_discoveryAdvertisedAddress:-}
-    NEO4J_causal__clustering_transaction__listen__address=${NEO4J_causalClustering_transactionListenAddress:-}
-    NEO4J_causal__clustering_transaction__advertised__address=${NEO4J_causalClustering_transactionAdvertisedAddress:-}
-    NEO4J_causal__clustering_raft__listen__address=${NEO4J_causalClustering_raftListenAddress:-}
-    NEO4J_causal__clustering_raft__advertised__address=${NEO4J_causalClustering_raftAdvertisedAddress:-}
+    # Backward compatibility - map old hardcoded env variables into new naming convention (if they aren't set already)
+    # Set some to default values if unset
+    : ${NEO4J_dbms_tx__log_rotation_retention__policy:=${NEO4J_dbms_txLog_rotation_retentionPolicy:-"100M size"}}
+    : ${NEO4J_wrapper_java_additional:=${NEO4J_UDC_SOURCE:-"-Dneo4j.ext.udc.source=docker"}}
+    : ${NEO4J_dbms_memory_heap_initial__size:=${NEO4J_dbms_memory_heap_maxSize:-"512M"}}
+    : ${NEO4J_dbms_memory_heap_max__size:=${NEO4J_dbms_memory_heap_maxSize:-"512M"}}
+    : ${NEO4J_dbms_unmanaged__extension__classes:=${NEO4J_dbms_unmanagedExtensionClasses:-}}
+    : ${NEO4J_dbms_allow__format__migration:=${NEO4J_dbms_allowFormatMigration:-}}
+    : ${NEO4J_dbms_connectors_default__advertised__address:=${NEO4J_dbms_connectors_defaultAdvertisedAddress:-}}
+    : ${NEO4J_ha_server__id:=${NEO4J_ha_serverId:-}}
+    : ${NEO4J_ha_initial__hosts:=${NEO4J_ha_initialHosts:-}}
+    : ${NEO4J_causal__clustering_expected__core__cluster__size:=${NEO4J_causalClustering_expectedCoreClusterSize:-}}
+    : ${NEO4J_causal__clustering_initial__discovery__members:=${NEO4J_causalClustering_initialDiscoveryMembers:-}}
+    : ${NEO4J_causal__clustering_discovery__listen__address:=${NEO4J_causalClustering_discoveryListenAddress:-"0.0.0.0:5000"}}
+    : ${NEO4J_causal__clustering_discovery__advertised__address:=${NEO4J_causalClustering_discoveryAdvertisedAddress:-"$(hostname):5000"}}
+    : ${NEO4J_causal__clustering_transaction__listen__address:=${NEO4J_causalClustering_transactionListenAddress:-"0.0.0.0:6000"}}
+    : ${NEO4J_causal__clustering_transaction__advertised__address:=${NEO4J_causalClustering_transactionAdvertisedAddress:-"$(hostname):6000"}}
+    : ${NEO4J_causal__clustering_raft__listen__address:=${NEO4J_causalClustering_raftListenAddress:-"0.0.0.0:7000"}}
+    : ${NEO4J_causal__clustering_raft__advertised__address:=${NEO4J_causalClustering_raftAdvertisedAddress:-"$(hostname):7000"}}
+
+    : ${NEO4J_dbms_connectors_default__listen__address:="0.0.0.0"}
+    : ${NEO4J_dbms_connector_http_listen__address:="0.0.0.0:7474"}
+    : ${NEO4J_dbms_connector_https_listen__address:="0.0.0.0:7473"}
+    : ${NEO4J_dbms_connector_bolt_listen__address:="0.0.0.0:7687"}
+    : ${NEO4J_ha_host_coordination:="$(hostname):5001"}
+    : ${NEO4J_ha_host_data:="$(hostname):6001"}
 
     # unset old hardcoded unsupported env variables
     unset NEO4J_dbms_txLog_rotation_retentionPolicy NEO4J_UDC_SOURCE \
@@ -42,25 +50,6 @@ if [ "$1" == "neo4j" ]; then
         NEO4J_causalClustering_transactionAdvertisedAddress \
         NEO4J_causalClustering_raftListenAddress \
         NEO4J_causalClustering_raftAdvertisedAddress
-
-    # Custom settings for dockerized neo4j
-    : ${NEO4J_dbms_tx__log_rotation_retention__policy:=100M size}
-    : ${NEO4J_dbms_memory_pagecache_size:=512M}
-    : ${NEO4J_wrapper_java_additional:=-Dneo4j.ext.udc.source=docker}
-    : ${NEO4J_dbms_memory_heap_initial__size:=512M}
-    : ${NEO4J_dbms_memory_heap_max__size:=512M}
-    : ${NEO4J_dbms_connectors_default__listen__address:=0.0.0.0}
-    : ${NEO4J_dbms_connector_http_listen__address:=0.0.0.0:7474}
-    : ${NEO4J_dbms_connector_https_listen__address:=0.0.0.0:7473}
-    : ${NEO4J_dbms_connector_bolt_listen__address:=0.0.0.0:7687}
-    : ${NEO4J_ha_host_coordination:=$(hostname):5001}
-    : ${NEO4J_ha_host_data:=$(hostname):6001}
-    : ${NEO4J_causal__clustering_discovery__listen__address:=0.0.0.0:5000}
-    : ${NEO4J_causal__clustering_discovery__advertised__address:=$(hostname):5000}
-    : ${NEO4J_causal__clustering_transaction__listen__address:=0.0.0.0:6000}
-    : ${NEO4J_causal__clustering_transaction__advertised__address:=$(hostname):6000}
-    : ${NEO4J_causal__clustering_raft__listen__address:=0.0.0.0:7000}
-    : ${NEO4J_causal__clustering_raft__advertised__address:=$(hostname):7000}
 
     if [ -d /conf ]; then
         find /conf -type f -exec cp {} conf \;

--- a/src/3.3/docker-entrypoint.sh
+++ b/src/3.3/docker-entrypoint.sh
@@ -10,24 +10,32 @@ if [ "$1" == "neo4j" ]; then
     # NEO4J_dbms_tx__log_rotation_retention__policy env variable to set
     #       dbms.tx_log.rotation.retention_policy setting
 
-    # Backward compatibility - map old hardcoded env variables into new naming convention
-    NEO4J_dbms_tx__log_rotation_retention__policy=${NEO4J_dbms_txLog_rotation_retentionPolicy:-}
-    NEO4J_wrapper_java_additional=${NEO4J_UDC_SOURCE:-}
-    NEO4J_dbms_memory_heap_initial__size=${NEO4J_dbms_memory_heap_maxSize:-}
-    NEO4J_dbms_memory_heap_max__size=${NEO4J_dbms_memory_heap_maxSize:-}
-    NEO4J_dbms_unmanaged__extension__classes=${NEO4J_dbms_unmanagedExtensionClasses:-}
-    NEO4J_dbms_allow__format__migration=${NEO4J_dbms_allowFormatMigration:-}
-    NEO4J_dbms_connectors_default__advertised__address=${NEO4J_dbms_connectors_defaultAdvertisedAddress:-}
-    NEO4J_ha_server__id=${NEO4J_ha_serverId:-}
-    NEO4J_ha_initial__hosts=${NEO4J_ha_initialHosts:-}
-    NEO4J_causal__clustering_expected__core__cluster__size=${NEO4J_causalClustering_expectedCoreClusterSize:-}
-    NEO4J_causal__clustering_initial__discovery__members=${NEO4J_causalClustering_initialDiscoveryMembers:-}
-    NEO4J_causal__clustering_discovery__listen__address=${NEO4J_causalClustering_discoveryListenAddress:-}
-    NEO4J_causal__clustering_discovery__advertised__address=${NEO4J_causalClustering_discoveryAdvertisedAddress:-}
-    NEO4J_causal__clustering_transaction__listen__address=${NEO4J_causalClustering_transactionListenAddress:-}
-    NEO4J_causal__clustering_transaction__advertised__address=${NEO4J_causalClustering_transactionAdvertisedAddress:-}
-    NEO4J_causal__clustering_raft__listen__address=${NEO4J_causalClustering_raftListenAddress:-}
-    NEO4J_causal__clustering_raft__advertised__address=${NEO4J_causalClustering_raftAdvertisedAddress:-}
+    # Backward compatibility - map old hardcoded env variables into new naming convention (if they aren't set already)
+    # Set some to default values if unset
+    : ${NEO4J_dbms_tx__log_rotation_retention__policy:=${NEO4J_dbms_txLog_rotation_retentionPolicy:-"100M size"}}
+    : ${NEO4J_wrapper_java_additional:=${NEO4J_UDC_SOURCE:-"-Dneo4j.ext.udc.source=docker"}}
+    : ${NEO4J_dbms_memory_heap_initial__size:=${NEO4J_dbms_memory_heap_maxSize:-"512M"}}
+    : ${NEO4J_dbms_memory_heap_max__size:=${NEO4J_dbms_memory_heap_maxSize:-"512M"}}
+    : ${NEO4J_dbms_unmanaged__extension__classes:=${NEO4J_dbms_unmanagedExtensionClasses:-}}
+    : ${NEO4J_dbms_allow__format__migration:=${NEO4J_dbms_allowFormatMigration:-}}
+    : ${NEO4J_dbms_connectors_default__advertised__address:=${NEO4J_dbms_connectors_defaultAdvertisedAddress:-}}
+    : ${NEO4J_ha_server__id:=${NEO4J_ha_serverId:-}}
+    : ${NEO4J_ha_initial__hosts:=${NEO4J_ha_initialHosts:-}}
+    : ${NEO4J_causal__clustering_expected__core__cluster__size:=${NEO4J_causalClustering_expectedCoreClusterSize:-}}
+    : ${NEO4J_causal__clustering_initial__discovery__members:=${NEO4J_causalClustering_initialDiscoveryMembers:-}}
+    : ${NEO4J_causal__clustering_discovery__listen__address:=${NEO4J_causalClustering_discoveryListenAddress:-"0.0.0.0:5000"}}
+    : ${NEO4J_causal__clustering_discovery__advertised__address:=${NEO4J_causalClustering_discoveryAdvertisedAddress:-"$(hostname):5000"}}
+    : ${NEO4J_causal__clustering_transaction__listen__address:=${NEO4J_causalClustering_transactionListenAddress:-"0.0.0.0:6000"}}
+    : ${NEO4J_causal__clustering_transaction__advertised__address:=${NEO4J_causalClustering_transactionAdvertisedAddress:-"$(hostname):6000"}}
+    : ${NEO4J_causal__clustering_raft__listen__address:=${NEO4J_causalClustering_raftListenAddress:-"0.0.0.0:7000"}}
+    : ${NEO4J_causal__clustering_raft__advertised__address:=${NEO4J_causalClustering_raftAdvertisedAddress:-"$(hostname):7000"}}
+
+    : ${NEO4J_dbms_connectors_default__listen__address:="0.0.0.0"}
+    : ${NEO4J_dbms_connector_http_listen__address:="0.0.0.0:7474"}
+    : ${NEO4J_dbms_connector_https_listen__address:="0.0.0.0:7473"}
+    : ${NEO4J_dbms_connector_bolt_listen__address:="0.0.0.0:7687"}
+    : ${NEO4J_ha_host_coordination:="$(hostname):5001"}
+    : ${NEO4J_ha_host_data:="$(hostname):6001"}
 
     # unset old hardcoded unsupported env variables
     unset NEO4J_dbms_txLog_rotation_retentionPolicy NEO4J_UDC_SOURCE \

--- a/test/ha-cluster-compose.yml
+++ b/test/ha-cluster-compose.yml
@@ -41,8 +41,8 @@ services:
     environment:
       - NEO4J_AUTH=neo4j/neo
       - NEO4J_dbms_mode=HA
-      - NEO4J_ha_serverId=3
-      - NEO4J_ha_initialHosts=master:5001,slave1:5555,slave2:5001
+      - NEO4J_ha_server__id=3
+      - NEO4J_ha_initial__hosts=master:5001,slave1:5555,slave2:5001
       - NEO4J_ha_host_coordination=slave2:5001
       - NEO4J_ha_host_data=slave2:6001
       - NEO4J_ha_slave__only=true


### PR DESCRIPTION
* For values which had old hardcoded versions we would always override
  the new kind. If the old variable had no value then we wrote that
  empty value.
* Now only sets the values conditionally: if no value for the new kind
  of variable exists, and then only if the previous variable has a
  value. And if not, then we write whatever is the default (or nothing).