### PR TITLE
Dev jgrobbel docker on mac

### DIFF
--- a/devenv
+++ b/devenv
@@ -2,6 +2,51 @@
 
 PATH="./build:${PATH}"
 
+# MacOS specific checks
+if [ "$(uname)" == "Darwin" ] ; then
+
+  echo "Setting PATH with MacOS specific locations"
+  export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
+  export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
+  export PATH="/usr/local/opt/make/libexec/gnubin:$PATH"
+
+  if ! grep --version 2>/dev/null | grep -q "GNU grep" ; then
+    cat >&2 <<EOF
+== GNU grep is required. Fix with ==
+
+  brew install grep --with-default-names
+
+EOF
+  fi
+
+  if ! sed --version 2>/dev/null | grep -q "GNU sed" ; then
+    cat >&2 <<EOF
+== GNU sed is required. Fix with ==
+
+  brew install gnu-sed
+
+EOF
+  fi
+
+  if ! readlink --version 2>/dev/null | grep -q "GNU coreutils" ; then
+    cat >&2 <<EOF
+== GNU coreutils is required. Fix with ==
+
+  brew install coreutils  --with-default-names
+
+EOF
+  fi
+
+  # have to use || here because BSD find doesnt even support --version (it errors)
+  # shellcheck disable=SC2185
+  find --version 1>/dev/null 2>/dev/null || cat >&2 <<EOF
+== GNU findutils is required. Fix with ==
+
+    brew install findutils  --with-default-names
+
+EOF
+fi # MacOS specific checks
+
 if ! which make >/dev/null; then
     if which apt-get >/dev/null; then
         sudo apt-get install make

--- a/test/causal-cluster-compose.yml
+++ b/test/causal-cluster-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 
 networks:
   lan:
@@ -12,6 +12,8 @@ services:
       - lan
     environment:
       - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
+      - NEO4J_dbms_memory_pagecache_size=10M
+      - NEO4J_dbms_memory_heap_initial__size=10M
       - NEO4J_AUTH=none
       - NEO4J_dbms_mode=CORE
       - NEO4J_causalClustering_expectedCoreClusterSize=3
@@ -23,6 +25,8 @@ services:
       - lan
     environment:
       - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
+      - NEO4J_dbms_memory_pagecache_size=10M
+      - NEO4J_dbms_memory_heap_initial__size=10M
       - NEO4J_AUTH=neo4j/neo
       - NEO4J_dbms_mode=CORE
       - NEO4J_causalClustering_expectedCoreClusterSize=3
@@ -34,6 +38,8 @@ services:
       - lan
     environment:
       - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
+      - NEO4J_dbms_memory_pagecache_size=10M
+      - NEO4J_dbms_memory_heap_initial__size=10M
       - NEO4J_AUTH=neo4j/neo
       - NEO4J_dbms_mode=CORE
       - NEO4J_causalClustering_discoveryAdvertisedAddress=core3:5000
@@ -49,6 +55,8 @@ services:
       - lan
     environment:
       - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
+      - NEO4J_dbms_memory_pagecache_size=10M
+      - NEO4J_dbms_memory_heap_initial__size=10M
       - NEO4J_AUTH=neo4j/neo
       - NEO4J_dbms_mode=READ_REPLICA
       - NEO4J_causalClustering_initialDiscoveryMembers=core1:5000,core2:5000,core3:5000

--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine
+
+RUN apk update && apk add --no-cache curl bash util-linux grep
+
+CMD ["bash", "-c", "while true; do sleep 120; done"]

--- a/test/ha-cluster-compose.yml
+++ b/test/ha-cluster-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 
 networks:
   lan:
@@ -12,6 +12,8 @@ services:
       - lan
     environment:
       - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
+      - NEO4J_dbms_memory_pagecache_size=10M
+      - NEO4J_dbms_memory_heap_initial__size=10M
       - NEO4J_AUTH=neo4j/neo
       - NEO4J_ha_serverId=1
       - NEO4J_dbms_mode=HA
@@ -26,6 +28,8 @@ services:
       - lan
     environment:
       - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
+      - NEO4J_dbms_memory_pagecache_size=10M
+      - NEO4J_dbms_memory_heap_initial__size=10M
       - NEO4J_AUTH=neo4j/neo
       - NEO4J_dbms_mode=HA
       - NEO4J_ha_serverId=2
@@ -42,6 +46,8 @@ services:
       - lan
     environment:
       - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
+      - NEO4J_dbms_memory_pagecache_size=10M
+      - NEO4J_dbms_memory_heap_initial__size=10M
       - NEO4J_AUTH=neo4j/neo
       - NEO4J_dbms_mode=HA
       - NEO4J_ha_serverId=3

--- a/test/test-dumps-config
+++ b/test/test-dumps-config
@@ -7,7 +7,7 @@ readonly image="$1"
 readonly series="$2"
 readonly cname="neo4j-$(uuidgen)"
 
-# Docker for mac doesn't allow access from /var/
+# mktemp on OSX by default uses /var/folders/ which is not available to docker
 readonly dir=$(mktemp --directory --tmpdir=/tmp/)
 
 docker run --rm --volume="${dir}:/conf" "${image}" dump-config

--- a/test/test-dumps-config
+++ b/test/test-dumps-config
@@ -7,7 +7,8 @@ readonly image="$1"
 readonly series="$2"
 readonly cname="neo4j-$(uuidgen)"
 
-readonly dir=$(mktemp --directory)
+# Docker for mac doesn't allow access from /var/
+readonly dir=$(mktemp --directory --tmpdir=/tmp/)
 
 docker run --rm --volume="${dir}:/conf" "${image}" dump-config
 

--- a/test/test-ha-clustering-basic
+++ b/test/test-ha-clustering-basic
@@ -28,6 +28,11 @@ readonly compose_file=$(mktemp tmp/out/XXXXXXXX.yml)
 
 cp "$(dirname "$0")/ha-cluster-compose.yml" "${compose_file}"
 
+if [[ "${series}" == "3.0" ]]; then
+  # Neo4j 3.0 series does not support [MG] type values for memory_heap_initial
+  sed --in-place -e "s/NEO4J_dbms_memory_heap_initial__size=10M/NEO4J_dbms_memory_heap_initial__size=10/g" "${compose_file}"
+fi
+
 readonly cname="core-$(uuidgen)"
 readonly rname="slave-$(uuidgen)"
 

--- a/test/test-neo4j-admin-conf-override
+++ b/test/test-neo4j-admin-conf-override
@@ -21,7 +21,7 @@ fi
 . "$(dirname "$0")/helpers.sh"
 readonly cname="neo4j-$(uuidgen)"
 
-# Docker for mac doesn't allow access from /var/
+# mktemp on OSX by default uses /var/folders/ which is not available to docker
 readonly dir=$(mktemp --directory --tmpdir=/tmp/)
 touch "${dir}/neo4j.conf"
 

--- a/test/test-neo4j-admin-conf-override
+++ b/test/test-neo4j-admin-conf-override
@@ -21,7 +21,8 @@ fi
 . "$(dirname "$0")/helpers.sh"
 readonly cname="neo4j-$(uuidgen)"
 
-readonly dir=$(mktemp --directory)
+# Docker for mac doesn't allow access from /var/
+readonly dir=$(mktemp --directory --tmpdir=/tmp/)
 touch "${dir}/neo4j.conf"
 
 docker run --rm --volume="${dir}:/var/lib/neo4j/conf" \


### PR DESCRIPTION
This PR allows make to complete successfully on a mac.
The key fixes are:
1. Reducing the memory footprint of the containers.
2. Use /tmp for mktemp files as /var is not available to docker
3. Use a jump host network container to give access to the docker0 bridge.