### PR TITLE
Use the `docker_run` helper for this test as well.

### DIFF
--- a/test/causal-cluster-compose.yml
+++ b/test/causal-cluster-compose.yml
@@ -11,6 +11,7 @@ services:
     networks:
       - lan
     environment:
+      - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
       - NEO4J_AUTH=none
       - NEO4J_dbms_mode=CORE
       - NEO4J_causalClustering_expectedCoreClusterSize=3
@@ -21,6 +22,7 @@ services:
     networks:
       - lan
     environment:
+      - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
       - NEO4J_AUTH=neo4j/neo
       - NEO4J_dbms_mode=CORE
       - NEO4J_causalClustering_expectedCoreClusterSize=3
@@ -31,6 +33,7 @@ services:
     networks:
       - lan
     environment:
+      - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
       - NEO4J_AUTH=neo4j/neo
       - NEO4J_dbms_mode=CORE
       - NEO4J_causalClustering_discoveryAdvertisedAddress=core3:5000
@@ -45,6 +48,7 @@ services:
     networks:
       - lan
     environment:
+      - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
       - NEO4J_AUTH=neo4j/neo
       - NEO4J_dbms_mode=READ_REPLICA
       - NEO4J_causalClustering_initialDiscoveryMembers=core1:5000,core2:5000,core3:5000

--- a/test/ha-cluster-compose.yml
+++ b/test/ha-cluster-compose.yml
@@ -11,6 +11,7 @@ services:
     networks:
       - lan
     environment:
+      - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
       - NEO4J_AUTH=neo4j/neo
       - NEO4J_ha_serverId=1
       - NEO4J_dbms_mode=HA
@@ -24,6 +25,7 @@ services:
     networks:
       - lan
     environment:
+      - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
       - NEO4J_AUTH=neo4j/neo
       - NEO4J_dbms_mode=HA
       - NEO4J_ha_serverId=2
@@ -39,6 +41,7 @@ services:
     networks:
       - lan
     environment:
+      - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
       - NEO4J_AUTH=neo4j/neo
       - NEO4J_dbms_mode=HA
       - NEO4J_ha_server__id=3

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -17,8 +17,10 @@ docker_run() {
   local l_image="$1" l_cname="$2"; shift; shift
 
   local envs=()
-  for env in "$@"; do
+  if [[ ! "$@" =~ "NEO4J_ACCEPT_LICENSE_AGREEMENT=no" ]]; then
     envs+=("--env=NEO4J_ACCEPT_LICENSE_AGREEMENT=yes")
+  fi
+  for env in "$@"; do
     envs+=("--env=${env}")
   done
   local cid="$(docker run --detach "${envs[@]}" --name="${l_cname}" "${l_image}")"

--- a/test/test-requires-license-agreement-acceptance
+++ b/test/test-requires-license-agreement-acceptance
@@ -23,9 +23,11 @@ if ! [[ "${edition}" == "enterprise" ]]; then
   exit 0
 fi
 
-output=$(docker run --name="$cname" "${image}")
+output=$(docker_run "$image" "$cname" "NEO4J_ACCEPT_LICENSE_AGREEMENT=no")
+logfile=$(echo $output | awk '{print $2}')
 
-if [[ $output == *"must accept the license"* ]]; then
+if grep --quiet "must accept the license" $logfile; then
+  echo "License agreement not accepted."
   exit 0
 else
   echo "Not accepting the license agreement should have failed."


### PR DESCRIPTION
The license-acceptance test was doing `docker run` manually. This makes it use the test helper so the tests are all run the same.

Hopefully this will fix our CI build as well.