### PR TITLE
Run Neo4j as non-root 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ tmp/.tests-pass-%: tmp/.image-id-% $(shell find test -name 'test-*') $(shell fin
 > mkdir -p $(@D)
 > image_id=$$(cat $<)
 > for test in $(filter test/test-%,$^); do
->   echo "Running $${test}"
+>   echo "Running $${test} with ${series} $*"
 >   "$${test}" "$${image_id}" "${series}" "$*"
 > done
 > touch $@

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ tarball = neo4j-$(1)-$(2)-unix.tar.gz
 dist_site := http://dist.neo4j.org
 series := $(shell echo "$(NEO4J_VERSION)" | sed -E 's/^([0-9]+\.[0-9]+)\..*/\1/')
 
-all: out/enterprise/.sentinel out/community/.sentinel
+all: out/community/.sentinel out/enterprise/.sentinel
 .PHONY: all
 
 test: test-community test-enterprise

--- a/src/2.3/docker-entrypoint.sh
+++ b/src/2.3/docker-entrypoint.sh
@@ -78,7 +78,7 @@ elif [ "$1" == "dump-config" ]; then
     if [ -d /conf ]; then
         cp --recursive conf/* /conf
     else
-        echo "You must provide a /conf volume"
+        echo >&2 "You must provide a /conf volume"
         exit 1
     fi
 else

--- a/src/3.0/docker-entrypoint.sh
+++ b/src/3.0/docker-entrypoint.sh
@@ -27,7 +27,7 @@ if [ "${cmd}" == "dump-config" ]; then
         cp --recursive conf/* /conf
         exit 0
     else
-        echo "You must provide a /conf volume"
+        echo >&2 "You must provide a /conf volume"
         exit 1
     fi
 fi

--- a/src/3.1/Dockerfile
+++ b/src/3.1/Dockerfile
@@ -2,7 +2,8 @@ FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache --quiet \
     bash \
-    curl
+    curl \
+    su-exec
 
 ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%%
@@ -14,14 +15,16 @@ RUN curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && echo "${NEO4J_SHA256}  ${NEO4J_TARBALL}" | sha256sum -csw - \
     && tar --extract --file ${NEO4J_TARBALL} --directory /var/lib \
     && mv /var/lib/neo4j-* /var/lib/neo4j \
-    && rm ${NEO4J_TARBALL}
+    && rm ${NEO4J_TARBALL} \
+    && mv /var/lib/neo4j/data /data \
+    && chown -R root:root /data \
+    && chown -R root:root /var/lib/neo4j \
+    && ln -s /data /var/lib/neo4j/data \
+    && apk del curl
 
 ENV PATH /var/lib/neo4j/bin:$PATH
 
 WORKDIR /var/lib/neo4j
-
-RUN mv data /data \
-    && ln -s /data
 
 VOLUME /data
 

--- a/src/3.1/docker-entrypoint.sh
+++ b/src/3.1/docker-entrypoint.sh
@@ -3,19 +3,15 @@
 cmd="$1"
 
 if [[ "${cmd}" != *"neo4j"* ]]; then
-    [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
-
-    if [ "${cmd}" == "dump-config" ]; then
-        if [ -d /conf ]; then
-            cp --recursive conf/* /conf
-            exit 0
-        else
-            echo "You must provide a /conf volume"
-            exit 1
-        fi
+  if [ "${cmd}" == "dump-config" ]; then
+    if [ -d /conf ]; then
+      cp --recursive conf/* /conf
+      exit 0
+    else
+      echo >&2 "You must provide a /conf volume"
+      exit 1
     fi
-    exec "$@"
-    exit $?
+  fi
 fi
 
 # Env variable naming convention:

--- a/src/3.1/docker-entrypoint.sh
+++ b/src/3.1/docker-entrypoint.sh
@@ -2,10 +2,59 @@
 
 cmd="$1"
 
+# We intentionally chown /data to root in Dockerfile so we can detect
+# if no volume is mounted
+if [[ "$(stat -c %u /data)" != "0" ]]; then
+  # /data is a volume, is the same uid/gid for neo4j user
+  user_uid="$(stat -c %u /data)"
+  user_gid="$(stat -c %g /data)"
+elif [ -d /conf ] && [[ "${cmd}" == "dump-config" ]]; then
+  # A configuration volume has been mounted and we are dumping config
+  user_uid="$(stat -c %u /conf)"
+  user_gid="$(stat -c %g /conf)"
+else
+  # Set to zero (root) to signal no mounting has been done
+  user_uid="0"
+  user_gid="0"
+fi
+
+# Only add group if it does not already exist
+if ! getent group neo4j >/dev/null && [[ "${user_gid}" = 0 ]]; then
+  addgroup -S neo4j
+elif ! getent group neo4j >/dev/null; then
+  addgroup -S -g "${user_gid}" neo4j
+fi
+
+# Only add user if it does not already exist
+if ! getent passwd neo4j >/dev/null && [[ "${user_uid}" = 0 ]]; then
+  adduser -S -H -h /var/lib/neo4j -G neo4j neo4j
+elif ! getent passwd neo4j >/dev/null; then
+  adduser -S -u "${user_uid}" -H -h /var/lib/neo4j -G neo4j neo4j
+fi
+
+# Need to chown the home directory - but a user might have mounted a
+# volume here. So take care not to chown volumes (stuff not owned by
+# root due to our intentional chowning to root in the Dockerfile)
+if [[ "$(stat -c %u /var/lib/neo4j)" = "0" ]]; then
+  # Non-recursive chown for the base directory
+  chown neo4j:neo4j /var/lib/neo4j
+fi
+
+while IFS= read -r -d '' dir
+do
+  if [[ "$(stat -c %u "${dir}")" = "0" ]]; then
+    # Using mindepth 1 to avoid the base directory here so recursive is OK
+    chown -R neo4j:neo4j "${dir}"
+  fi
+done <   <(find /var/lib/neo4j -type d -mindepth 1 -maxdepth 1 -print0)
+
+# Data dir is chowned later
+
 if [[ "${cmd}" != *"neo4j"* ]]; then
   if [ "${cmd}" == "dump-config" ]; then
     if [ -d /conf ]; then
-      cp --recursive conf/* /conf
+      # Run with neo4j user so we write files with correct permissions
+      su-exec neo4j cp --recursive conf/* /conf
       exit 0
     else
       echo >&2 "You must provide a /conf volume"
@@ -94,13 +143,13 @@ if [ "${cmd}" == "neo4j" ] ; then
     elif [[ "${NEO4J_AUTH:-}" == neo4j/* ]]; then
         password="${NEO4J_AUTH#neo4j/}"
         if [ "${password}" == "neo4j" ]; then
-            echo "Invalid value for password. It cannot be 'neo4j', which is the default."
+            echo >&2 "Invalid value for password. It cannot be 'neo4j', which is the default."
             exit 1
         fi
         # Will exit with error if users already exist (and print a message explaining that)
         bin/neo4j-admin set-initial-password "${password}" || true
     elif [ -n "${NEO4J_AUTH:-}" ]; then
-        echo "Invalid value for NEO4J_AUTH: '${NEO4J_AUTH}'"
+        echo >&2 "Invalid value for NEO4J_AUTH: '${NEO4J_AUTH}'"
         exit 1
     fi
 fi
@@ -120,10 +169,17 @@ for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
     fi
 done
 
+# Chown the data dir now that (maybe) an initial password has been
+# set (this is a file in the data dir)
+if [[ "$(stat -c %u /data)" = "0" ]]; then
+  chown -R neo4j:neo4j /data
+fi
+
 [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
 
-if [ "${cmd}" == "neo4j" ] ; then
-    exec neo4j console
+# Use su-exec to drop privileges to neo4j user
+if [ "${cmd}" == "neo4j" ]; then
+    su-exec neo4j neo4j console
 else
-    exec "$@"
+    su-exec neo4j "$@"
 fi

--- a/src/3.2/Dockerfile
+++ b/src/3.2/Dockerfile
@@ -2,7 +2,8 @@ FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache --quiet \
     bash \
-    curl
+    curl \
+    su-exec
 
 ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%%
@@ -16,6 +17,8 @@ RUN curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && mv /var/lib/neo4j-* /var/lib/neo4j \
     && rm ${NEO4J_TARBALL} \
     && mv /var/lib/neo4j/data /data \
+    && chown -R root:root /data \
+    && chown -R root:root /var/lib/neo4j \
     && ln -s /data /var/lib/neo4j/data \
     && apk del curl
 

--- a/src/3.2/docker-entrypoint.sh
+++ b/src/3.2/docker-entrypoint.sh
@@ -3,19 +3,15 @@
 cmd="$1"
 
 if [[ "${cmd}" != *"neo4j"* ]]; then
-    [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
-
-    if [ "${cmd}" == "dump-config" ]; then
-        if [ -d /conf ]; then
-            cp --recursive conf/* /conf
-            exit 0
-        else
-            echo "You must provide a /conf volume"
-            exit 1
-        fi
+  if [ "${cmd}" == "dump-config" ]; then
+    if [ -d /conf ]; then
+      cp --recursive conf/* /conf
+      exit 0
+    else
+      echo >&2 "You must provide a /conf volume"
+      exit 1
     fi
-    exec "$@"
-    exit $?
+  fi
 fi
 
 # Env variable naming convention:

--- a/src/3.2/docker-entrypoint.sh
+++ b/src/3.2/docker-entrypoint.sh
@@ -2,10 +2,59 @@
 
 cmd="$1"
 
+# We intentionally chown /data to root in Dockerfile so we can detect
+# if no volume is mounted
+if [[ "$(stat -c %u /data)" != "0" ]]; then
+  # /data is a volume, is the same uid/gid for neo4j user
+  user_uid="$(stat -c %u /data)"
+  user_gid="$(stat -c %g /data)"
+elif [ -d /conf ] && [[ "${cmd}" == "dump-config" ]]; then
+  # A configuration volume has been mounted and we are dumping config
+  user_uid="$(stat -c %u /conf)"
+  user_gid="$(stat -c %g /conf)"
+else
+  # Set to zero (root) to signal no mounting has been done
+  user_uid="0"
+  user_gid="0"
+fi
+
+# Only add group if it does not already exist
+if ! getent group neo4j >/dev/null && [[ "${user_gid}" = 0 ]]; then
+  addgroup -S neo4j
+elif ! getent group neo4j >/dev/null; then
+  addgroup -S -g "${user_gid}" neo4j
+fi
+
+# Only add user if it does not already exist
+if ! getent passwd neo4j >/dev/null && [[ "${user_uid}" = 0 ]]; then
+  adduser -S -H -h /var/lib/neo4j -G neo4j neo4j
+elif ! getent passwd neo4j >/dev/null; then
+  adduser -S -u "${user_uid}" -H -h /var/lib/neo4j -G neo4j neo4j
+fi
+
+# Need to chown the home directory - but a user might have mounted a
+# volume here. So take care not to chown volumes (stuff not owned by
+# root due to our intentional chowning to root in the Dockerfile)
+if [[ "$(stat -c %u /var/lib/neo4j)" = "0" ]]; then
+  # Non-recursive chown for the base directory
+  chown neo4j:neo4j /var/lib/neo4j
+fi
+
+while IFS= read -r -d '' dir
+do
+  if [[ "$(stat -c %u "${dir}")" = "0" ]]; then
+    # Using mindepth 1 to avoid the base directory here so recursive is OK
+    chown -R neo4j:neo4j "${dir}"
+  fi
+done <   <(find /var/lib/neo4j -type d -mindepth 1 -maxdepth 1 -print0)
+
+# Data dir is chowned later
+
 if [[ "${cmd}" != *"neo4j"* ]]; then
   if [ "${cmd}" == "dump-config" ]; then
     if [ -d /conf ]; then
-      cp --recursive conf/* /conf
+      # Run with neo4j user so we write files with correct permissions
+      su-exec neo4j cp --recursive conf/* /conf
       exit 0
     else
       echo >&2 "You must provide a /conf volume"
@@ -94,13 +143,13 @@ if [ "${cmd}" == "neo4j" ] ; then
     elif [[ "${NEO4J_AUTH:-}" == neo4j/* ]]; then
         password="${NEO4J_AUTH#neo4j/}"
         if [ "${password}" == "neo4j" ]; then
-            echo "Invalid value for password. It cannot be 'neo4j', which is the default."
+            echo >&2 "Invalid value for password. It cannot be 'neo4j', which is the default."
             exit 1
         fi
         # Will exit with error if users already exist (and print a message explaining that)
         bin/neo4j-admin set-initial-password "${password}" || true
     elif [ -n "${NEO4J_AUTH:-}" ]; then
-        echo "Invalid value for NEO4J_AUTH: '${NEO4J_AUTH}'"
+        echo >&2 "Invalid value for NEO4J_AUTH: '${NEO4J_AUTH}'"
         exit 1
     fi
 fi
@@ -120,10 +169,17 @@ for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
     fi
 done
 
+# Chown the data dir now that (maybe) an initial password has been
+# set (this is a file in the data dir)
+if [[ "$(stat -c %u /data)" = "0" ]]; then
+  chown -R neo4j:neo4j /data
+fi
+
 [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
 
-if [ "${cmd}" == "neo4j" ] ; then
-    exec neo4j console
+# Use su-exec to drop privileges to neo4j user
+if [ "${cmd}" == "neo4j" ]; then
+    su-exec neo4j neo4j console
 else
-    exec "$@"
+    su-exec neo4j "$@"
 fi

--- a/src/3.3/Dockerfile
+++ b/src/3.3/Dockerfile
@@ -2,7 +2,8 @@ FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache --quiet \
     bash \
-    curl
+    curl \
+    su-exec
 
 ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \
@@ -17,6 +18,8 @@ RUN curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && mv /var/lib/neo4j-* /var/lib/neo4j \
     && rm ${NEO4J_TARBALL} \
     && mv /var/lib/neo4j/data /data \
+    && chown -R root:root /data \
+    && chown -R root:root /var/lib/neo4j \
     && ln -s /data /var/lib/neo4j/data \
     && apk del curl
 

--- a/src/3.3/docker-entrypoint.sh
+++ b/src/3.3/docker-entrypoint.sh
@@ -2,10 +2,59 @@
 
 cmd="$1"
 
+# We intentionally chown /data to root in Dockerfile so we can detect
+# if no volume is mounted
+if [[ "$(stat -c %u /data)" != "0" ]]; then
+  # /data is a volume, is the same uid/gid for neo4j user
+  user_uid="$(stat -c %u /data)"
+  user_gid="$(stat -c %g /data)"
+elif [ -d /conf ] && [[ "${cmd}" == "dump-config" ]]; then
+  # A configuration volume has been mounted and we are dumping config
+  user_uid="$(stat -c %u /conf)"
+  user_gid="$(stat -c %g /conf)"
+else
+  # Set to zero (root) to signal no mounting has been done
+  user_uid="0"
+  user_gid="0"
+fi
+
+# Only add group if it does not already exist
+if ! getent group neo4j >/dev/null && [[ "${user_gid}" = 0 ]]; then
+  addgroup -S neo4j
+elif ! getent group neo4j >/dev/null; then
+  addgroup -S -g "${user_gid}" neo4j
+fi
+
+# Only add user if it does not already exist
+if ! getent passwd neo4j >/dev/null && [[ "${user_uid}" = 0 ]]; then
+  adduser -S -H -h /var/lib/neo4j -G neo4j neo4j
+elif ! getent passwd neo4j >/dev/null; then
+  adduser -S -u "${user_uid}" -H -h /var/lib/neo4j -G neo4j neo4j
+fi
+
+# Need to chown the home directory - but a user might have mounted a
+# volume here. So take care not to chown volumes (stuff not owned by
+# root due to our intentional chowning to root in the Dockerfile)
+if [[ "$(stat -c %u /var/lib/neo4j)" = "0" ]]; then
+  # Non-recursive chown for the base directory
+  chown neo4j:neo4j /var/lib/neo4j
+fi
+
+while IFS= read -r -d '' dir
+do
+  if [[ "$(stat -c %u "${dir}")" = "0" ]]; then
+    # Using mindepth 1 to avoid the base directory here so recursive is OK
+    chown -R neo4j:neo4j "${dir}"
+  fi
+done <   <(find /var/lib/neo4j -type d -mindepth 1 -maxdepth 1 -print0)
+
+# Data dir is chowned later
+
 if [[ "${cmd}" != *"neo4j"* ]]; then
   if [ "${cmd}" == "dump-config" ]; then
     if [ -d /conf ]; then
-      cp --recursive conf/* /conf
+      # Run with neo4j user so we write files with correct permissions
+      su-exec neo4j cp --recursive conf/* /conf
       exit 0
     else
       echo >&2 "You must provide a /conf volume"
@@ -139,13 +188,13 @@ if [ "${cmd}" == "neo4j" ]; then
     elif [[ "${NEO4J_AUTH:-}" == neo4j/* ]]; then
         password="${NEO4J_AUTH#neo4j/}"
         if [ "${password}" == "neo4j" ]; then
-            echo "Invalid value for password. It cannot be 'neo4j', which is the default."
+            echo >&2 "Invalid value for password. It cannot be 'neo4j', which is the default."
             exit 1
         fi
         # Will exit with error if users already exist (and print a message explaining that)
         bin/neo4j-admin set-initial-password "${password}" || true
     elif [ -n "${NEO4J_AUTH:-}" ]; then
-        echo "Invalid value for NEO4J_AUTH: '${NEO4J_AUTH}'"
+        echo >&2 "Invalid value for NEO4J_AUTH: '${NEO4J_AUTH}'"
         exit 1
     fi
 fi
@@ -165,10 +214,17 @@ for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
     fi
 done
 
+# Chown the data dir now that (maybe) an initial password has been
+# set (this is a file in the data dir)
+if [[ "$(stat -c %u /data)" = "0" ]]; then
+  chown -R neo4j:neo4j /data
+fi
+
 [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
 
+# Use su-exec to drop privileges to neo4j user
 if [ "${cmd}" == "neo4j" ]; then
-    exec neo4j console
+    su-exec neo4j neo4j console
 else
-    exec "$@"
+    su-exec neo4j "$@"
 fi

--- a/src/3.3/docker-entrypoint.sh
+++ b/src/3.3/docker-entrypoint.sh
@@ -3,24 +3,20 @@
 cmd="$1"
 
 if [[ "${cmd}" != *"neo4j"* ]]; then
-    [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
-
-    if [ "${cmd}" == "dump-config" ]; then
-        if [ -d /conf ]; then
-            cp --recursive conf/* /conf
-            exit 0
-        else
-            echo "You must provide a /conf volume"
-            exit 1
-        fi
+  if [ "${cmd}" == "dump-config" ]; then
+    if [ -d /conf ]; then
+      cp --recursive conf/* /conf
+      exit 0
+    else
+      echo >&2 "You must provide a /conf volume"
+      exit 1
     fi
-    exec "$@"
-    exit $?
-fi
-
-if [ "$NEO4J_EDITION" == "enterprise" ]; then
+  fi
+else
+  # Only prompt for license agreement if command contains "neo4j" in it
+  if [ "$NEO4J_EDITION" == "enterprise" ]; then
     if [ "${NEO4J_ACCEPT_LICENSE_AGREEMENT:=no}" != "yes" ]; then
-        echo "
+      echo >&2 "
 In order to use Neo4j Enterprise Edition you must accept the license agreement.
 
 (c) Network Engine for Objects in Lund AB.  2017.  All Rights Reserved.
@@ -39,8 +35,9 @@ To do this you can use the following docker argument:
 
         --env=NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
 "
-        exit 1
+      exit 1
     fi
+  fi
 fi
 
 # Env variable naming convention:

--- a/src/3.3/docker-entrypoint.sh
+++ b/src/3.3/docker-entrypoint.sh
@@ -32,7 +32,7 @@ Email inquiries can be directed to: licensing@neo4j.com
 More information is also available at: https://neo4j.com/licensing/
 
 
-To accept the license agreemnt set the environment variable
+To accept the license agreement set the environment variable
 NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
 
 To do this you can use the following docker argument:

--- a/src/3.4/Dockerfile
+++ b/src/3.4/Dockerfile
@@ -2,7 +2,8 @@ FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache --quiet \
     bash \
-    curl
+    curl \
+    su-exec
 
 ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \
@@ -17,6 +18,8 @@ RUN curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && mv /var/lib/neo4j-* /var/lib/neo4j \
     && rm ${NEO4J_TARBALL} \
     && mv /var/lib/neo4j/data /data \
+    && chown -R root:root /data \
+    && chown -R root:root /var/lib/neo4j \
     && ln -s /data /var/lib/neo4j/data \
     && apk del curl
 

--- a/src/3.4/docker-entrypoint.sh
+++ b/src/3.4/docker-entrypoint.sh
@@ -3,24 +3,20 @@
 cmd="$1"
 
 if [[ "${cmd}" != *"neo4j"* ]]; then
-    [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
-
-    if [ "${cmd}" == "dump-config" ]; then
-        if [ -d /conf ]; then
-            cp --recursive conf/* /conf
-            exit 0
-        else
-            echo "You must provide a /conf volume"
-            exit 1
-        fi
+  if [ "${cmd}" == "dump-config" ]; then
+    if [ -d /conf ]; then
+      cp --recursive conf/* /conf
+      exit 0
+    else
+      echo >&2 "You must provide a /conf volume"
+      exit 1
     fi
-    exec "$@"
-    exit $?
-fi
-
-if [ "$NEO4J_EDITION" == "enterprise" ]; then
+  fi
+else
+  # Only prompt for license agreement if command contains "neo4j" in it
+  if [ "$NEO4J_EDITION" == "enterprise" ]; then
     if [ "${NEO4J_ACCEPT_LICENSE_AGREEMENT:=no}" != "yes" ]; then
-        echo "
+      echo >&2 "
 In order to use Neo4j Enterprise Edition you must accept the license agreement.
 
 (c) Network Engine for Objects in Lund AB.  2017.  All Rights Reserved.
@@ -39,8 +35,9 @@ To do this you can use the following docker argument:
 
         --env=NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
 "
-        exit 1
+      exit 1
     fi
+  fi
 fi
 
 # Env variable naming convention:

--- a/src/3.4/docker-entrypoint.sh
+++ b/src/3.4/docker-entrypoint.sh
@@ -2,10 +2,59 @@
 
 cmd="$1"
 
+# We intentionally chown /data to root in Dockerfile so we can detect
+# if no volume is mounted
+if [[ "$(stat -c %u /data)" != "0" ]]; then
+  # /data is a volume, is the same uid/gid for neo4j user
+  user_uid="$(stat -c %u /data)"
+  user_gid="$(stat -c %g /data)"
+elif [ -d /conf ] && [[ "${cmd}" == "dump-config" ]]; then
+  # A configuration volume has been mounted and we are dumping config
+  user_uid="$(stat -c %u /conf)"
+  user_gid="$(stat -c %g /conf)"
+else
+  # Set to zero (root) to signal no mounting has been done
+  user_uid="0"
+  user_gid="0"
+fi
+
+# Only add group if it does not already exist
+if ! getent group neo4j >/dev/null && [[ "${user_gid}" = 0 ]]; then
+  addgroup -S neo4j
+elif ! getent group neo4j >/dev/null; then
+  addgroup -S -g "${user_gid}" neo4j
+fi
+
+# Only add user if it does not already exist
+if ! getent passwd neo4j >/dev/null && [[ "${user_uid}" = 0 ]]; then
+  adduser -S -H -h /var/lib/neo4j -G neo4j neo4j
+elif ! getent passwd neo4j >/dev/null; then
+  adduser -S -u "${user_uid}" -H -h /var/lib/neo4j -G neo4j neo4j
+fi
+
+# Need to chown the home directory - but a user might have mounted a
+# volume here. So take care not to chown volumes (stuff not owned by
+# root due to our intentional chowning to root in the Dockerfile)
+if [[ "$(stat -c %u /var/lib/neo4j)" = "0" ]]; then
+  # Non-recursive chown for the base directory
+  chown neo4j:neo4j /var/lib/neo4j
+fi
+
+while IFS= read -r -d '' dir
+do
+  if [[ "$(stat -c %u "${dir}")" = "0" ]]; then
+    # Using mindepth 1 to avoid the base directory here so recursive is OK
+    chown -R neo4j:neo4j "${dir}"
+  fi
+done <   <(find /var/lib/neo4j -type d -mindepth 1 -maxdepth 1 -print0)
+
+# Data dir is chowned later
+
 if [[ "${cmd}" != *"neo4j"* ]]; then
   if [ "${cmd}" == "dump-config" ]; then
     if [ -d /conf ]; then
-      cp --recursive conf/* /conf
+      # Run with neo4j user so we write files with correct permissions
+      su-exec neo4j cp --recursive conf/* /conf
       exit 0
     else
       echo >&2 "You must provide a /conf volume"
@@ -132,13 +181,13 @@ if [ "${cmd}" == "neo4j" ] ; then
     elif [[ "${NEO4J_AUTH:-}" == neo4j/* ]]; then
         password="${NEO4J_AUTH#neo4j/}"
         if [ "${password}" == "neo4j" ]; then
-            echo "Invalid value for password. It cannot be 'neo4j', which is the default."
+            echo >&2 "Invalid value for password. It cannot be 'neo4j', which is the default."
             exit 1
         fi
         # Will exit with error if users already exist (and print a message explaining that)
         bin/neo4j-admin set-initial-password "${password}" || true
     elif [ -n "${NEO4J_AUTH:-}" ]; then
-        echo "Invalid value for NEO4J_AUTH: '${NEO4J_AUTH}'"
+        echo >&2 "Invalid value for NEO4J_AUTH: '${NEO4J_AUTH}'"
         exit 1
     fi
 fi
@@ -158,10 +207,17 @@ for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
     fi
 done
 
+# Chown the data dir now that (maybe) an initial password has been
+# set (this is a file in the data dir)
+if [[ "$(stat -c %u /data)" = "0" ]]; then
+  chown -R neo4j:neo4j /data
+fi
+
 [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
 
-if [ "${cmd}" == "neo4j" ] ; then
-    exec neo4j console
+# Use su-exec to drop privileges to neo4j user
+if [ "${cmd}" == "neo4j" ]; then
+    su-exec neo4j neo4j console
 else
-    exec "$@"
+    su-exec neo4j "$@"
 fi

--- a/src/3.4/docker-entrypoint.sh
+++ b/src/3.4/docker-entrypoint.sh
@@ -32,7 +32,7 @@ Email inquiries can be directed to: licensing@neo4j.com
 More information is also available at: https://neo4j.com/licensing/
 
 
-To accept the license agreemnt set the environment variable
+To accept the license agreement set the environment variable
 NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
 
 To do this you can use the following docker argument:

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -28,6 +28,21 @@ docker_run() {
   trap "docker_cleanup ${cid}" EXIT
 }
 
+docker_run_with_volume() {
+  local l_image="$1" l_cname="$2" l_volume="$3"; shift; shift; shift
+
+  local envs=()
+  if [[ ! "$@" =~ "NEO4J_ACCEPT_LICENSE_AGREEMENT=no" ]]; then
+    envs+=("--env=NEO4J_ACCEPT_LICENSE_AGREEMENT=yes")
+  fi
+  for env in "$@"; do
+    envs+=("--env=${env}")
+  done
+  local cid="$(docker run --detach "${envs[@]}" --name="${l_cname}" --volume="${l_volume}" "${l_image}")"
+  echo "log: tmp/out/${cid}.log"
+  trap "docker_cleanup ${cid}" EXIT
+}
+
 docker_compose_cleanup() {
   local l_composefile="$1"
   # Place compose logs in similarly named file
@@ -134,4 +149,12 @@ neo4j_readnode() {
     [[ "${SECONDS}" -ge "${end}" ]] && exit 1
     sleep 1
   done
+}
+
+uid_of() {
+  stat -c %u "$1"
+}
+
+gid_of() {
+  stat -c %g "$1"
 }

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -4,7 +4,7 @@ docker_cleanup() {
   mkdir -p tmp/out
   local l_logfile="tmp/out/${cid}.log"
 
-  docker logs "${cid}" > "${l_logfile}" || echo "failed to write log"
+  docker logs "${cid}" >"${l_logfile}" 2>&1 || echo "failed to write log"
   docker rm --force "${cid}" >/dev/null
 }
 

--- a/test/test-dumps-config
+++ b/test/test-dumps-config
@@ -9,10 +9,37 @@ readonly cname="neo4j-$(uuidgen)"
 
 readonly dir=$(mktemp --directory)
 
+GID="$(gid_of "${dir}")"
+readonly GID
+
 docker run --rm --volume="${dir}:/conf" "${image}" dump-config
 
 if [[ "${series}" == "2.3" ]]; then
-    [[ -f "${dir}/neo4j.properties" ]]
+  if ! [[ -f "${dir}/neo4j.properties" ]]; then
+    echo >&2 "no properties file found"
+    exit 1
+  fi
 else
-    [[ -f "${dir}/neo4j.conf" ]]
+  if ! [[ -f "${dir}/neo4j.conf" ]]; then
+    echo >&2 "No conf file found"
+    exit 1
+  fi
 fi
+
+if [[ "${series}" == "2.3" ]] || [[ "${series}" == "3.0" ]]; then
+  echo "Skipping: UID checks, code not present pre-3.1"
+  exit 0
+fi
+
+while IFS= read -r -d '' file
+do
+  if [[ "${UID}" != "$(uid_of "${file}")" ]]; then
+    echo >&2 Unexpected UID of "${file}" after dumping config
+    exit 1
+  fi
+
+  if [[ "${GID}" != "$(gid_of "${file}")" ]]; then
+    echo >&2 Unexpected GID of "${file}" after dumping config
+    exit 1
+  fi
+done <   <(find "${dir}" -print0)

--- a/test/test-path
+++ b/test/test-path
@@ -21,7 +21,7 @@ if [[ "${result}" == "/var/lib/neo4j/bin/${cypher_shell_cmd}" ]]; then
   echo "${cypher_shell_cmd} (and by implication all neo4j/bin) on path."
   exit 0
 else
-  echo "${cypher_shell_cmd} (and by implication all neo4j/bin) not on path"
+  echo >&2 "${cypher_shell_cmd} (and by implication all neo4j/bin) not on path"
   exit 1
 fi
 

--- a/test/test-requires-license-agreement-acceptance
+++ b/test/test-requires-license-agreement-acceptance
@@ -30,6 +30,7 @@ if grep --quiet "must accept the license" $logfile; then
   echo "License agreement not accepted."
   exit 0
 else
-  echo "Not accepting the license agreement should have failed."
+  echo >&2 "Not accepting the license agreement should have failed."
+  echo >&2 "${output}"
   exit 1
 fi

--- a/test/test-starts-up-with-data-volume
+++ b/test/test-starts-up-with-data-volume
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset
+
+. "$(dirname "$0")/helpers.sh"
+
+readonly image="$1"
+readonly series="$2"
+readonly cname="neo4j-$(uuidgen)"
+
+readonly datadir=$(mktemp --directory)
+GID="$(gid_of "${datadir}")"
+readonly GID
+
+docker_run_with_volume "$image" "$cname" "${datadir}:/data" "NEO4J_AUTH=none"
+readonly ip="$(docker_ip "${cname}")"
+neo4j_wait "${ip}"
+
+if [[ "${series}" == "2.3" ]] || [[ "${series}" == "3.0" ]]; then
+  echo "Skipping: UID checks, code not present pre-3.1"
+  exit 0
+fi
+
+while IFS= read -r -d '' file
+do
+  if [[ "${UID}" != "$(uid_of "${file}")" ]]; then
+    echo >&2 Unexpected UID of "${file}" after running with mounted data volume
+    exit 1
+  fi
+
+  if [[ "${GID}" != "$(gid_of "${file}")" ]]; then
+    echo >&2 Unexpected GID of "${file}" after running with mounted data volume
+    exit 1
+  fi
+done <   <(find "${datadir}" -print0)


### PR DESCRIPTION
This builds on #22

It uses `su-exec` [instead of gosu](https://github.com/tianon/gosu#su-exec) as
recommended by the author of `gosu` himself for Alpine images.

I have confirmed that docker these days sets a sensible ulimit so this
is no longer an issue we need to consider.

There is a fair amount of special handling in the entrypoint for
file permissions. We chown the relevant directories to the neo4j user
to make them writable for the process but we take care not to chown
directories which are volumes (to reasonable extents).

If a volume is mounted in `/data` or `/conf` (in that order) the neo4j
user is created with the same UID and GID as those directories. This
has the effect that the container will write new files with the same
UID/GID as the user owning the host directory. So once the container
exists, files will not have surprising (and maybe non-existing) owners on the host system.

Tests have been added to verify that the UID of files written are
sensible when volume mounts exist.

Fixes #50 