### PR TITLE
#94 Allow auth credentials to be configured via files.

### DIFF
--- a/src/2.3/docker-entrypoint.sh
+++ b/src/2.3/docker-entrypoint.sh
@@ -14,6 +14,28 @@ setting() {
     fi
 }
 
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
 if [ "$1" == "neo4j" ]; then
     setting "keep_logical_logs" "${NEO4J_KEEP_LOGICAL_LOGS:-100M size}" neo4j.properties
     setting "dbms.pagecache.memory" "${NEO4J_CACHE_MEMORY:-512M}" neo4j.properties
@@ -23,6 +45,7 @@ if [ "$1" == "neo4j" ]; then
     setting "org.neo4j.server.thirdparty_jaxrs_classes" "${NEO4J_THIRDPARTY_JAXRS_CLASSES:-}" neo4j-server.properties
     setting "allow_store_upgrade" "${NEO4J_ALLOW_STORE_UPGRADE:-}" neo4j.properties
 
+    file_env 'NEO4J_AUTH'
     if [ "${NEO4J_AUTH:-}" == "none" ]; then
         setting "dbms.security.auth_enabled" "false" neo4j-server.properties
     elif [[ "${NEO4J_AUTH:-}" == neo4j/* ]]; then

--- a/src/3.0/docker-entrypoint.sh
+++ b/src/3.0/docker-entrypoint.sh
@@ -20,6 +20,28 @@ setting() {
     fi
 }
 
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
 if [ "$1" == "neo4j" ]; then
 
     # Env variable naming convention:
@@ -77,6 +99,7 @@ if [ "$1" == "neo4j" ]; then
         NEO4J_dbms_directories_metrics="/metrics"
     fi
 
+    file_env 'NEO4J_AUTH'
     if [ "${NEO4J_AUTH:-}" == "none" ]; then
         NEO4J_dbms_security_auth__enabled=false
     elif [[ "${NEO4J_AUTH:-}" == neo4j/* ]]; then

--- a/src/3.1/docker-entrypoint.sh
+++ b/src/3.1/docker-entrypoint.sh
@@ -1,5 +1,27 @@
 #!/bin/bash -eu
 
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
 if [ "$1" == "neo4j" ]; then
 
     # Env variable naming convention:
@@ -75,6 +97,7 @@ if [ "$1" == "neo4j" ]; then
         NEO4J_dbms_directories_metrics="/metrics"
     fi
 
+    file_env 'NEO4J_AUTH'
     if [ "${NEO4J_AUTH:-}" == "none" ]; then
         NEO4J_dbms_security_auth__enabled=false
     elif [[ "${NEO4J_AUTH:-}" == neo4j/* ]]; then

--- a/src/3.2/docker-entrypoint.sh
+++ b/src/3.2/docker-entrypoint.sh
@@ -1,5 +1,27 @@
 #!/bin/bash -eu
 
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
 if [ "$1" == "neo4j" ]; then
 
     # Env variable naming convention:
@@ -75,6 +97,7 @@ if [ "$1" == "neo4j" ]; then
         NEO4J_dbms_directories_metrics="/metrics"
     fi
 
+    file_env 'NEO4J_AUTH'
     if [ "${NEO4J_AUTH:-}" == "none" ]; then
         NEO4J_dbms_security_auth__enabled=false
     elif [[ "${NEO4J_AUTH:-}" == neo4j/* ]]; then

--- a/src/3.3/docker-entrypoint.sh
+++ b/src/3.3/docker-entrypoint.sh
@@ -1,5 +1,27 @@
 #!/bin/bash -eu
 
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
 if [ "$1" == "neo4j" ]; then
 
     # Env variable naming convention:
@@ -94,6 +116,7 @@ if [ "$1" == "neo4j" ]; then
         NEO4J_dbms_directories_metrics="/metrics"
     fi
 
+    file_env 'NEO4J_AUTH'
     if [ "${NEO4J_AUTH:-}" == "none" ]; then
         NEO4J_dbms_security_auth__enabled=false
     elif [[ "${NEO4J_AUTH:-}" == neo4j/* ]]; then

--- a/src/3.4/docker-entrypoint.sh
+++ b/src/3.4/docker-entrypoint.sh
@@ -1,5 +1,27 @@
 #!/bin/bash -eu
 
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
 if [ "$1" == "neo4j" ]; then
 
     # Env variable naming convention:
@@ -86,6 +108,7 @@ if [ "$1" == "neo4j" ]; then
         NEO4J_dbms_directories_metrics="/metrics"
     fi
 
+    file_env 'NEO4J_AUTH'
     if [ "${NEO4J_AUTH:-}" == "none" ]; then
         NEO4J_dbms_security_auth__enabled=false
     elif [[ "${NEO4J_AUTH:-}" == neo4j/* ]]; then


### PR DESCRIPTION
This allows for the auth credentials to be specified via a file so docker secrets can be used.

So you could define a neo4j service like:
```yaml
version: '3.1'

secrets:
  neo4j-auth:
    external: true

services:
  neo4j:
    command: /docker-entrypoint.sh neo4j
    deploy:
      mode: replicated
      replicas: 1
    environment:
      NEO4J_AUTH_FILE: /run/secrets/neo4j-auth
```

Where `neo4j-auth` is a file that has the contents: `neo4j/somefancypassword`

------------------

The `file_env` function was lifted from the mysql entrypoint script:
https://github.com/docker-library/mysql/blob/master/5.7/docker-entrypoint.sh#L21-L41