### PR TITLE
Always setup neo4j config with overrides except for 'dump-config'

### DIFF
--- a/src/3.0/docker-entrypoint.sh
+++ b/src/3.0/docker-entrypoint.sh
@@ -20,63 +20,74 @@ setting() {
     fi
 }
 
-if [ "$1" == "neo4j" ]; then
+cmd="$1"
 
-    # Env variable naming convention:
-    # - prefix NEO4J_
-    # - double underscore char '__' instead of single underscore '_' char in the setting name
-    # - underscore char '_' instead of dot '.' char in the setting name
-    # Example:
-    # NEO4J_dbms_tx__log_rotation_retention__policy env variable to set
-    #       dbms.tx_log.rotation.retention_policy setting
-
-    # Backward compatibility - map old hardcoded env variables into new naming convention (if they aren't set already)
-    # Set some to default values if unset
-    : ${NEO4J_dbms_tx__log_rotation_retention__policy:=${NEO4J_dbms_txLog_rotation_retentionPolicy:-"100M size"}}
-    : ${NEO4J_wrapper_java_additional:=${NEO4J_UDC_SOURCE:-"-Dneo4j.ext.udc.source=docker"}}
-    : ${NEO4J_dbms_memory_heap_initial__size:=${NEO4J_dbms_memory_heap_maxSize:-"512"}}
-    : ${NEO4J_dbms_memory_heap_max__size:=${NEO4J_dbms_memory_heap_maxSize:-"512"}}
-    : ${NEO4J_dbms_unmanaged__extension__classes:=${NEO4J_dbms_unmanagedExtensionClasses:-}}
-    : ${NEO4J_dbms_allow__format__migration:=${NEO4J_dbms_allowFormatMigration:-}}
-    : ${NEO4J_ha_server__id:=${NEO4J_ha_serverId:-}}
-    : ${NEO4J_ha_initial__hosts:=${NEO4J_ha_initialHosts:-}}
-
-    : ${NEO4J_dbms_connector_http_address:="0.0.0.0:7474"}
-    : ${NEO4J_dbms_connector_https_address:="0.0.0.0:7473"}
-    : ${NEO4J_dbms_connector_bolt_address:="0.0.0.0:7687"}
-    : ${NEO4J_ha_host_coordination:="$(hostname):5001"}
-    : ${NEO4J_ha_host_data:="$(hostname):6001"}
-
-    # unset old hardcoded unsupported env variables
-    unset NEO4J_dbms_txLog_rotation_retentionPolicy NEO4J_UDC_SOURCE \
-        NEO4J_dbms_memory_heap_maxSize NEO4J_dbms_memory_heap_maxSize \
-        NEO4J_dbms_unmanagedExtensionClasses NEO4J_dbms_allowFormatMigration \
-        NEO4J_ha_initialHosts
-
+if [ "${cmd}" == "dump-config" ]; then
     if [ -d /conf ]; then
-        find /conf -type f -exec cp {} conf \;
+        cp --recursive conf/* /conf
+        exit 0
+    else
+        echo "You must provide a /conf volume"
+        exit 1
     fi
+fi
 
-    if [ -d /ssl ]; then
-        NEO4J_dbms_directories_certificates="/ssl"
-    fi
+# Env variable naming convention:
+# - prefix NEO4J_
+# - double underscore char '__' instead of single underscore '_' char in the setting name
+# - underscore char '_' instead of dot '.' char in the setting name
+# Example:
+# NEO4J_dbms_tx__log_rotation_retention__policy env variable to set
+#       dbms.tx_log.rotation.retention_policy setting
 
-    if [ -d /plugins ]; then
-        NEO4J_dbms_directories_plugins="/plugins"
-    fi
+# Backward compatibility - map old hardcoded env variables into new naming convention (if they aren't set already)
+# Set some to default values if unset
+: ${NEO4J_dbms_tx__log_rotation_retention__policy:=${NEO4J_dbms_txLog_rotation_retentionPolicy:-"100M size"}}
+: ${NEO4J_wrapper_java_additional:=${NEO4J_UDC_SOURCE:-"-Dneo4j.ext.udc.source=docker"}}
+: ${NEO4J_dbms_memory_heap_initial__size:=${NEO4J_dbms_memory_heap_maxSize:-"512"}}
+: ${NEO4J_dbms_memory_heap_max__size:=${NEO4J_dbms_memory_heap_maxSize:-"512"}}
+: ${NEO4J_dbms_unmanaged__extension__classes:=${NEO4J_dbms_unmanagedExtensionClasses:-}}
+: ${NEO4J_dbms_allow__format__migration:=${NEO4J_dbms_allowFormatMigration:-}}
+: ${NEO4J_ha_server__id:=${NEO4J_ha_serverId:-}}
+: ${NEO4J_ha_initial__hosts:=${NEO4J_ha_initialHosts:-}}
 
-    if [ -d /logs ]; then
-        NEO4J_dbms_directories_logs="/logs"
-    fi
+: ${NEO4J_dbms_connector_http_address:="0.0.0.0:7474"}
+: ${NEO4J_dbms_connector_https_address:="0.0.0.0:7473"}
+: ${NEO4J_dbms_connector_bolt_address:="0.0.0.0:7687"}
+: ${NEO4J_ha_host_coordination:="$(hostname):5001"}
+: ${NEO4J_ha_host_data:="$(hostname):6001"}
 
-    if [ -d /import ]; then
-        NEO4J_dbms_directories_import="/import"
-    fi
+# unset old hardcoded unsupported env variables
+unset NEO4J_dbms_txLog_rotation_retentionPolicy NEO4J_UDC_SOURCE \
+    NEO4J_dbms_memory_heap_maxSize NEO4J_dbms_memory_heap_maxSize \
+    NEO4J_dbms_unmanagedExtensionClasses NEO4J_dbms_allowFormatMigration \
+    NEO4J_ha_initialHosts
 
-    if [ -d /metrics ]; then
-        NEO4J_dbms_directories_metrics="/metrics"
-    fi
+if [ -d /conf ]; then
+    find /conf -type f -exec cp {} conf \;
+fi
 
+if [ -d /ssl ]; then
+    NEO4J_dbms_directories_certificates="/ssl"
+fi
+
+if [ -d /plugins ]; then
+    NEO4J_dbms_directories_plugins="/plugins"
+fi
+
+if [ -d /logs ]; then
+    NEO4J_dbms_directories_logs="/logs"
+fi
+
+if [ -d /import ]; then
+    NEO4J_dbms_directories_import="/import"
+fi
+
+if [ -d /metrics ]; then
+    NEO4J_dbms_directories_metrics="/metrics"
+fi
+
+if [ "${cmd}" == "neo4j" ] ; then
     if [ "${NEO4J_AUTH:-}" == "none" ]; then
         NEO4J_dbms_security_auth__enabled=false
     elif [[ "${NEO4J_AUTH:-}" == neo4j/* ]]; then
@@ -120,32 +131,27 @@ if [ "$1" == "neo4j" ]; then
         echo "Invalid value for NEO4J_AUTH: '${NEO4J_AUTH}'"
         exit 1
     fi
+fi
 
-    # list env variables with prefix NEO4J_ and create settings from them
-    unset NEO4J_AUTH NEO4J_SHA256 NEO4J_TARBALL
-    for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
-        setting=$(echo ${i} | sed 's|^NEO4J_||' | sed 's|_|.|g' | sed 's|\.\.|_|g')
-        value=$(echo ${!i})
-        if [[ -n ${value} ]]; then
-            if grep -q -F "${setting}=" conf/neo4j.conf; then
-                # Remove any lines containing the setting already
-                sed --in-place "/${setting}=.*/d" conf/neo4j.conf
-            fi
-            # Then always append setting to file
-            echo "${setting}=${value}" >> conf/neo4j.conf
+# list env variables with prefix NEO4J_ and create settings from them
+unset NEO4J_AUTH NEO4J_SHA256 NEO4J_TARBALL
+for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
+    setting=$(echo ${i} | sed 's|^NEO4J_||' | sed 's|_|.|g' | sed 's|\.\.|_|g')
+    value=$(echo ${!i})
+    if [[ -n ${value} ]]; then
+        if grep -q -F "${setting}=" conf/neo4j.conf; then
+            # Remove any lines containing the setting already
+            sed --in-place "/${setting}=.*/d" conf/neo4j.conf
         fi
-    done
-
-    [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
-
-    exec bin/neo4j console
-elif [ "$1" == "dump-config" ]; then
-    if [ -d /conf ]; then
-        cp --recursive conf/* /conf
-    else
-        echo "You must provide a /conf volume"
-        exit 1
+        # Then always append setting to file
+        echo "${setting}=${value}" >> conf/neo4j.conf
     fi
+done
+
+[ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
+
+if [ "${cmd}" == "neo4j" ] ; then
+    exec bin/neo4j console
 else
     exec "$@"
 fi

--- a/src/3.1/docker-entrypoint.sh
+++ b/src/3.1/docker-entrypoint.sh
@@ -1,80 +1,92 @@
 #!/bin/bash -eu
 
-if [ "$1" == "neo4j" ]; then
+cmd="$1"
 
-    # Env variable naming convention:
-    # - prefix NEO4J_
-    # - double underscore char '__' instead of single underscore '_' char in the setting name
-    # - underscore char '_' instead of dot '.' char in the setting name
-    # Example:
-    # NEO4J_dbms_tx__log_rotation_retention__policy env variable to set
-    #       dbms.tx_log.rotation.retention_policy setting
-
-    # Backward compatibility - map old hardcoded env variables into new naming convention (if they aren't set already)
-    # Set some to default values if unset
-    : ${NEO4J_dbms_tx__log_rotation_retention__policy:=${NEO4J_dbms_txLog_rotation_retentionPolicy:-"100M size"}}
-    : ${NEO4J_wrapper_java_additional:=${NEO4J_UDC_SOURCE:-"-Dneo4j.ext.udc.source=docker"}}
-    : ${NEO4J_dbms_memory_heap_initial__size:=${NEO4J_dbms_memory_heap_maxSize:-"512M"}}
-    : ${NEO4J_dbms_memory_heap_max__size:=${NEO4J_dbms_memory_heap_maxSize:-"512M"}}
-    : ${NEO4J_dbms_unmanaged__extension__classes:=${NEO4J_dbms_unmanagedExtensionClasses:-}}
-    : ${NEO4J_dbms_allow__format__migration:=${NEO4J_dbms_allowFormatMigration:-}}
-    : ${NEO4J_dbms_connectors_default__advertised__address:=${NEO4J_dbms_connectors_defaultAdvertisedAddress:-}}
-    : ${NEO4J_ha_server__id:=${NEO4J_ha_serverId:-}}
-    : ${NEO4J_ha_initial__hosts:=${NEO4J_ha_initialHosts:-}}
-    : ${NEO4J_causal__clustering_expected__core__cluster__size:=${NEO4J_causalClustering_expectedCoreClusterSize:-}}
-    : ${NEO4J_causal__clustering_initial__discovery__members:=${NEO4J_causalClustering_initialDiscoveryMembers:-}}
-    : ${NEO4J_causal__clustering_discovery__listen__address:=${NEO4J_causalClustering_discoveryListenAddress:-"0.0.0.0:5000"}}
-    : ${NEO4J_causal__clustering_discovery__advertised__address:=${NEO4J_causalClustering_discoveryAdvertisedAddress:-"$(hostname):5000"}}
-    : ${NEO4J_causal__clustering_transaction__listen__address:=${NEO4J_causalClustering_transactionListenAddress:-"0.0.0.0:6000"}}
-    : ${NEO4J_causal__clustering_transaction__advertised__address:=${NEO4J_causalClustering_transactionAdvertisedAddress:-"$(hostname):6000"}}
-    : ${NEO4J_causal__clustering_raft__listen__address:=${NEO4J_causalClustering_raftListenAddress:-"0.0.0.0:7000"}}
-    : ${NEO4J_causal__clustering_raft__advertised__address:=${NEO4J_causalClustering_raftAdvertisedAddress:-"$(hostname):7000"}}
-
-    : ${NEO4J_dbms_connectors_default__listen__address:="0.0.0.0"}
-    : ${NEO4J_dbms_connector_http_listen__address:="0.0.0.0:7474"}
-    : ${NEO4J_dbms_connector_https_listen__address:="0.0.0.0:7473"}
-    : ${NEO4J_dbms_connector_bolt_listen__address:="0.0.0.0:7687"}
-    : ${NEO4J_ha_host_coordination:="$(hostname):5001"}
-    : ${NEO4J_ha_host_data:="$(hostname):6001"}
-
-    # unset old hardcoded unsupported env variables
-    unset NEO4J_dbms_txLog_rotation_retentionPolicy NEO4J_UDC_SOURCE \
-        NEO4J_dbms_memory_heap_maxSize NEO4J_dbms_memory_heap_maxSize \
-        NEO4J_dbms_unmanagedExtensionClasses NEO4J_dbms_allowFormatMigration \
-        NEO4J_dbms_connectors_defaultAdvertisedAddress NEO4J_ha_serverId \
-        NEO4J_ha_initialHosts NEO4J_causalClustering_expectedCoreClusterSize \
-        NEO4J_causalClustering_initialDiscoveryMembers \
-        NEO4J_causalClustering_discoveryListenAddress \
-        NEO4J_causalClustering_discoveryAdvertisedAddress \
-        NEO4J_causalClustering_transactionListenAddress \
-        NEO4J_causalClustering_transactionAdvertisedAddress \
-        NEO4J_causalClustering_raftListenAddress \
-        NEO4J_causalClustering_raftAdvertisedAddress
-
+if [ "${cmd}" == "dump-config" ]; then
     if [ -d /conf ]; then
-        find /conf -type f -exec cp {} conf \;
+        cp --recursive conf/* /conf
+        exit 0
+    else
+        echo "You must provide a /conf volume"
+        exit 1
     fi
+fi
 
-    if [ -d /ssl ]; then
-        NEO4J_dbms_directories_certificates="/ssl"
-    fi
+# Env variable naming convention:
+# - prefix NEO4J_
+# - double underscore char '__' instead of single underscore '_' char in the setting name
+# - underscore char '_' instead of dot '.' char in the setting name
+# Example:
+# NEO4J_dbms_tx__log_rotation_retention__policy env variable to set
+#       dbms.tx_log.rotation.retention_policy setting
 
-    if [ -d /plugins ]; then
-        NEO4J_dbms_directories_plugins="/plugins"
-    fi
+# Backward compatibility - map old hardcoded env variables into new naming convention (if they aren't set already)
+# Set some to default values if unset
+: ${NEO4J_dbms_tx__log_rotation_retention__policy:=${NEO4J_dbms_txLog_rotation_retentionPolicy:-"100M size"}}
+: ${NEO4J_wrapper_java_additional:=${NEO4J_UDC_SOURCE:-"-Dneo4j.ext.udc.source=docker"}}
+: ${NEO4J_dbms_memory_heap_initial__size:=${NEO4J_dbms_memory_heap_maxSize:-"512M"}}
+: ${NEO4J_dbms_memory_heap_max__size:=${NEO4J_dbms_memory_heap_maxSize:-"512M"}}
+: ${NEO4J_dbms_unmanaged__extension__classes:=${NEO4J_dbms_unmanagedExtensionClasses:-}}
+: ${NEO4J_dbms_allow__format__migration:=${NEO4J_dbms_allowFormatMigration:-}}
+: ${NEO4J_dbms_connectors_default__advertised__address:=${NEO4J_dbms_connectors_defaultAdvertisedAddress:-}}
+: ${NEO4J_ha_server__id:=${NEO4J_ha_serverId:-}}
+: ${NEO4J_ha_initial__hosts:=${NEO4J_ha_initialHosts:-}}
+: ${NEO4J_causal__clustering_expected__core__cluster__size:=${NEO4J_causalClustering_expectedCoreClusterSize:-}}
+: ${NEO4J_causal__clustering_initial__discovery__members:=${NEO4J_causalClustering_initialDiscoveryMembers:-}}
+: ${NEO4J_causal__clustering_discovery__listen__address:=${NEO4J_causalClustering_discoveryListenAddress:-"0.0.0.0:5000"}}
+: ${NEO4J_causal__clustering_discovery__advertised__address:=${NEO4J_causalClustering_discoveryAdvertisedAddress:-"$(hostname):5000"}}
+: ${NEO4J_causal__clustering_transaction__listen__address:=${NEO4J_causalClustering_transactionListenAddress:-"0.0.0.0:6000"}}
+: ${NEO4J_causal__clustering_transaction__advertised__address:=${NEO4J_causalClustering_transactionAdvertisedAddress:-"$(hostname):6000"}}
+: ${NEO4J_causal__clustering_raft__listen__address:=${NEO4J_causalClustering_raftListenAddress:-"0.0.0.0:7000"}}
+: ${NEO4J_causal__clustering_raft__advertised__address:=${NEO4J_causalClustering_raftAdvertisedAddress:-"$(hostname):7000"}}
 
-    if [ -d /logs ]; then
-        NEO4J_dbms_directories_logs="/logs"
-    fi
+: ${NEO4J_dbms_connectors_default__listen__address:="0.0.0.0"}
+: ${NEO4J_dbms_connector_http_listen__address:="0.0.0.0:7474"}
+: ${NEO4J_dbms_connector_https_listen__address:="0.0.0.0:7473"}
+: ${NEO4J_dbms_connector_bolt_listen__address:="0.0.0.0:7687"}
+: ${NEO4J_ha_host_coordination:="$(hostname):5001"}
+: ${NEO4J_ha_host_data:="$(hostname):6001"}
 
-    if [ -d /import ]; then
-        NEO4J_dbms_directories_import="/import"
-    fi
+# unset old hardcoded unsupported env variables
+unset NEO4J_dbms_txLog_rotation_retentionPolicy NEO4J_UDC_SOURCE \
+    NEO4J_dbms_memory_heap_maxSize NEO4J_dbms_memory_heap_maxSize \
+    NEO4J_dbms_unmanagedExtensionClasses NEO4J_dbms_allowFormatMigration \
+    NEO4J_dbms_connectors_defaultAdvertisedAddress NEO4J_ha_serverId \
+    NEO4J_ha_initialHosts NEO4J_causalClustering_expectedCoreClusterSize \
+    NEO4J_causalClustering_initialDiscoveryMembers \
+    NEO4J_causalClustering_discoveryListenAddress \
+    NEO4J_causalClustering_discoveryAdvertisedAddress \
+    NEO4J_causalClustering_transactionListenAddress \
+    NEO4J_causalClustering_transactionAdvertisedAddress \
+    NEO4J_causalClustering_raftListenAddress \
+    NEO4J_causalClustering_raftAdvertisedAddress
 
-    if [ -d /metrics ]; then
-        NEO4J_dbms_directories_metrics="/metrics"
-    fi
+if [ -d /conf ]; then
+    find /conf -type f -exec cp {} conf \;
+fi
 
+if [ -d /ssl ]; then
+    NEO4J_dbms_directories_certificates="/ssl"
+fi
+
+if [ -d /plugins ]; then
+    NEO4J_dbms_directories_plugins="/plugins"
+fi
+
+if [ -d /logs ]; then
+    NEO4J_dbms_directories_logs="/logs"
+fi
+
+if [ -d /import ]; then
+    NEO4J_dbms_directories_import="/import"
+fi
+
+if [ -d /metrics ]; then
+    NEO4J_dbms_directories_metrics="/metrics"
+fi
+
+# set the neo4j initial password only if you run the database server
+if [ "${cmd}" == "neo4j" ] ; then
     if [ "${NEO4J_AUTH:-}" == "none" ]; then
         NEO4J_dbms_security_auth__enabled=false
     elif [[ "${NEO4J_AUTH:-}" == neo4j/* ]]; then
@@ -89,32 +101,27 @@ if [ "$1" == "neo4j" ]; then
         echo "Invalid value for NEO4J_AUTH: '${NEO4J_AUTH}'"
         exit 1
     fi
+fi
 
-    # list env variables with prefix NEO4J_ and create settings from them
-    unset NEO4J_AUTH NEO4J_SHA256 NEO4J_TARBALL
-    for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
-        setting=$(echo ${i} | sed 's|^NEO4J_||' | sed 's|_|.|g' | sed 's|\.\.|_|g')
-        value=$(echo ${!i})
-        if [[ -n ${value} ]]; then
-            if grep -q -F "${setting}=" conf/neo4j.conf; then
-                # Remove any lines containing the setting already
-                sed --in-place "/${setting}=.*/d" conf/neo4j.conf
-            fi
-            # Then always append setting to file
-            echo "${setting}=${value}" >> conf/neo4j.conf
+# list env variables with prefix NEO4J_ and create settings from them
+unset NEO4J_AUTH NEO4J_SHA256 NEO4J_TARBALL
+for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
+    setting=$(echo ${i} | sed 's|^NEO4J_||' | sed 's|_|.|g' | sed 's|\.\.|_|g')
+    value=$(echo ${!i})
+    if [[ -n ${value} ]]; then
+        if grep -q -F "${setting}=" conf/neo4j.conf; then
+            # Remove any lines containing the setting already
+            sed --in-place "/${setting}=.*/d" conf/neo4j.conf
         fi
-    done
-
-    [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
-
-    exec bin/neo4j console
-elif [ "$1" == "dump-config" ]; then
-    if [ -d /conf ]; then
-        cp --recursive conf/* /conf
-    else
-        echo "You must provide a /conf volume"
-        exit 1
+        # Then always append setting to file
+        echo "${setting}=${value}" >> conf/neo4j.conf
     fi
+done
+
+[ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
+
+if [ "${cmd}" == "neo4j" ] ; then
+    exec neo4j console
 else
     exec "$@"
 fi

--- a/src/3.2/docker-entrypoint.sh
+++ b/src/3.2/docker-entrypoint.sh
@@ -1,80 +1,92 @@
 #!/bin/bash -eu
 
-if [ "$1" == "neo4j" ]; then
+cmd="$1"
 
-    # Env variable naming convention:
-    # - prefix NEO4J_
-    # - double underscore char '__' instead of single underscore '_' char in the setting name
-    # - underscore char '_' instead of dot '.' char in the setting name
-    # Example:
-    # NEO4J_dbms_tx__log_rotation_retention__policy env variable to set
-    #       dbms.tx_log.rotation.retention_policy setting
-
-    # Backward compatibility - map old hardcoded env variables into new naming convention (if they aren't set already)
-    # Set some to default values if unset
-    : ${NEO4J_dbms_tx__log_rotation_retention__policy:=${NEO4J_dbms_txLog_rotation_retentionPolicy:-"100M size"}}
-    : ${NEO4J_wrapper_java_additional:=${NEO4J_UDC_SOURCE:-"-Dneo4j.ext.udc.source=docker"}}
-    : ${NEO4J_dbms_memory_heap_initial__size:=${NEO4J_dbms_memory_heap_maxSize:-"512M"}}
-    : ${NEO4J_dbms_memory_heap_max__size:=${NEO4J_dbms_memory_heap_maxSize:-"512M"}}
-    : ${NEO4J_dbms_unmanaged__extension__classes:=${NEO4J_dbms_unmanagedExtensionClasses:-}}
-    : ${NEO4J_dbms_allow__format__migration:=${NEO4J_dbms_allowFormatMigration:-}}
-    : ${NEO4J_dbms_connectors_default__advertised__address:=${NEO4J_dbms_connectors_defaultAdvertisedAddress:-}}
-    : ${NEO4J_ha_server__id:=${NEO4J_ha_serverId:-}}
-    : ${NEO4J_ha_initial__hosts:=${NEO4J_ha_initialHosts:-}}
-    : ${NEO4J_causal__clustering_expected__core__cluster__size:=${NEO4J_causalClustering_expectedCoreClusterSize:-}}
-    : ${NEO4J_causal__clustering_initial__discovery__members:=${NEO4J_causalClustering_initialDiscoveryMembers:-}}
-    : ${NEO4J_causal__clustering_discovery__listen__address:=${NEO4J_causalClustering_discoveryListenAddress:-"0.0.0.0:5000"}}
-    : ${NEO4J_causal__clustering_discovery__advertised__address:=${NEO4J_causalClustering_discoveryAdvertisedAddress:-"$(hostname):5000"}}
-    : ${NEO4J_causal__clustering_transaction__listen__address:=${NEO4J_causalClustering_transactionListenAddress:-"0.0.0.0:6000"}}
-    : ${NEO4J_causal__clustering_transaction__advertised__address:=${NEO4J_causalClustering_transactionAdvertisedAddress:-"$(hostname):6000"}}
-    : ${NEO4J_causal__clustering_raft__listen__address:=${NEO4J_causalClustering_raftListenAddress:-"0.0.0.0:7000"}}
-    : ${NEO4J_causal__clustering_raft__advertised__address:=${NEO4J_causalClustering_raftAdvertisedAddress:-"$(hostname):7000"}}
-
-    : ${NEO4J_dbms_connectors_default__listen__address:="0.0.0.0"}
-    : ${NEO4J_dbms_connector_http_listen__address:="0.0.0.0:7474"}
-    : ${NEO4J_dbms_connector_https_listen__address:="0.0.0.0:7473"}
-    : ${NEO4J_dbms_connector_bolt_listen__address:="0.0.0.0:7687"}
-    : ${NEO4J_ha_host_coordination:="$(hostname):5001"}
-    : ${NEO4J_ha_host_data:="$(hostname):6001"}
-
-    # unset old hardcoded unsupported env variables
-    unset NEO4J_dbms_txLog_rotation_retentionPolicy NEO4J_UDC_SOURCE \
-        NEO4J_dbms_memory_heap_maxSize NEO4J_dbms_memory_heap_maxSize \
-        NEO4J_dbms_unmanagedExtensionClasses NEO4J_dbms_allowFormatMigration \
-        NEO4J_dbms_connectors_defaultAdvertisedAddress NEO4J_ha_serverId \
-        NEO4J_ha_initialHosts NEO4J_causalClustering_expectedCoreClusterSize \
-        NEO4J_causalClustering_initialDiscoveryMembers \
-        NEO4J_causalClustering_discoveryListenAddress \
-        NEO4J_causalClustering_discoveryAdvertisedAddress \
-        NEO4J_causalClustering_transactionListenAddress \
-        NEO4J_causalClustering_transactionAdvertisedAddress \
-        NEO4J_causalClustering_raftListenAddress \
-        NEO4J_causalClustering_raftAdvertisedAddress
-
+if [ "${cmd}" == "dump-config" ]; then
     if [ -d /conf ]; then
-        find /conf -type f -exec cp {} conf \;
+        cp --recursive conf/* /conf
+        exit 0
+    else
+        echo "You must provide a /conf volume"
+        exit 1
     fi
+fi
 
-    if [ -d /ssl ]; then
-        NEO4J_dbms_directories_certificates="/ssl"
-    fi
+# Env variable naming convention:
+# - prefix NEO4J_
+# - double underscore char '__' instead of single underscore '_' char in the setting name
+# - underscore char '_' instead of dot '.' char in the setting name
+# Example:
+# NEO4J_dbms_tx__log_rotation_retention__policy env variable to set
+#       dbms.tx_log.rotation.retention_policy setting
 
-    if [ -d /plugins ]; then
-        NEO4J_dbms_directories_plugins="/plugins"
-    fi
+# Backward compatibility - map old hardcoded env variables into new naming convention (if they aren't set already)
+# Set some to default values if unset
+: ${NEO4J_dbms_tx__log_rotation_retention__policy:=${NEO4J_dbms_txLog_rotation_retentionPolicy:-"100M size"}}
+: ${NEO4J_wrapper_java_additional:=${NEO4J_UDC_SOURCE:-"-Dneo4j.ext.udc.source=docker"}}
+: ${NEO4J_dbms_memory_heap_initial__size:=${NEO4J_dbms_memory_heap_maxSize:-"512M"}}
+: ${NEO4J_dbms_memory_heap_max__size:=${NEO4J_dbms_memory_heap_maxSize:-"512M"}}
+: ${NEO4J_dbms_unmanaged__extension__classes:=${NEO4J_dbms_unmanagedExtensionClasses:-}}
+: ${NEO4J_dbms_allow__format__migration:=${NEO4J_dbms_allowFormatMigration:-}}
+: ${NEO4J_dbms_connectors_default__advertised__address:=${NEO4J_dbms_connectors_defaultAdvertisedAddress:-}}
+: ${NEO4J_ha_server__id:=${NEO4J_ha_serverId:-}}
+: ${NEO4J_ha_initial__hosts:=${NEO4J_ha_initialHosts:-}}
+: ${NEO4J_causal__clustering_expected__core__cluster__size:=${NEO4J_causalClustering_expectedCoreClusterSize:-}}
+: ${NEO4J_causal__clustering_initial__discovery__members:=${NEO4J_causalClustering_initialDiscoveryMembers:-}}
+: ${NEO4J_causal__clustering_discovery__listen__address:=${NEO4J_causalClustering_discoveryListenAddress:-"0.0.0.0:5000"}}
+: ${NEO4J_causal__clustering_discovery__advertised__address:=${NEO4J_causalClustering_discoveryAdvertisedAddress:-"$(hostname):5000"}}
+: ${NEO4J_causal__clustering_transaction__listen__address:=${NEO4J_causalClustering_transactionListenAddress:-"0.0.0.0:6000"}}
+: ${NEO4J_causal__clustering_transaction__advertised__address:=${NEO4J_causalClustering_transactionAdvertisedAddress:-"$(hostname):6000"}}
+: ${NEO4J_causal__clustering_raft__listen__address:=${NEO4J_causalClustering_raftListenAddress:-"0.0.0.0:7000"}}
+: ${NEO4J_causal__clustering_raft__advertised__address:=${NEO4J_causalClustering_raftAdvertisedAddress:-"$(hostname):7000"}}
 
-    if [ -d /logs ]; then
-        NEO4J_dbms_directories_logs="/logs"
-    fi
+: ${NEO4J_dbms_connectors_default__listen__address:="0.0.0.0"}
+: ${NEO4J_dbms_connector_http_listen__address:="0.0.0.0:7474"}
+: ${NEO4J_dbms_connector_https_listen__address:="0.0.0.0:7473"}
+: ${NEO4J_dbms_connector_bolt_listen__address:="0.0.0.0:7687"}
+: ${NEO4J_ha_host_coordination:="$(hostname):5001"}
+: ${NEO4J_ha_host_data:="$(hostname):6001"}
 
-    if [ -d /import ]; then
-        NEO4J_dbms_directories_import="/import"
-    fi
+# unset old hardcoded unsupported env variables
+unset NEO4J_dbms_txLog_rotation_retentionPolicy NEO4J_UDC_SOURCE \
+    NEO4J_dbms_memory_heap_maxSize NEO4J_dbms_memory_heap_maxSize \
+    NEO4J_dbms_unmanagedExtensionClasses NEO4J_dbms_allowFormatMigration \
+    NEO4J_dbms_connectors_defaultAdvertisedAddress NEO4J_ha_serverId \
+    NEO4J_ha_initialHosts NEO4J_causalClustering_expectedCoreClusterSize \
+    NEO4J_causalClustering_initialDiscoveryMembers \
+    NEO4J_causalClustering_discoveryListenAddress \
+    NEO4J_causalClustering_discoveryAdvertisedAddress \
+    NEO4J_causalClustering_transactionListenAddress \
+    NEO4J_causalClustering_transactionAdvertisedAddress \
+    NEO4J_causalClustering_raftListenAddress \
+    NEO4J_causalClustering_raftAdvertisedAddress
 
-    if [ -d /metrics ]; then
-        NEO4J_dbms_directories_metrics="/metrics"
-    fi
+if [ -d /conf ]; then
+    find /conf -type f -exec cp {} conf \;
+fi
 
+if [ -d /ssl ]; then
+    NEO4J_dbms_directories_certificates="/ssl"
+fi
+
+if [ -d /plugins ]; then
+    NEO4J_dbms_directories_plugins="/plugins"
+fi
+
+if [ -d /logs ]; then
+    NEO4J_dbms_directories_logs="/logs"
+fi
+
+if [ -d /import ]; then
+    NEO4J_dbms_directories_import="/import"
+fi
+
+if [ -d /metrics ]; then
+    NEO4J_dbms_directories_metrics="/metrics"
+fi
+
+# set the neo4j initial password only if you run the database server
+if [ "${cmd}" == "neo4j" ] ; then
     if [ "${NEO4J_AUTH:-}" == "none" ]; then
         NEO4J_dbms_security_auth__enabled=false
     elif [[ "${NEO4J_AUTH:-}" == neo4j/* ]]; then
@@ -89,32 +101,27 @@ if [ "$1" == "neo4j" ]; then
         echo "Invalid value for NEO4J_AUTH: '${NEO4J_AUTH}'"
         exit 1
     fi
+fi
 
-    # list env variables with prefix NEO4J_ and create settings from them
-    unset NEO4J_AUTH NEO4J_SHA256 NEO4J_TARBALL
-    for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
-        setting=$(echo ${i} | sed 's|^NEO4J_||' | sed 's|_|.|g' | sed 's|\.\.|_|g')
-        value=$(echo ${!i})
-        if [[ -n ${value} ]]; then
-            if grep -q -F "${setting}=" conf/neo4j.conf; then
-                # Remove any lines containing the setting already
-                sed --in-place "/${setting}=.*/d" conf/neo4j.conf
-            fi
-            # Then always append setting to file
-            echo "${setting}=${value}" >> conf/neo4j.conf
+# list env variables with prefix NEO4J_ and create settings from them
+unset NEO4J_AUTH NEO4J_SHA256 NEO4J_TARBALL
+for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
+    setting=$(echo ${i} | sed 's|^NEO4J_||' | sed 's|_|.|g' | sed 's|\.\.|_|g')
+    value=$(echo ${!i})
+    if [[ -n ${value} ]]; then
+        if grep -q -F "${setting}=" conf/neo4j.conf; then
+            # Remove any lines containing the setting already
+            sed --in-place "/${setting}=.*/d" conf/neo4j.conf
         fi
-    done
-
-    [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
-
-    exec bin/neo4j console
-elif [ "$1" == "dump-config" ]; then
-    if [ -d /conf ]; then
-        cp --recursive conf/* /conf
-    else
-        echo "You must provide a /conf volume"
-        exit 1
+        # Then always append setting to file
+        echo "${setting}=${value}" >> conf/neo4j.conf
     fi
+done
+
+[ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
+
+if [ "${cmd}" == "neo4j" ] ; then
+    exec neo4j console
 else
     exec "$@"
 fi

--- a/src/3.3/docker-entrypoint.sh
+++ b/src/3.3/docker-entrypoint.sh
@@ -1,9 +1,20 @@
 #!/bin/bash -eu
 
-if [ "$1" == "neo4j" ]; then
-    if [ "$NEO4J_EDITION" == "enterprise" ]; then
-        if [ "${NEO4J_ACCEPT_LICENSE_AGREEMENT:=no}" != "yes" ]; then
-            echo "
+cmd="$1"
+
+if [ "${cmd}" == "dump-config" ]; then
+    if [ -d /conf ]; then
+        cp --recursive conf/* /conf
+        exit 0
+    else
+        echo "You must provide a /conf volume"
+        exit 1
+    fi
+fi
+
+if [ "$NEO4J_EDITION" == "enterprise" ]; then
+    if [ "${NEO4J_ACCEPT_LICENSE_AGREEMENT:=no}" != "yes" ]; then
+        echo "
 In order to use Neo4j Enterprise Edition you must accept the license agreement.
 
 (c) Network Engine for Objects in Lund AB.  2017.  All Rights Reserved.
@@ -22,102 +33,104 @@ To do this you can use the following docker argument:
 
         --env=NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
 "
-            exit 1
-        fi
+        exit 1
     fi
+fi
 
-    # Env variable naming convention:
-    # - prefix NEO4J_
-    # - double underscore char '__' instead of single underscore '_' char in the setting name
-    # - underscore char '_' instead of dot '.' char in the setting name
-    # Example:
-    # NEO4J_dbms_tx__log_rotation_retention__policy env variable to set
-    #       dbms.tx_log.rotation.retention_policy setting
+# Env variable naming convention:
+# - prefix NEO4J_
+# - double underscore char '__' instead of single underscore '_' char in the setting name
+# - underscore char '_' instead of dot '.' char in the setting name
+# Example:
+# NEO4J_dbms_tx__log_rotation_retention__policy env variable to set
+#       dbms.tx_log.rotation.retention_policy setting
 
-    # Backward compatibility - map old hardcoded env variables into new naming convention (if they aren't set already)
-    # Set some to default values if unset
-    : ${NEO4J_dbms_tx__log_rotation_retention__policy:=${NEO4J_dbms_txLog_rotation_retentionPolicy:-"100M size"}}
-    : ${NEO4J_wrapper_java_additional:=${NEO4J_UDC_SOURCE:-"-Dneo4j.ext.udc.source=docker"}}
-    : ${NEO4J_dbms_memory_heap_initial__size:=${NEO4J_dbms_memory_heap_maxSize:-"512M"}}
-    : ${NEO4J_dbms_memory_heap_max__size:=${NEO4J_dbms_memory_heap_maxSize:-"512M"}}
-    : ${NEO4J_dbms_unmanaged__extension__classes:=${NEO4J_dbms_unmanagedExtensionClasses:-}}
-    : ${NEO4J_dbms_allow__format__migration:=${NEO4J_dbms_allowFormatMigration:-}}
-    : ${NEO4J_dbms_connectors_default__advertised__address:=${NEO4J_dbms_connectors_defaultAdvertisedAddress:-}}
-    : ${NEO4J_ha_server__id:=${NEO4J_ha_serverId:-}}
-    : ${NEO4J_ha_initial__hosts:=${NEO4J_ha_initialHosts:-}}
-    : ${NEO4J_causal__clustering_expected__core__cluster__size:=${NEO4J_causalClustering_expectedCoreClusterSize:-}}
-    : ${NEO4J_causal__clustering_initial__discovery__members:=${NEO4J_causalClustering_initialDiscoveryMembers:-}}
-    : ${NEO4J_causal__clustering_discovery__listen__address:=${NEO4J_causalClustering_discoveryListenAddress:-"0.0.0.0:5000"}}
-    : ${NEO4J_causal__clustering_discovery__advertised__address:=${NEO4J_causalClustering_discoveryAdvertisedAddress:-"$(hostname):5000"}}
-    : ${NEO4J_causal__clustering_transaction__listen__address:=${NEO4J_causalClustering_transactionListenAddress:-"0.0.0.0:6000"}}
-    : ${NEO4J_causal__clustering_transaction__advertised__address:=${NEO4J_causalClustering_transactionAdvertisedAddress:-"$(hostname):6000"}}
-    : ${NEO4J_causal__clustering_raft__listen__address:=${NEO4J_causalClustering_raftListenAddress:-"0.0.0.0:7000"}}
-    : ${NEO4J_causal__clustering_raft__advertised__address:=${NEO4J_causalClustering_raftAdvertisedAddress:-"$(hostname):7000"}}
+# Backward compatibility - map old hardcoded env variables into new naming convention (if they aren't set already)
+# Set some to default values if unset
+: ${NEO4J_dbms_tx__log_rotation_retention__policy:=${NEO4J_dbms_txLog_rotation_retentionPolicy:-"100M size"}}
+: ${NEO4J_wrapper_java_additional:=${NEO4J_UDC_SOURCE:-"-Dneo4j.ext.udc.source=docker"}}
+: ${NEO4J_dbms_memory_heap_initial__size:=${NEO4J_dbms_memory_heap_maxSize:-"512M"}}
+: ${NEO4J_dbms_memory_heap_max__size:=${NEO4J_dbms_memory_heap_maxSize:-"512M"}}
+: ${NEO4J_dbms_unmanaged__extension__classes:=${NEO4J_dbms_unmanagedExtensionClasses:-}}
+: ${NEO4J_dbms_allow__format__migration:=${NEO4J_dbms_allowFormatMigration:-}}
+: ${NEO4J_dbms_connectors_default__advertised__address:=${NEO4J_dbms_connectors_defaultAdvertisedAddress:-}}
+: ${NEO4J_ha_server__id:=${NEO4J_ha_serverId:-}}
+: ${NEO4J_ha_initial__hosts:=${NEO4J_ha_initialHosts:-}}
+: ${NEO4J_causal__clustering_expected__core__cluster__size:=${NEO4J_causalClustering_expectedCoreClusterSize:-}}
+: ${NEO4J_causal__clustering_initial__discovery__members:=${NEO4J_causalClustering_initialDiscoveryMembers:-}}
+: ${NEO4J_causal__clustering_discovery__listen__address:=${NEO4J_causalClustering_discoveryListenAddress:-"0.0.0.0:5000"}}
+: ${NEO4J_causal__clustering_discovery__advertised__address:=${NEO4J_causalClustering_discoveryAdvertisedAddress:-"$(hostname):5000"}}
+: ${NEO4J_causal__clustering_transaction__listen__address:=${NEO4J_causalClustering_transactionListenAddress:-"0.0.0.0:6000"}}
+: ${NEO4J_causal__clustering_transaction__advertised__address:=${NEO4J_causalClustering_transactionAdvertisedAddress:-"$(hostname):6000"}}
+: ${NEO4J_causal__clustering_raft__listen__address:=${NEO4J_causalClustering_raftListenAddress:-"0.0.0.0:7000"}}
+: ${NEO4J_causal__clustering_raft__advertised__address:=${NEO4J_causalClustering_raftAdvertisedAddress:-"$(hostname):7000"}}
 
-    : ${NEO4J_dbms_connectors_default__listen__address:="0.0.0.0"}
-    : ${NEO4J_dbms_connector_http_listen__address:="0.0.0.0:7474"}
-    : ${NEO4J_dbms_connector_https_listen__address:="0.0.0.0:7473"}
-    : ${NEO4J_dbms_connector_bolt_listen__address:="0.0.0.0:7687"}
-    : ${NEO4J_ha_host_coordination:="$(hostname):5001"}
-    : ${NEO4J_ha_host_data:="$(hostname):6001"}
+: ${NEO4J_dbms_connectors_default__listen__address:="0.0.0.0"}
+: ${NEO4J_dbms_connector_http_listen__address:="0.0.0.0:7474"}
+: ${NEO4J_dbms_connector_https_listen__address:="0.0.0.0:7473"}
+: ${NEO4J_dbms_connector_bolt_listen__address:="0.0.0.0:7687"}
+: ${NEO4J_ha_host_coordination:="$(hostname):5001"}
+: ${NEO4J_ha_host_data:="$(hostname):6001"}
 
-    # unset old hardcoded unsupported env variables
-    unset NEO4J_dbms_txLog_rotation_retentionPolicy NEO4J_UDC_SOURCE \
-        NEO4J_dbms_memory_heap_maxSize NEO4J_dbms_memory_heap_maxSize \
-        NEO4J_dbms_unmanagedExtensionClasses NEO4J_dbms_allowFormatMigration \
-        NEO4J_dbms_connectors_defaultAdvertisedAddress NEO4J_ha_serverId \
-        NEO4J_ha_initialHosts NEO4J_causalClustering_expectedCoreClusterSize \
-        NEO4J_causalClustering_initialDiscoveryMembers \
-        NEO4J_causalClustering_discoveryListenAddress \
-        NEO4J_causalClustering_discoveryAdvertisedAddress \
-        NEO4J_causalClustering_transactionListenAddress \
-        NEO4J_causalClustering_transactionAdvertisedAddress \
-        NEO4J_causalClustering_raftListenAddress \
-        NEO4J_causalClustering_raftAdvertisedAddress
+# unset old hardcoded unsupported env variables
+unset NEO4J_dbms_txLog_rotation_retentionPolicy NEO4J_UDC_SOURCE \
+    NEO4J_dbms_memory_heap_maxSize NEO4J_dbms_memory_heap_maxSize \
+    NEO4J_dbms_unmanagedExtensionClasses NEO4J_dbms_allowFormatMigration \
+    NEO4J_dbms_connectors_defaultAdvertisedAddress NEO4J_ha_serverId \
+    NEO4J_ha_initialHosts NEO4J_causalClustering_expectedCoreClusterSize \
+    NEO4J_causalClustering_initialDiscoveryMembers \
+    NEO4J_causalClustering_discoveryListenAddress \
+    NEO4J_causalClustering_discoveryAdvertisedAddress \
+    NEO4J_causalClustering_transactionListenAddress \
+    NEO4J_causalClustering_transactionAdvertisedAddress \
+    NEO4J_causalClustering_raftListenAddress \
+    NEO4J_causalClustering_raftAdvertisedAddress
 
-    # Custom settings for dockerized neo4j
-    : ${NEO4J_dbms_tx__log_rotation_retention__policy:=100M size}
-    : ${NEO4J_dbms_memory_pagecache_size:=512M}
-    : ${NEO4J_wrapper_java_additional:=-Dneo4j.ext.udc.source=docker}
-    : ${NEO4J_dbms_memory_heap_initial__size:=512M}
-    : ${NEO4J_dbms_memory_heap_max__size:=512M}
-    : ${NEO4J_dbms_connectors_default__listen__address:=0.0.0.0}
-    : ${NEO4J_dbms_connector_http_listen__address:=0.0.0.0:7474}
-    : ${NEO4J_dbms_connector_https_listen__address:=0.0.0.0:7473}
-    : ${NEO4J_dbms_connector_bolt_listen__address:=0.0.0.0:7687}
-    : ${NEO4J_ha_host_coordination:=$(hostname):5001}
-    : ${NEO4J_ha_host_data:=$(hostname):6001}
-    : ${NEO4J_causal__clustering_discovery__listen__address:=0.0.0.0:5000}
-    : ${NEO4J_causal__clustering_discovery__advertised__address:=$(hostname):5000}
-    : ${NEO4J_causal__clustering_transaction__listen__address:=0.0.0.0:6000}
-    : ${NEO4J_causal__clustering_transaction__advertised__address:=$(hostname):6000}
-    : ${NEO4J_causal__clustering_raft__listen__address:=0.0.0.0:7000}
-    : ${NEO4J_causal__clustering_raft__advertised__address:=$(hostname):7000}
+# Custom settings for dockerized neo4j
+: ${NEO4J_dbms_tx__log_rotation_retention__policy:=100M size}
+: ${NEO4J_dbms_memory_pagecache_size:=512M}
+: ${NEO4J_wrapper_java_additional:=-Dneo4j.ext.udc.source=docker}
+: ${NEO4J_dbms_memory_heap_initial__size:=512M}
+: ${NEO4J_dbms_memory_heap_max__size:=512M}
+: ${NEO4J_dbms_connectors_default__listen__address:=0.0.0.0}
+: ${NEO4J_dbms_connector_http_listen__address:=0.0.0.0:7474}
+: ${NEO4J_dbms_connector_https_listen__address:=0.0.0.0:7473}
+: ${NEO4J_dbms_connector_bolt_listen__address:=0.0.0.0:7687}
+: ${NEO4J_ha_host_coordination:=$(hostname):5001}
+: ${NEO4J_ha_host_data:=$(hostname):6001}
+: ${NEO4J_causal__clustering_discovery__listen__address:=0.0.0.0:5000}
+: ${NEO4J_causal__clustering_discovery__advertised__address:=$(hostname):5000}
+: ${NEO4J_causal__clustering_transaction__listen__address:=0.0.0.0:6000}
+: ${NEO4J_causal__clustering_transaction__advertised__address:=$(hostname):6000}
+: ${NEO4J_causal__clustering_raft__listen__address:=0.0.0.0:7000}
+: ${NEO4J_causal__clustering_raft__advertised__address:=$(hostname):7000}
 
-    if [ -d /conf ]; then
-        find /conf -type f -exec cp {} conf \;
-    fi
+if [ -d /conf ]; then
+    find /conf -type f -exec cp {} conf \;
+fi
 
-    if [ -d /ssl ]; then
-        NEO4J_dbms_directories_certificates="/ssl"
-    fi
+if [ -d /ssl ]; then
+    NEO4J_dbms_directories_certificates="/ssl"
+fi
 
-    if [ -d /plugins ]; then
-        NEO4J_dbms_directories_plugins="/plugins"
-    fi
+if [ -d /plugins ]; then
+    NEO4J_dbms_directories_plugins="/plugins"
+fi
 
-    if [ -d /logs ]; then
-        NEO4J_dbms_directories_logs="/logs"
-    fi
+if [ -d /logs ]; then
+    NEO4J_dbms_directories_logs="/logs"
+fi
 
-    if [ -d /import ]; then
-        NEO4J_dbms_directories_import="/import"
-    fi
+if [ -d /import ]; then
+    NEO4J_dbms_directories_import="/import"
+fi
 
-    if [ -d /metrics ]; then
-        NEO4J_dbms_directories_metrics="/metrics"
-    fi
+if [ -d /metrics ]; then
+    NEO4J_dbms_directories_metrics="/metrics"
+fi
 
+# set the neo4j initial password only if you run the database server
+if [ "${cmd}" == "neo4j" ]; then
     if [ "${NEO4J_AUTH:-}" == "none" ]; then
         NEO4J_dbms_security_auth__enabled=false
     elif [[ "${NEO4J_AUTH:-}" == neo4j/* ]]; then
@@ -132,32 +145,27 @@ To do this you can use the following docker argument:
         echo "Invalid value for NEO4J_AUTH: '${NEO4J_AUTH}'"
         exit 1
     fi
+fi
 
-    # list env variables with prefix NEO4J_ and create settings from them
-    unset NEO4J_AUTH NEO4J_SHA256 NEO4J_TARBALL
-    for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
-        setting=$(echo ${i} | sed 's|^NEO4J_||' | sed 's|_|.|g' | sed 's|\.\.|_|g')
-        value=$(echo ${!i})
-        if [[ -n ${value} ]]; then
-            if grep -q -F "${setting}=" conf/neo4j.conf; then
-                # Remove any lines containing the setting already
-                sed --in-place "/${setting}=.*/d" conf/neo4j.conf
-            fi
-            # Then always append setting to file
-            echo "${setting}=${value}" >> conf/neo4j.conf
+# list env variables with prefix NEO4J_ and create settings from them
+unset NEO4J_AUTH NEO4J_SHA256 NEO4J_TARBALL
+for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
+    setting=$(echo ${i} | sed 's|^NEO4J_||' | sed 's|_|.|g' | sed 's|\.\.|_|g')
+    value=$(echo ${!i})
+    if [[ -n ${value} ]]; then
+        if grep -q -F "${setting}=" conf/neo4j.conf; then
+            # Remove any lines containing the setting already
+            sed --in-place "/${setting}=.*/d" conf/neo4j.conf
         fi
-    done
-
-    [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
-
-    exec bin/neo4j console
-elif [ "$1" == "dump-config" ]; then
-    if [ -d /conf ]; then
-        cp --recursive conf/* /conf
-    else
-        echo "You must provide a /conf volume"
-        exit 1
+        # Then always append setting to file
+        echo "${setting}=${value}" >> conf/neo4j.conf
     fi
+done
+
+[ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
+
+if [ "${cmd}" == "neo4j" ]; then
+    exec neo4j console
 else
     exec "$@"
 fi

--- a/src/3.4/docker-entrypoint.sh
+++ b/src/3.4/docker-entrypoint.sh
@@ -1,9 +1,20 @@
 #!/bin/bash -eu
 
-if [ "$1" == "neo4j" ]; then
-    if [ "$NEO4J_EDITION" == "enterprise" ]; then
-        if [ "${NEO4J_ACCEPT_LICENSE_AGREEMENT:=no}" != "yes" ]; then
-            echo "
+cmd="$1"
+
+if [ "${cmd}" == "dump-config" ]; then
+    if [ -d /conf ]; then
+        cp --recursive conf/* /conf
+        exit 0
+    else
+        echo "You must provide a /conf volume"
+        exit 1
+    fi
+fi
+
+if [ "$NEO4J_EDITION" == "enterprise" ]; then
+    if [ "${NEO4J_ACCEPT_LICENSE_AGREEMENT:=no}" != "yes" ]; then
+        echo "
 In order to use Neo4j Enterprise Edition you must accept the license agreement.
 
 (c) Network Engine for Objects in Lund AB.  2017.  All Rights Reserved.
@@ -22,94 +33,96 @@ To do this you can use the following docker argument:
 
         --env=NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
 "
-            exit 1
-        fi
+        exit 1
     fi
+fi
 
-    # Env variable naming convention:
-    # - prefix NEO4J_
-    # - double underscore char '__' instead of single underscore '_' char in the setting name
-    # - underscore char '_' instead of dot '.' char in the setting name
-    # Example:
-    # NEO4J_dbms_tx__log_rotation_retention__policy env variable to set
-    #       dbms.tx_log.rotation.retention_policy setting
+# Env variable naming convention:
+# - prefix NEO4J_
+# - double underscore char '__' instead of single underscore '_' char in the setting name
+# - underscore char '_' instead of dot '.' char in the setting name
+# Example:
+# NEO4J_dbms_tx__log_rotation_retention__policy env variable to set
+#       dbms.tx_log.rotation.retention_policy setting
 
-    # Backward compatibility - map old hardcoded env variables into new naming convention
-    NEO4J_dbms_tx__log_rotation_retention__policy=${NEO4J_dbms_txLog_rotation_retentionPolicy:-}
-    NEO4J_wrapper_java_additional=${NEO4J_UDC_SOURCE:-}
-    NEO4J_dbms_memory_heap_initial__size=${NEO4J_dbms_memory_heap_maxSize:-}
-    NEO4J_dbms_memory_heap_max__size=${NEO4J_dbms_memory_heap_maxSize:-}
-    NEO4J_dbms_unmanaged__extension__classes=${NEO4J_dbms_unmanagedExtensionClasses:-}
-    NEO4J_dbms_allow__format__migration=${NEO4J_dbms_allowFormatMigration:-}
-    NEO4J_dbms_connectors_default__advertised__address=${NEO4J_dbms_connectors_defaultAdvertisedAddress:-}
-    NEO4J_ha_server__id=${NEO4J_ha_serverId:-}
-    NEO4J_ha_initial__hosts=${NEO4J_ha_initialHosts:-}
-    NEO4J_causal__clustering_expected__core__cluster__size=${NEO4J_causalClustering_expectedCoreClusterSize:-}
-    NEO4J_causal__clustering_initial__discovery__members=${NEO4J_causalClustering_initialDiscoveryMembers:-}
-    NEO4J_causal__clustering_discovery__listen__address=${NEO4J_causalClustering_discoveryListenAddress:-}
-    NEO4J_causal__clustering_discovery__advertised__address=${NEO4J_causalClustering_discoveryAdvertisedAddress:-}
-    NEO4J_causal__clustering_transaction__listen__address=${NEO4J_causalClustering_transactionListenAddress:-}
-    NEO4J_causal__clustering_transaction__advertised__address=${NEO4J_causalClustering_transactionAdvertisedAddress:-}
-    NEO4J_causal__clustering_raft__listen__address=${NEO4J_causalClustering_raftListenAddress:-}
-    NEO4J_causal__clustering_raft__advertised__address=${NEO4J_causalClustering_raftAdvertisedAddress:-}
+# Backward compatibility - map old hardcoded env variables into new naming convention
+NEO4J_dbms_tx__log_rotation_retention__policy=${NEO4J_dbms_txLog_rotation_retentionPolicy:-}
+NEO4J_wrapper_java_additional=${NEO4J_UDC_SOURCE:-}
+NEO4J_dbms_memory_heap_initial__size=${NEO4J_dbms_memory_heap_maxSize:-}
+NEO4J_dbms_memory_heap_max__size=${NEO4J_dbms_memory_heap_maxSize:-}
+NEO4J_dbms_unmanaged__extension__classes=${NEO4J_dbms_unmanagedExtensionClasses:-}
+NEO4J_dbms_allow__format__migration=${NEO4J_dbms_allowFormatMigration:-}
+NEO4J_dbms_connectors_default__advertised__address=${NEO4J_dbms_connectors_defaultAdvertisedAddress:-}
+NEO4J_ha_server__id=${NEO4J_ha_serverId:-}
+NEO4J_ha_initial__hosts=${NEO4J_ha_initialHosts:-}
+NEO4J_causal__clustering_expected__core__cluster__size=${NEO4J_causalClustering_expectedCoreClusterSize:-}
+NEO4J_causal__clustering_initial__discovery__members=${NEO4J_causalClustering_initialDiscoveryMembers:-}
+NEO4J_causal__clustering_discovery__listen__address=${NEO4J_causalClustering_discoveryListenAddress:-}
+NEO4J_causal__clustering_discovery__advertised__address=${NEO4J_causalClustering_discoveryAdvertisedAddress:-}
+NEO4J_causal__clustering_transaction__listen__address=${NEO4J_causalClustering_transactionListenAddress:-}
+NEO4J_causal__clustering_transaction__advertised__address=${NEO4J_causalClustering_transactionAdvertisedAddress:-}
+NEO4J_causal__clustering_raft__listen__address=${NEO4J_causalClustering_raftListenAddress:-}
+NEO4J_causal__clustering_raft__advertised__address=${NEO4J_causalClustering_raftAdvertisedAddress:-}
 
-    # unset old hardcoded unsupported env variables
-    unset NEO4J_dbms_txLog_rotation_retentionPolicy NEO4J_UDC_SOURCE \
-        NEO4J_dbms_memory_heap_maxSize NEO4J_dbms_memory_heap_maxSize \
-        NEO4J_dbms_unmanagedExtensionClasses NEO4J_dbms_allowFormatMigration \
-        NEO4J_dbms_connectors_defaultAdvertisedAddress NEO4J_ha_serverId \
-        NEO4J_ha_initialHosts NEO4J_causalClustering_expectedCoreClusterSize \
-        NEO4J_causalClustering_initialDiscoveryMembers \
-        NEO4J_causalClustering_discoveryListenAddress \
-        NEO4J_causalClustering_discoveryAdvertisedAddress \
-        NEO4J_causalClustering_transactionListenAddress \
-        NEO4J_causalClustering_transactionAdvertisedAddress \
-        NEO4J_causalClustering_raftListenAddress \
-        NEO4J_causalClustering_raftAdvertisedAddress
+# unset old hardcoded unsupported env variables
+unset NEO4J_dbms_txLog_rotation_retentionPolicy NEO4J_UDC_SOURCE \
+    NEO4J_dbms_memory_heap_maxSize NEO4J_dbms_memory_heap_maxSize \
+    NEO4J_dbms_unmanagedExtensionClasses NEO4J_dbms_allowFormatMigration \
+    NEO4J_dbms_connectors_defaultAdvertisedAddress NEO4J_ha_serverId \
+    NEO4J_ha_initialHosts NEO4J_causalClustering_expectedCoreClusterSize \
+    NEO4J_causalClustering_initialDiscoveryMembers \
+    NEO4J_causalClustering_discoveryListenAddress \
+    NEO4J_causalClustering_discoveryAdvertisedAddress \
+    NEO4J_causalClustering_transactionListenAddress \
+    NEO4J_causalClustering_transactionAdvertisedAddress \
+    NEO4J_causalClustering_raftListenAddress \
+    NEO4J_causalClustering_raftAdvertisedAddress
 
-    # Custom settings for dockerized neo4j
-    : ${NEO4J_dbms_tx__log_rotation_retention__policy:=100M size}
-    : ${NEO4J_dbms_memory_pagecache_size:=512M}
-    : ${NEO4J_wrapper_java_additional:=-Dneo4j.ext.udc.source=docker}
-    : ${NEO4J_dbms_memory_heap_initial__size:=512M}
-    : ${NEO4J_dbms_memory_heap_max__size:=512M}
-    : ${NEO4J_dbms_connectors_default__listen__address:=0.0.0.0}
-    : ${NEO4J_dbms_connector_http_listen__address:=0.0.0.0:7474}
-    : ${NEO4J_dbms_connector_https_listen__address:=0.0.0.0:7473}
-    : ${NEO4J_dbms_connector_bolt_listen__address:=0.0.0.0:7687}
-    : ${NEO4J_ha_host_coordination:=$(hostname):5001}
-    : ${NEO4J_ha_host_data:=$(hostname):6001}
-    : ${NEO4J_causal__clustering_discovery__listen__address:=0.0.0.0:5000}
-    : ${NEO4J_causal__clustering_discovery__advertised__address:=$(hostname):5000}
-    : ${NEO4J_causal__clustering_transaction__listen__address:=0.0.0.0:6000}
-    : ${NEO4J_causal__clustering_transaction__advertised__address:=$(hostname):6000}
-    : ${NEO4J_causal__clustering_raft__listen__address:=0.0.0.0:7000}
-    : ${NEO4J_causal__clustering_raft__advertised__address:=$(hostname):7000}
+# Custom settings for dockerized neo4j
+: ${NEO4J_dbms_tx__log_rotation_retention__policy:=100M size}
+: ${NEO4J_dbms_memory_pagecache_size:=512M}
+: ${NEO4J_wrapper_java_additional:=-Dneo4j.ext.udc.source=docker}
+: ${NEO4J_dbms_memory_heap_initial__size:=512M}
+: ${NEO4J_dbms_memory_heap_max__size:=512M}
+: ${NEO4J_dbms_connectors_default__listen__address:=0.0.0.0}
+: ${NEO4J_dbms_connector_http_listen__address:=0.0.0.0:7474}
+: ${NEO4J_dbms_connector_https_listen__address:=0.0.0.0:7473}
+: ${NEO4J_dbms_connector_bolt_listen__address:=0.0.0.0:7687}
+: ${NEO4J_ha_host_coordination:=$(hostname):5001}
+: ${NEO4J_ha_host_data:=$(hostname):6001}
+: ${NEO4J_causal__clustering_discovery__listen__address:=0.0.0.0:5000}
+: ${NEO4J_causal__clustering_discovery__advertised__address:=$(hostname):5000}
+: ${NEO4J_causal__clustering_transaction__listen__address:=0.0.0.0:6000}
+: ${NEO4J_causal__clustering_transaction__advertised__address:=$(hostname):6000}
+: ${NEO4J_causal__clustering_raft__listen__address:=0.0.0.0:7000}
+: ${NEO4J_causal__clustering_raft__advertised__address:=$(hostname):7000}
 
-    if [ -d /conf ]; then
-        find /conf -type f -exec cp {} conf \;
-    fi
+if [ -d /conf ]; then
+    find /conf -type f -exec cp {} conf \;
+fi
 
-    if [ -d /ssl ]; then
-        NEO4J_dbms_directories_certificates="/ssl"
-    fi
+if [ -d /ssl ]; then
+    NEO4J_dbms_directories_certificates="/ssl"
+fi
 
-    if [ -d /plugins ]; then
-        NEO4J_dbms_directories_plugins="/plugins"
-    fi
+if [ -d /plugins ]; then
+    NEO4J_dbms_directories_plugins="/plugins"
+fi
 
-    if [ -d /logs ]; then
-        NEO4J_dbms_directories_logs="/logs"
-    fi
+if [ -d /logs ]; then
+    NEO4J_dbms_directories_logs="/logs"
+fi
 
-    if [ -d /import ]; then
-        NEO4J_dbms_directories_import="/import"
-    fi
+if [ -d /import ]; then
+    NEO4J_dbms_directories_import="/import"
+fi
 
-    if [ -d /metrics ]; then
-        NEO4J_dbms_directories_metrics="/metrics"
-    fi
+if [ -d /metrics ]; then
+    NEO4J_dbms_directories_metrics="/metrics"
+fi
 
+# set the neo4j initial password only if you run the database server
+if [ "${cmd}" == "neo4j" ] ; then
     if [ "${NEO4J_AUTH:-}" == "none" ]; then
         NEO4J_dbms_security_auth__enabled=false
     elif [[ "${NEO4J_AUTH:-}" == neo4j/* ]]; then
@@ -124,32 +137,27 @@ To do this you can use the following docker argument:
         echo "Invalid value for NEO4J_AUTH: '${NEO4J_AUTH}'"
         exit 1
     fi
+fi
 
-    # list env variables with prefix NEO4J_ and create settings from them
-    unset NEO4J_AUTH NEO4J_SHA256 NEO4J_TARBALL
-    for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
-        setting=$(echo ${i} | sed 's|^NEO4J_||' | sed 's|_|.|g' | sed 's|\.\.|_|g')
-        value=$(echo ${!i})
-        if [[ -n ${value} ]]; then
-            if grep -q -F "${setting}=" conf/neo4j.conf; then
-                # Remove any lines containing the setting already
-                sed --in-place "/${setting}=.*/d" conf/neo4j.conf
-            fi
-            # Then always append setting to file
-            echo "${setting}=${value}" >> conf/neo4j.conf
+# list env variables with prefix NEO4J_ and create settings from them
+unset NEO4J_AUTH NEO4J_SHA256 NEO4J_TARBALL
+for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
+    setting=$(echo ${i} | sed 's|^NEO4J_||' | sed 's|_|.|g' | sed 's|\.\.|_|g')
+    value=$(echo ${!i})
+    if [[ -n ${value} ]]; then
+        if grep -q -F "${setting}=" conf/neo4j.conf; then
+            # Remove any lines containing the setting already
+            sed --in-place "/${setting}=.*/d" conf/neo4j.conf
         fi
-    done
-
-    [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
-
-    exec bin/neo4j console
-elif [ "$1" == "dump-config" ]; then
-    if [ -d /conf ]; then
-        cp --recursive conf/* /conf
-    else
-        echo "You must provide a /conf volume"
-        exit 1
+        # Then always append setting to file
+        echo "${setting}=${value}" >> conf/neo4j.conf
     fi
+done
+
+[ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
+
+if [ "${cmd}" == "neo4j" ] ; then
+    exec neo4j console
 else
     exec "$@"
 fi

--- a/src/3.4/docker-entrypoint.sh
+++ b/src/3.4/docker-entrypoint.sh
@@ -45,24 +45,25 @@ fi
 # NEO4J_dbms_tx__log_rotation_retention__policy env variable to set
 #       dbms.tx_log.rotation.retention_policy setting
 
-# Backward compatibility - map old hardcoded env variables into new naming convention
-NEO4J_dbms_tx__log_rotation_retention__policy=${NEO4J_dbms_txLog_rotation_retentionPolicy:-}
-NEO4J_wrapper_java_additional=${NEO4J_UDC_SOURCE:-}
-NEO4J_dbms_memory_heap_initial__size=${NEO4J_dbms_memory_heap_maxSize:-}
-NEO4J_dbms_memory_heap_max__size=${NEO4J_dbms_memory_heap_maxSize:-}
-NEO4J_dbms_unmanaged__extension__classes=${NEO4J_dbms_unmanagedExtensionClasses:-}
-NEO4J_dbms_allow__format__migration=${NEO4J_dbms_allowFormatMigration:-}
-NEO4J_dbms_connectors_default__advertised__address=${NEO4J_dbms_connectors_defaultAdvertisedAddress:-}
-NEO4J_ha_server__id=${NEO4J_ha_serverId:-}
-NEO4J_ha_initial__hosts=${NEO4J_ha_initialHosts:-}
-NEO4J_causal__clustering_expected__core__cluster__size=${NEO4J_causalClustering_expectedCoreClusterSize:-}
-NEO4J_causal__clustering_initial__discovery__members=${NEO4J_causalClustering_initialDiscoveryMembers:-}
-NEO4J_causal__clustering_discovery__listen__address=${NEO4J_causalClustering_discoveryListenAddress:-}
-NEO4J_causal__clustering_discovery__advertised__address=${NEO4J_causalClustering_discoveryAdvertisedAddress:-}
-NEO4J_causal__clustering_transaction__listen__address=${NEO4J_causalClustering_transactionListenAddress:-}
-NEO4J_causal__clustering_transaction__advertised__address=${NEO4J_causalClustering_transactionAdvertisedAddress:-}
-NEO4J_causal__clustering_raft__listen__address=${NEO4J_causalClustering_raftListenAddress:-}
-NEO4J_causal__clustering_raft__advertised__address=${NEO4J_causalClustering_raftAdvertisedAddress:-}
+# Backward compatibility - map old hardcoded env variables into new naming convention (if they aren't set already)
+# Set some to default values if unset
+: ${NEO4J_dbms_tx__log_rotation_retention__policy:=${NEO4J_dbms_txLog_rotation_retentionPolicy:-"100M size"}}
+: ${NEO4J_wrapper_java_additional:=${NEO4J_UDC_SOURCE:-"-Dneo4j.ext.udc.source=docker"}}
+: ${NEO4J_dbms_memory_heap_initial__size:=${NEO4J_dbms_memory_heap_maxSize:-"512M"}}
+: ${NEO4J_dbms_memory_heap_max__size:=${NEO4J_dbms_memory_heap_maxSize:-"512M"}}
+: ${NEO4J_dbms_unmanaged__extension__classes:=${NEO4J_dbms_unmanagedExtensionClasses:-}}
+: ${NEO4J_dbms_allow__format__migration:=${NEO4J_dbms_allowFormatMigration:-}}
+: ${NEO4J_dbms_connectors_default__advertised__address:=${NEO4J_dbms_connectors_defaultAdvertisedAddress:-}}
+: ${NEO4J_ha_server__id:=${NEO4J_ha_serverId:-}}
+: ${NEO4J_ha_initial__hosts:=${NEO4J_ha_initialHosts:-}}
+: ${NEO4J_causal__clustering_expected__core__cluster__size:=${NEO4J_causalClustering_expectedCoreClusterSize:-}}
+: ${NEO4J_causal__clustering_initial__discovery__members:=${NEO4J_causalClustering_initialDiscoveryMembers:-}}
+: ${NEO4J_causal__clustering_discovery__listen__address:=${NEO4J_causalClustering_discoveryListenAddress:-"0.0.0.0:5000"}}
+: ${NEO4J_causal__clustering_discovery__advertised__address:=${NEO4J_causalClustering_discoveryAdvertisedAddress:-"$(hostname):5000"}}
+: ${NEO4J_causal__clustering_transaction__listen__address:=${NEO4J_causalClustering_transactionListenAddress:-"0.0.0.0:6000"}}
+: ${NEO4J_causal__clustering_transaction__advertised__address:=${NEO4J_causalClustering_transactionAdvertisedAddress:-"$(hostname):6000"}}
+: ${NEO4J_causal__clustering_raft__listen__address:=${NEO4J_causalClustering_raftListenAddress:-"0.0.0.0:7000"}}
+: ${NEO4J_causal__clustering_raft__advertised__address:=${NEO4J_causalClustering_raftAdvertisedAddress:-"$(hostname):7000"}}
 
 # unset old hardcoded unsupported env variables
 unset NEO4J_dbms_txLog_rotation_retentionPolicy NEO4J_UDC_SOURCE \

--- a/test/test-neo4j-admin-conf-override
+++ b/test/test-neo4j-admin-conf-override
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset
+
+readonly image="$1"
+readonly series="$2"
+
+assert_property_overridden() {
+    local path="$1"
+    local property="$2"
+    if [[ -z "$(cat "${path}/neo4j.conf" | grep "${property}")" ]] ; then
+        exit 1
+    fi
+}
+
+# there is no neo4j-admin for 2.3
+if [[ "${series}" == "2.3" ]]; then
+   exit 0;
+fi
+
+. "$(dirname "$0")/helpers.sh"
+readonly cname="neo4j-$(uuidgen)"
+
+readonly dir=$(mktemp --directory)
+touch "${dir}/neo4j.conf"
+
+docker run --rm --volume="${dir}:/var/lib/neo4j/conf" \
+                --env=NEO4J_ACCEPT_LICENSE_AGREEMENT=yes \
+                --env=NEO4J_dbms_memory_pagecache_size=1000m \
+                --env=NEO4J_dbms_memory_heap_initial__size=2000m \
+                --env=NEO4J_dbms_memory_heap_max__size=3000m \
+                "${image}" neo4j-admin help >/dev/null
+
+assert_property_overridden "${dir}" "dbms.memory.pagecache.size=1000m"
+assert_property_overridden "${dir}" "dbms.memory.heap.initial_size=2000m"
+assert_property_overridden "${dir}" "dbms.memory.heap.max_size=3000m"

--- a/test/test-neo4j-admin-conf-override
+++ b/test/test-neo4j-admin-conf-override
@@ -30,6 +30,8 @@ docker run --rm --volume="${dir}:/var/lib/neo4j/conf" \
                 --env=NEO4J_dbms_memory_heap_max__size=3000m \
                 "${image}" neo4j-admin help >/dev/null
 
+cat "${dir}/neo4j.conf"
+
 assert_property_overridden "${dir}" "dbms.memory.pagecache.size=1000m"
 assert_property_overridden "${dir}" "dbms.memory.heap.initial_size=2000m"
 assert_property_overridden "${dir}" "dbms.memory.heap.max_size=3000m"

--- a/test/test-path
+++ b/test/test-path
@@ -15,7 +15,8 @@ else
   cypher_shell_cmd='cypher-shell'
 fi
 
-readonly result="$(docker run --name "${cname}"  "${image}" which ${cypher_shell_cmd})"
+readonly result="$(docker run --env=NEO4J_ACCEPT_LICENSE_AGREEMENT=yes \
+    --name "${cname}"  "${image}" which ${cypher_shell_cmd})"
 
 if [[ "${result}" == "/var/lib/neo4j/bin/${cypher_shell_cmd}" ]]; then
   echo "${cypher_shell_cmd} (and by implication all neo4j/bin) on path."


### PR DESCRIPTION
The main use case here is that neo4j-admin needs a neo4j configuration
to work properly, e.g., when you execute backup/restore/dump.  This
changes will enable to setup a conf with overrides while executing
neo4j-admin or other neo4j related commands.