### PR TITLE
Simplify non root execution

### DIFF
--- a/src/3.1/Dockerfile
+++ b/src/3.1/Dockerfile
@@ -1,10 +1,6 @@
 FROM openjdk:8-jre-alpine
 
-RUN apk add --no-cache --quiet \
-    bash \
-    curl \
-    tini \
-    su-exec
+RUN addgroup -S neo4j && adduser -S -H -h /var/lib/neo4j -G neo4j neo4j
 
 ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%%
@@ -12,15 +8,23 @@ ARG NEO4J_URI=%%NEO4J_DIST_SITE%%/%%NEO4J_TARBALL%%
 
 COPY ./local-package/* /tmp/
 
-RUN curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
+RUN apk add --no-cache --quiet \
+    bash \
+    curl \
+    tini \
+    su-exec \
+    && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && echo "${NEO4J_SHA256}  ${NEO4J_TARBALL}" | sha256sum -csw - \
     && tar --extract --file ${NEO4J_TARBALL} --directory /var/lib \
     && mv /var/lib/neo4j-* /var/lib/neo4j \
     && rm ${NEO4J_TARBALL} \
     && mv /var/lib/neo4j/data /data \
-    && chown -R root:root /data \
-    && chown -R root:root /var/lib/neo4j \
-    && ln -s /data /var/lib/neo4j/data
+    && chown -R neo4j:neo4j /data \
+    && chmod -R 777 /data \
+    && chown -R neo4j:neo4j /var/lib/neo4j \
+    && chmod -R 777 /var/lib/neo4j \
+    && ln -s /data /var/lib/neo4j/data \
+    && apk del curl
 
 ENV PATH /var/lib/neo4j/bin:$PATH
 

--- a/src/3.2/Dockerfile
+++ b/src/3.2/Dockerfile
@@ -1,10 +1,6 @@
 FROM openjdk:8-jre-alpine
 
-RUN apk add --no-cache --quiet \
-    bash \
-    curl \
-    tini \
-    su-exec
+RUN addgroup -S neo4j && adduser -S -H -h /var/lib/neo4j -G neo4j neo4j
 
 ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%%
@@ -12,15 +8,23 @@ ARG NEO4J_URI=%%NEO4J_DIST_SITE%%/%%NEO4J_TARBALL%%
 
 COPY ./local-package/* /tmp/
 
-RUN curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
+RUN apk add --no-cache --quiet \
+    bash \
+    curl \
+    tini \
+    su-exec \
+    && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && echo "${NEO4J_SHA256}  ${NEO4J_TARBALL}" | sha256sum -csw - \
     && tar --extract --file ${NEO4J_TARBALL} --directory /var/lib \
     && mv /var/lib/neo4j-* /var/lib/neo4j \
     && rm ${NEO4J_TARBALL} \
     && mv /var/lib/neo4j/data /data \
-    && chown -R root:root /data \
-    && chown -R root:root /var/lib/neo4j \
-    && ln -s /data /var/lib/neo4j/data
+    && chown -R neo4j:neo4j /data \
+    && chmod -R 777 /data \
+    && chown -R neo4j:neo4j /var/lib/neo4j \
+    && chmod -R 777 /var/lib/neo4j \
+    && ln -s /data /var/lib/neo4j/data \
+    && apk del curl
 
 ENV PATH /var/lib/neo4j/bin:$PATH
 

--- a/src/3.3/Dockerfile
+++ b/src/3.3/Dockerfile
@@ -1,10 +1,6 @@
 FROM openjdk:8-jre-alpine
 
-RUN apk add --no-cache --quiet \
-    bash \
-    curl \
-    tini \
-    su-exec
+RUN addgroup -S neo4j && adduser -S -H -h /var/lib/neo4j -G neo4j neo4j
 
 ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \
@@ -13,15 +9,23 @@ ARG NEO4J_URI=%%NEO4J_DIST_SITE%%/%%NEO4J_TARBALL%%
 
 COPY ./local-package/* /tmp/
 
-RUN curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
+RUN apk add --no-cache --quiet \
+    bash \
+    curl \
+    tini \
+    su-exec \
+    && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && echo "${NEO4J_SHA256}  ${NEO4J_TARBALL}" | sha256sum -csw - \
     && tar --extract --file ${NEO4J_TARBALL} --directory /var/lib \
     && mv /var/lib/neo4j-* /var/lib/neo4j \
     && rm ${NEO4J_TARBALL} \
     && mv /var/lib/neo4j/data /data \
-    && chown -R root:root /data \
-    && chown -R root:root /var/lib/neo4j \
-    && ln -s /data /var/lib/neo4j/data
+    && chown -R neo4j:neo4j /data \
+    && chmod -R 777 /data \
+    && chown -R neo4j:neo4j /var/lib/neo4j \
+    && chmod -R 777 /var/lib/neo4j \
+    && ln -s /data /var/lib/neo4j/data \
+    && apk del curl
 
 ENV PATH /var/lib/neo4j/bin:$PATH
 

--- a/src/3.3/docker-entrypoint.sh
+++ b/src/3.3/docker-entrypoint.sh
@@ -2,62 +2,38 @@
 
 cmd="$1"
 
-# We intentionally chown /data to root in Dockerfile so we can detect
-# if no volume is mounted
-if [[ "$(stat -c %u /data)" != "0" ]]; then
-  # /data is a volume, is the same uid/gid for neo4j user
-  user_uid="$(stat -c %u /data)"
-  user_gid="$(stat -c %g /data)"
-elif [ -d /conf ] && [[ "${cmd}" == "dump-config" ]]; then
-  # A configuration volume has been mounted and we are dumping config
-  user_uid="$(stat -c %u /conf)"
-  user_gid="$(stat -c %g /conf)"
+# If we're running as root, then run as the neo4j user. Otherwise
+# docker is running with --user and we simply use that user.  Note
+# that su-exec, despite its name, does not replicate the functionality
+# of exec, so we need to use both
+if [ "$(id -u)" = "0" ]; then
+  userid="neo4j"
+  groupid="neo4j"
+  exec_cmd="exec su-exec neo4j"
+else
+  userid="$(id -u)"
+  groupid="$(id -g)"
+  exec_cmd="exec"
 fi
-
-
-# Only add group if it does not already exist which can happen
-#   1. if the docker container is restarted
-#   2. if the mounted directory has group "nobody" for example which is a default group
-# And only add with specific GID if mounted directory
-if [[ "${user_gid:-0}" = 0 ]]; then
-  if ! getent group neo4j >/dev/null; then
-    addgroup -S neo4j
-  fi
-  user_gid=$(getent group neo4j | awk -F ':' '{ print $3 }')
-# Check if a group with that gid already exists, and if so don't add a neo4j group
-elif ! getent group | awk -F ':' '{ print $3 }' | grep -q "${user_gid}"; then
-  addgroup -S -g "${user_gid}" neo4j
-fi
-
-group_name=$(getent group "${user_gid}" | awk -F ':' '{ print $1 }')
-readonly group_name
-
-# Only add user if it does not already exist
-if [[ "${user_uid:-0}" = 0 ]]; then
-  if ! getent passwd neo4j >/dev/null; then
-    adduser -S -H -h /var/lib/neo4j -G "${group_name}" neo4j
-  fi
-  user_uid=$(getent passwd neo4j | awk -F ':' '{ print $3 }')
-elif ! getent passwd | awk -F ':' '{ print $3 }' | grep -q "${user_uid}"; then
-  adduser -S -u "${user_uid}" -H -h /var/lib/neo4j -G "${group_name}" neo4j
-fi
-
-user_name=$(getent passwd "${user_uid}" | awk -F ':' '{ print $1 }')
-readonly user_name
+readonly userid
+readonly groupid
+readonly exec_cmd
 
 # Need to chown the home directory - but a user might have mounted a
-# volume here. So take care not to chown volumes (stuff not owned by
-# root due to our intentional chowning to root in the Dockerfile)
-if [[ "$(stat -c %u /var/lib/neo4j)" = "0" ]]; then
+# volume here (notably a conf volume). So take care not to chown
+# volumes (stuff not owned by neo4j)
+if [[ "$(id -u)" = "0" ]]; then
   # Non-recursive chown for the base directory
-  chown "${user_name}:${group_name}" /var/lib/neo4j
+  chown "${userid}":"${groupid}" /var/lib/neo4j
+  chmod 700 /var/lib/neo4j
 fi
 
 while IFS= read -r -d '' dir
 do
-  if [[ "$(stat -c %u "${dir}")" = "0" ]]; then
+  if [[ "$(id -u)" = "0" ]] && [[ "$(stat -c %U "${dir}")" = "neo4j" ]]; then
     # Using mindepth 1 to avoid the base directory here so recursive is OK
-    chown -R "${user_name}:${group_name}" "${dir}"
+    chown -R "${userid}":"${groupid}" "${dir}"
+    chmod -R 700 "${dir}"
   fi
 done <   <(find /var/lib/neo4j -type d -mindepth 1 -maxdepth 1 -print0)
 
@@ -66,10 +42,7 @@ done <   <(find /var/lib/neo4j -type d -mindepth 1 -maxdepth 1 -print0)
 if [[ "${cmd}" != *"neo4j"* ]]; then
   if [ "${cmd}" == "dump-config" ]; then
     if [ -d /conf ]; then
-      # Run with neo4j user so we write files with correct permissions
-      # Note that su-exec, despite its name, does not replicate the
-      # functionality of exec, so we need to use both
-      exec su-exec "${user_name}" cp --recursive conf/* /conf
+      ${exec_cmd} cp --recursive conf/* /conf
       exit 0
     else
       echo >&2 "You must provide a /conf volume"
@@ -231,8 +204,9 @@ done
 
 # Chown the data dir now that (maybe) an initial password has been
 # set (this is a file in the data dir)
-if [[ "$(stat -c %u /data)" = "0" ]]; then
-  chown -R "${user_name}:${group_name}" /data
+if [[ "$(id -u)" = "0" ]]; then
+  chmod -R 755 /data
+  chown -R "${userid}":"${groupid}" /data
 fi
 
 [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
@@ -241,7 +215,7 @@ fi
 # Note that su-exec, despite its name, does not replicate the
 # functionality of exec, so we need to use both
 if [ "${cmd}" == "neo4j" ]; then
-    exec su-exec "${user_name}" neo4j console
+  ${exec_cmd} neo4j console
 else
-    exec su-exec "${user_name}" "$@"
+  ${exec_cmd} "$@"
 fi

--- a/src/3.4/Dockerfile
+++ b/src/3.4/Dockerfile
@@ -1,10 +1,6 @@
 FROM openjdk:8-jre-alpine
 
-RUN apk add --no-cache --quiet \
-    bash \
-    curl \
-    tini \
-    su-exec
+RUN addgroup -S neo4j && adduser -S -H -h /var/lib/neo4j -G neo4j neo4j
 
 ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \
@@ -13,15 +9,23 @@ ARG NEO4J_URI=%%NEO4J_DIST_SITE%%/%%NEO4J_TARBALL%%
 
 COPY ./local-package/* /tmp/
 
-RUN curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
+RUN apk add --no-cache --quiet \
+    bash \
+    curl \
+    tini \
+    su-exec \
+    && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && echo "${NEO4J_SHA256}  ${NEO4J_TARBALL}" | sha256sum -csw - \
     && tar --extract --file ${NEO4J_TARBALL} --directory /var/lib \
     && mv /var/lib/neo4j-* /var/lib/neo4j \
     && rm ${NEO4J_TARBALL} \
     && mv /var/lib/neo4j/data /data \
-    && chown -R root:root /data \
-    && chown -R root:root /var/lib/neo4j \
-    && ln -s /data /var/lib/neo4j/data
+    && chown -R neo4j:neo4j /data \
+    && chmod -R 777 /data \
+    && chown -R neo4j:neo4j /var/lib/neo4j \
+    && chmod -R 777 /var/lib/neo4j \
+    && ln -s /data /var/lib/neo4j/data \
+    && apk del curl
 
 ENV PATH /var/lib/neo4j/bin:$PATH
 

--- a/src/3.4/docker-entrypoint.sh
+++ b/src/3.4/docker-entrypoint.sh
@@ -2,62 +2,38 @@
 
 cmd="$1"
 
-# We intentionally chown /data to root in Dockerfile so we can detect
-# if no volume is mounted
-if [[ "$(stat -c %u /data)" != "0" ]]; then
-  # /data is a volume, is the same uid/gid for neo4j user
-  user_uid="$(stat -c %u /data)"
-  user_gid="$(stat -c %g /data)"
-elif [ -d /conf ] && [[ "${cmd}" == "dump-config" ]]; then
-  # A configuration volume has been mounted and we are dumping config
-  user_uid="$(stat -c %u /conf)"
-  user_gid="$(stat -c %g /conf)"
+# If we're running as root, then run as the neo4j user. Otherwise
+# docker is running with --user and we simply use that user.  Note
+# that su-exec, despite its name, does not replicate the functionality
+# of exec, so we need to use both
+if [ "$(id -u)" = "0" ]; then
+  userid="neo4j"
+  groupid="neo4j"
+  exec_cmd="exec su-exec neo4j"
+else
+  userid="$(id -u)"
+  groupid="$(id -g)"
+  exec_cmd="exec"
 fi
-
-
-# Only add group if it does not already exist which can happen
-#   1. if the docker container is restarted
-#   2. if the mounted directory has group "nobody" for example which is a default group
-# And only add with specific GID if mounted directory
-if [[ "${user_gid:-0}" = 0 ]]; then
-  if ! getent group neo4j >/dev/null; then
-    addgroup -S neo4j
-  fi
-  user_gid=$(getent group neo4j | awk -F ':' '{ print $3 }')
-# Check if a group with that gid already exists, and if so don't add a neo4j group
-elif ! getent group | awk -F ':' '{ print $3 }' | grep -q "${user_gid}"; then
-  addgroup -S -g "${user_gid}" neo4j
-fi
-
-group_name=$(getent group "${user_gid}" | awk -F ':' '{ print $1 }')
-readonly group_name
-
-# Only add user if it does not already exist
-if [[ "${user_uid:-0}" = 0 ]]; then
-  if ! getent passwd neo4j >/dev/null; then
-    adduser -S -H -h /var/lib/neo4j -G "${group_name}" neo4j
-  fi
-  user_uid=$(getent passwd neo4j | awk -F ':' '{ print $3 }')
-elif ! getent passwd | awk -F ':' '{ print $3 }' | grep -q "${user_uid}"; then
-  adduser -S -u "${user_uid}" -H -h /var/lib/neo4j -G "${group_name}" neo4j
-fi
-
-user_name=$(getent passwd "${user_uid}" | awk -F ':' '{ print $1 }')
-readonly user_name
+readonly userid
+readonly groupid
+readonly exec_cmd
 
 # Need to chown the home directory - but a user might have mounted a
-# volume here. So take care not to chown volumes (stuff not owned by
-# root due to our intentional chowning to root in the Dockerfile)
-if [[ "$(stat -c %u /var/lib/neo4j)" = "0" ]]; then
+# volume here (notably a conf volume). So take care not to chown
+# volumes (stuff not owned by neo4j)
+if [[ "$(id -u)" = "0" ]]; then
   # Non-recursive chown for the base directory
-  chown "${user_name}:${group_name}" /var/lib/neo4j
+  chown "${userid}":"${groupid}" /var/lib/neo4j
+  chmod 700 /var/lib/neo4j
 fi
 
 while IFS= read -r -d '' dir
 do
-  if [[ "$(stat -c %u "${dir}")" = "0" ]]; then
+  if [[ "$(id -u)" = "0" ]] && [[ "$(stat -c %U "${dir}")" = "neo4j" ]]; then
     # Using mindepth 1 to avoid the base directory here so recursive is OK
-    chown -R "${user_name}:${group_name}" "${dir}"
+    chown -R "${userid}":"${groupid}" "${dir}"
+    chmod -R 700 "${dir}"
   fi
 done <   <(find /var/lib/neo4j -type d -mindepth 1 -maxdepth 1 -print0)
 
@@ -66,10 +42,7 @@ done <   <(find /var/lib/neo4j -type d -mindepth 1 -maxdepth 1 -print0)
 if [[ "${cmd}" != *"neo4j"* ]]; then
   if [ "${cmd}" == "dump-config" ]; then
     if [ -d /conf ]; then
-      # Run with neo4j user so we write files with correct permissions
-      # Note that su-exec, despite its name, does not replicate the
-      # functionality of exec, so we need to use both
-      exec su-exec "${user_name}" cp --recursive conf/* /conf
+      ${exec_cmd} cp --recursive conf/* /conf
       exit 0
     else
       echo >&2 "You must provide a /conf volume"
@@ -224,8 +197,9 @@ done
 
 # Chown the data dir now that (maybe) an initial password has been
 # set (this is a file in the data dir)
-if [[ "$(stat -c %u /data)" = "0" ]]; then
-  chown -R "${user_name}:${group_name}" /data
+if [[ "$(id -u)" = "0" ]]; then
+  chmod -R 755 /data
+  chown -R "${userid}":"${groupid}" /data
 fi
 
 [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
@@ -234,7 +208,7 @@ fi
 # Note that su-exec, despite its name, does not replicate the
 # functionality of exec, so we need to use both
 if [ "${cmd}" == "neo4j" ]; then
-    exec su-exec "${user_name}" neo4j console
+  ${exec_cmd} neo4j console
 else
-    exec su-exec "${user_name}" "$@"
+  ${exec_cmd} "$@"
 fi

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -65,7 +65,24 @@ docker_run_with_volume() {
   for env in "$@"; do
     envs+=("--env=${env}")
   done
-  local cid="$(docker run --detach "${envs[@]}" --name="${l_cname}" --volume="${l_volume}" "${l_image}")"
+  local cid
+  cid="$(docker run --detach "${envs[@]}" --name="${l_cname}" --volume="${l_volume}" "${l_image}")"
+  echo "log: tmp/out/${cid}.log"
+  trap "docker_cleanup ${cid}" EXIT
+}
+
+docker_run_with_volume_and_user() {
+  local l_image="$1" l_cname="$2" l_volume="$3" l_user="$4"; shift; shift; shift; shift
+
+  local envs=()
+  if [[ ! "$@" =~ "NEO4J_ACCEPT_LICENSE_AGREEMENT=no" ]]; then
+    envs+=("--env=NEO4J_ACCEPT_LICENSE_AGREEMENT=yes")
+  fi
+  for env in "$@"; do
+    envs+=("--env=${env}")
+  done
+  local cid
+  cid="$(docker run --detach "${envs[@]}" --name="${l_cname}" --volume="${l_volume}" --user="${l_user}" "${l_image}")"
   echo "log: tmp/out/${cid}.log"
   trap "docker_cleanup ${cid}" EXIT
 }

--- a/test/test-dumps-config
+++ b/test/test-dumps-config
@@ -13,7 +13,7 @@ readonly dir=$(mktemp --directory --tmpdir=/tmp/)
 GID="$(gid_of "${dir}")"
 readonly GID
 
-docker run --rm --volume="${dir}:/conf" "${image}" dump-config
+docker run --rm --volume="${dir}:/conf" --user="$(id -u):$(id -g)" "${image}" dump-config
 
 if [[ "${series}" == "2.3" ]]; then
   if ! [[ -f "${dir}/neo4j.properties" ]]; then
@@ -35,12 +35,12 @@ fi
 while IFS= read -r -d '' file
 do
   if [[ "${UID}" != "$(uid_of "${file}")" ]]; then
-    echo >&2 Unexpected UID of "${file}" after dumping config
+    echo >&2 Unexpected UID of "${file}" after dumping config: "$(uid_of "${file}")" != "${UID}"
     exit 1
   fi
 
   if [[ "${GID}" != "$(gid_of "${file}")" ]]; then
-    echo >&2 Unexpected GID of "${file}" after dumping config
+    echo >&2 Unexpected GID of "${file}" after dumping config: "$(gid_of "${file}")" != "${GID}"
     exit 1
   fi
 done <   <(find "${dir}" -print0)

--- a/test/test-starts-up-with-data-volume-and-user
+++ b/test/test-starts-up-with-data-volume-and-user
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset
+
+. "$(dirname "$0")/helpers.sh"
+
+readonly image="$1"
+readonly series="$2"
+readonly cname="neo4j-$(uuidgen)"
+
+# mktemp on OSX by default uses /var/folders/ which is not available to docker
+readonly datadir=$(mktemp --directory --tmpdir=/tmp/)
+GID="$(gid_of "${datadir}")"
+readonly GID
+
+docker_run_with_volume_and_user "$image" "$cname" "${datadir}:/data" "$(id -u):$(id -g)" "NEO4J_AUTH=none"
+readonly ip="$(docker_ip "${cname}")"
+neo4j_wait "${ip}"
+
+if [[ "${series}" == "2.3" ]] || [[ "${series}" == "3.0" ]]; then
+  echo "Skipping: UID checks, code not present pre-3.1"
+  exit 0
+fi
+
+while IFS= read -r -d '' file
+do
+  if [[ "${UID}" != "$(uid_of "${file}")" ]]; then
+    echo >&2 Unexpected UID of "${file}" after running with mounted data volume: "$(uid_of "${file}")" != "${UID}"
+    exit 1
+  fi
+
+  if [[ "${GID}" != "$(gid_of "${file}")" ]]; then
+    echo >&2 Unexpected GID of "${file}" after running with mounted data volume: "$(gid_of "${file}")" != "${GID}"
+    exit 1
+  fi
+done <   <(find "${datadir}" -print0)

--- a/test/test-starts-up-with-data-volume-default-user
+++ b/test/test-starts-up-with-data-volume-default-user
@@ -23,13 +23,13 @@ fi
 
 while IFS= read -r -d '' file
 do
-  if [[ "${UID}" != "$(uid_of "${file}")" ]]; then
-    echo >&2 Unexpected UID of "${file}" after running with mounted data volume
+  if [[ "0" = "$(uid_of "${file}")" ]]; then
+    echo >&2 "Did not expect UID of ${file} to be root (0) after running with mounted data volume"
     exit 1
   fi
 
-  if [[ "${GID}" != "$(gid_of "${file}")" ]]; then
-    echo >&2 Unexpected GID of "${file}" after running with mounted data volume
+  if [[ "$0" = "$(gid_of "${file}")" ]]; then
+    echo >&2 "Did not expect GID of ${file} to be root (0) after running with mounted data volume"
     exit 1
   fi
 done <   <(find "${datadir}" -print0)


### PR DESCRIPTION
Neo4j will always run as non-root. But if the user wants sensible UIDs
on the files in any volume, the user needs to make sure to invoke
docker with the `--user` option.

This matches what other official images do to run as non-root.