### PR TITLE
Avoid running neo4j specific code when running generic commands

### DIFF
--- a/src/3.1/docker-entrypoint.sh
+++ b/src/3.1/docker-entrypoint.sh
@@ -2,14 +2,20 @@
 
 cmd="$1"
 
-if [ "${cmd}" == "dump-config" ]; then
-    if [ -d /conf ]; then
-        cp --recursive conf/* /conf
-        exit 0
-    else
-        echo "You must provide a /conf volume"
-        exit 1
+if [[ "${cmd}" != *"neo4j"* ]]; then
+    [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
+
+    if [ "${cmd}" == "dump-config" ]; then
+        if [ -d /conf ]; then
+            cp --recursive conf/* /conf
+            exit 0
+        else
+            echo "You must provide a /conf volume"
+            exit 1
+        fi
     fi
+    exec "$@"
+    exit $?
 fi
 
 # Env variable naming convention:

--- a/src/3.2/docker-entrypoint.sh
+++ b/src/3.2/docker-entrypoint.sh
@@ -2,14 +2,20 @@
 
 cmd="$1"
 
-if [ "${cmd}" == "dump-config" ]; then
-    if [ -d /conf ]; then
-        cp --recursive conf/* /conf
-        exit 0
-    else
-        echo "You must provide a /conf volume"
-        exit 1
+if [[ "${cmd}" != *"neo4j"* ]]; then
+    [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
+
+    if [ "${cmd}" == "dump-config" ]; then
+        if [ -d /conf ]; then
+            cp --recursive conf/* /conf
+            exit 0
+        else
+            echo "You must provide a /conf volume"
+            exit 1
+        fi
     fi
+    exec "$@"
+    exit $?
 fi
 
 # Env variable naming convention:

--- a/src/3.3/docker-entrypoint.sh
+++ b/src/3.3/docker-entrypoint.sh
@@ -2,14 +2,20 @@
 
 cmd="$1"
 
-if [ "${cmd}" == "dump-config" ]; then
-    if [ -d /conf ]; then
-        cp --recursive conf/* /conf
-        exit 0
-    else
-        echo "You must provide a /conf volume"
-        exit 1
+if [[ "${cmd}" != *"neo4j"* ]]; then
+    [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
+
+    if [ "${cmd}" == "dump-config" ]; then
+        if [ -d /conf ]; then
+            cp --recursive conf/* /conf
+            exit 0
+        else
+            echo "You must provide a /conf volume"
+            exit 1
+        fi
     fi
+    exec "$@"
+    exit $?
 fi
 
 if [ "$NEO4J_EDITION" == "enterprise" ]; then

--- a/src/3.4/docker-entrypoint.sh
+++ b/src/3.4/docker-entrypoint.sh
@@ -2,14 +2,20 @@
 
 cmd="$1"
 
-if [ "${cmd}" == "dump-config" ]; then
-    if [ -d /conf ]; then
-        cp --recursive conf/* /conf
-        exit 0
-    else
-        echo "You must provide a /conf volume"
-        exit 1
+if [[ "${cmd}" != *"neo4j"* ]]; then
+    [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
+
+    if [ "${cmd}" == "dump-config" ]; then
+        if [ -d /conf ]; then
+            cp --recursive conf/* /conf
+            exit 0
+        else
+            echo "You must provide a /conf volume"
+            exit 1
+        fi
     fi
+    exec "$@"
+    exit $?
 fi
 
 if [ "$NEO4J_EDITION" == "enterprise" ]; then

--- a/test/test-neo4j-admin-conf-override
+++ b/test/test-neo4j-admin-conf-override
@@ -14,6 +14,7 @@ assert_property_overridden() {
 
 # there is no neo4j-admin for 2.3
 if [[ "${series}" == "2.3" ]]; then
+   echo "No neo4j-admin in 2.3: skipping neo4j-admin-conf-override test"
    exit 0;
 fi
 

--- a/test/test-path
+++ b/test/test-path
@@ -15,8 +15,7 @@ else
   cypher_shell_cmd='cypher-shell'
 fi
 
-readonly result="$(docker run --env=NEO4J_ACCEPT_LICENSE_AGREEMENT=yes \
-    --name "${cname}"  "${image}" which ${cypher_shell_cmd})"
+readonly result="$(docker run --name "${cname}"  "${image}" which ${cypher_shell_cmd})"
 
 if [[ "${result}" == "/var/lib/neo4j/bin/${cypher_shell_cmd}" ]]; then
   echo "${cypher_shell_cmd} (and by implication all neo4j/bin) on path."


### PR DESCRIPTION
In particular this makes sure we do not prompt for neo4j commercial
license when running commands not related to neo4j.