### PR TITLE
Wrap entrypoint with tini

### DIFF
--- a/src/3.1/Dockerfile
+++ b/src/3.1/Dockerfile
@@ -2,7 +2,8 @@ FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache --quiet \
     bash \
-    curl
+    curl \
+    tini
 
 ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%%
@@ -29,5 +30,5 @@ COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 EXPOSE 7474 7473 7687
 
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "-g", "--", "/docker-entrypoint.sh"]
 CMD ["neo4j"]

--- a/src/3.2/Dockerfile
+++ b/src/3.2/Dockerfile
@@ -2,7 +2,8 @@ FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache --quiet \
     bash \
-    curl
+    curl \
+    tini
 
 ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%%
@@ -29,5 +30,5 @@ COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 EXPOSE 7474 7473 7687
 
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "-g", "--", "/docker-entrypoint.sh"]
 CMD ["neo4j"]

--- a/src/3.3/Dockerfile
+++ b/src/3.3/Dockerfile
@@ -2,7 +2,8 @@ FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache --quiet \
     bash \
-    curl
+    curl \
+    tini
 
 ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \
@@ -30,5 +31,5 @@ COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 EXPOSE 7474 7473 7687
 
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "-g", "--", "/docker-entrypoint.sh"]
 CMD ["neo4j"]

--- a/src/3.4/Dockerfile
+++ b/src/3.4/Dockerfile
@@ -2,7 +2,8 @@ FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache --quiet \
     bash \
-    curl
+    curl \
+    tini
 
 ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \
@@ -30,5 +31,5 @@ COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 EXPOSE 7474 7473 7687
 
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "-g", "--", "/docker-entrypoint.sh"]
 CMD ["neo4j"]

--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -1,5 +1,6 @@
 FROM alpine
 
-RUN apk update && apk add --no-cache curl bash util-linux grep
+RUN apk update && apk add --no-cache curl bash util-linux grep tini
 
+ENTRYPOINT ["/sbin/tini", "-g", "--"]
 CMD ["bash", "-c", "while true; do sleep 120; done"]


### PR DESCRIPTION
Tini is a tiny "init-system" which handles signal forwarding to child
processes and most importantly handles reaping child processes.

Read more about it at

https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/
https://github.com/krallin/tini/issues/8
https://github.com/docker-library/official-images#init