### PR TITLE
Don't write things that look like neo4j config environment variables …

### DIFF
--- a/src/3.0/docker-entrypoint.sh
+++ b/src/3.0/docker-entrypoint.sh
@@ -11,7 +11,8 @@ setting() {
         fi
     fi
 
-    if [ -n "${value}" ]; then
+    # Don't allow settings with no value or settings that start with a number (neo4j converts settings to env variables and you cannot have an env variable that starts with a number)
+    if [[ -n ${value} ]] && [[ ! "${setting}" =~ ^NEO4J_[0-9]+.*$ ]]; then
         if grep --quiet --fixed-strings "${setting}=" conf/"${file}"; then
             sed --in-place "s|.*${setting}=.*|${setting}=${value}|" conf/"${file}"
         else

--- a/src/3.0/docker-entrypoint.sh
+++ b/src/3.0/docker-entrypoint.sh
@@ -12,7 +12,7 @@ setting() {
     fi
 
     # Don't allow settings with no value or settings that start with a number (neo4j converts settings to env variables and you cannot have an env variable that starts with a number)
-    if [[ -n ${value} ]] && [[ ! "${setting}" =~ ^NEO4J_[0-9]+.*$ ]]; then
+    if [[ -n ${value} ]] && [[ ! "${setting}" =~ ^[0-9]+.*$ ]]; then
         if grep --quiet --fixed-strings "${setting}=" conf/"${file}"; then
             sed --in-place "s|.*${setting}=.*|${setting}=${value}|" conf/"${file}"
         else
@@ -139,7 +139,7 @@ unset NEO4J_AUTH NEO4J_SHA256 NEO4J_TARBALL
 for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
     setting=$(echo ${i} | sed 's|^NEO4J_||' | sed 's|_|.|g' | sed 's|\.\.|_|g')
     value=$(echo ${!i})
-    if [[ -n ${value} ]]; then
+    if [[ -n ${value} ]] && [[ ! "${setting}" =~ ^[0-9]+.*$ ]]; then
         if grep -q -F "${setting}=" conf/neo4j.conf; then
             # Remove any lines containing the setting already
             sed --in-place "/${setting}=.*/d" conf/neo4j.conf

--- a/src/3.1/docker-entrypoint.sh
+++ b/src/3.1/docker-entrypoint.sh
@@ -146,13 +146,17 @@ for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
     setting=$(echo ${i} | sed 's|^NEO4J_||' | sed 's|_|.|g' | sed 's|\.\.|_|g')
     value=$(echo ${!i})
     # Don't allow settings with no value or settings that start with a number (neo4j converts settings to env variables and you cannot have an env variable that starts with a number)
-    if [[ -n ${value} ]] && [[ ! "${setting}" =~ ^[0-9]+.*$ ]]; then
-        if grep -q -F "${setting}=" conf/neo4j.conf; then
-            # Remove any lines containing the setting already
-            sed --in-place "/${setting}=.*/d" conf/neo4j.conf
+    if [[ -n ${value} ]]; then
+        if [[ ! "${setting}" =~ ^[0-9]+.*$ ]]; then
+            if grep -q -F "${setting}=" conf/neo4j.conf; then
+                # Remove any lines containing the setting already
+                sed --in-place "/${setting}=.*/d" conf/neo4j.conf
+            fi
+            # Then always append setting to file
+            echo "${setting}=${value}" >> conf/neo4j.conf
+        else
+            echo >&2 "WARNING: ${setting} not written to conf file because settings that start with a number are not permitted"
         fi
-        # Then always append setting to file
-        echo "${setting}=${value}" >> conf/neo4j.conf
     fi
 done
 

--- a/src/3.1/docker-entrypoint.sh
+++ b/src/3.1/docker-entrypoint.sh
@@ -145,7 +145,8 @@ unset NEO4J_AUTH NEO4J_SHA256 NEO4J_TARBALL
 for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
     setting=$(echo ${i} | sed 's|^NEO4J_||' | sed 's|_|.|g' | sed 's|\.\.|_|g')
     value=$(echo ${!i})
-    if [[ -n ${value} ]]; then
+    # Don't allow settings with no value or settings that start with a number (neo4j converts settings to env variables and you cannot have an env variable that starts with a number)
+    if [[ -n ${value} ]] && [[ ! "${setting}" =~ ^[0-9]+.*$ ]]; then
         if grep -q -F "${setting}=" conf/neo4j.conf; then
             # Remove any lines containing the setting already
             sed --in-place "/${setting}=.*/d" conf/neo4j.conf

--- a/src/3.2/docker-entrypoint.sh
+++ b/src/3.2/docker-entrypoint.sh
@@ -146,13 +146,17 @@ for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
     setting=$(echo ${i} | sed 's|^NEO4J_||' | sed 's|_|.|g' | sed 's|\.\.|_|g')
     value=$(echo ${!i})
     # Don't allow settings with no value or settings that start with a number (neo4j converts settings to env variables and you cannot have an env variable that starts with a number)
-    if [[ -n ${value} ]] && [[ ! "${setting}" =~ ^[0-9]+.*$ ]]; then
-        if grep -q -F "${setting}=" conf/neo4j.conf; then
-            # Remove any lines containing the setting already
-            sed --in-place "/${setting}=.*/d" conf/neo4j.conf
+    if [[ -n ${value} ]]; then
+        if [[ ! "${setting}" =~ ^[0-9]+.*$ ]]; then
+            if grep -q -F "${setting}=" conf/neo4j.conf; then
+                # Remove any lines containing the setting already
+                sed --in-place "/${setting}=.*/d" conf/neo4j.conf
+            fi
+            # Then always append setting to file
+            echo "${setting}=${value}" >> conf/neo4j.conf
+        else
+            echo >&2 "WARNING: ${setting} not written to conf file because settings that start with a number are not permitted"
         fi
-        # Then always append setting to file
-        echo "${setting}=${value}" >> conf/neo4j.conf
     fi
 done
 

--- a/src/3.2/docker-entrypoint.sh
+++ b/src/3.2/docker-entrypoint.sh
@@ -145,7 +145,8 @@ unset NEO4J_AUTH NEO4J_SHA256 NEO4J_TARBALL
 for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
     setting=$(echo ${i} | sed 's|^NEO4J_||' | sed 's|_|.|g' | sed 's|\.\.|_|g')
     value=$(echo ${!i})
-    if [[ -n ${value} ]]; then
+    # Don't allow settings with no value or settings that start with a number (neo4j converts settings to env variables and you cannot have an env variable that starts with a number)
+    if [[ -n ${value} ]] && [[ ! "${setting}" =~ ^[0-9]+.*$ ]]; then
         if grep -q -F "${setting}=" conf/neo4j.conf; then
             # Remove any lines containing the setting already
             sed --in-place "/${setting}=.*/d" conf/neo4j.conf

--- a/src/3.3/docker-entrypoint.sh
+++ b/src/3.3/docker-entrypoint.sh
@@ -193,13 +193,17 @@ for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
     setting=$(echo ${i} | sed 's|^NEO4J_||' | sed 's|_|.|g' | sed 's|\.\.|_|g')
     value=$(echo ${!i})
     # Don't allow settings with no value or settings that start with a number (neo4j converts settings to env variables and you cannot have an env variable that starts with a number)
-    if [[ -n ${value} ]] && [[ ! "${setting}" =~ ^[0-9]+.*$ ]]; then
-        if grep -q -F "${setting}=" conf/neo4j.conf; then
-            # Remove any lines containing the setting already
-            sed --in-place "/${setting}=.*/d" conf/neo4j.conf
+    if [[ -n ${value} ]]; then
+        if [[ ! "${setting}" =~ ^[0-9]+.*$ ]]; then
+            if grep -q -F "${setting}=" conf/neo4j.conf; then
+                # Remove any lines containing the setting already
+                sed --in-place "/${setting}=.*/d" conf/neo4j.conf
+            fi
+            # Then always append setting to file
+            echo "${setting}=${value}" >> conf/neo4j.conf
+        else
+            echo >&2 "WARNING: ${setting} not written to conf file because settings that start with a number are not permitted"
         fi
-        # Then always append setting to file
-        echo "${setting}=${value}" >> conf/neo4j.conf
     fi
 done
 

--- a/src/3.3/docker-entrypoint.sh
+++ b/src/3.3/docker-entrypoint.sh
@@ -192,7 +192,8 @@ unset NEO4J_AUTH NEO4J_SHA256 NEO4J_TARBALL
 for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
     setting=$(echo ${i} | sed 's|^NEO4J_||' | sed 's|_|.|g' | sed 's|\.\.|_|g')
     value=$(echo ${!i})
-    if [[ -n ${value} ]]; then
+    # Don't allow settings with no value or settings that start with a number (neo4j converts settings to env variables and you cannot have an env variable that starts with a number)
+    if [[ -n ${value} ]] && [[ ! "${setting}" =~ ^[0-9]+.*$ ]]; then
         if grep -q -F "${setting}=" conf/neo4j.conf; then
             # Remove any lines containing the setting already
             sed --in-place "/${setting}=.*/d" conf/neo4j.conf

--- a/src/3.4/docker-entrypoint.sh
+++ b/src/3.4/docker-entrypoint.sh
@@ -185,7 +185,8 @@ unset NEO4J_AUTH NEO4J_SHA256 NEO4J_TARBALL
 for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
     setting=$(echo ${i} | sed 's|^NEO4J_||' | sed 's|_|.|g' | sed 's|\.\.|_|g')
     value=$(echo ${!i})
-    if [[ -n ${value} ]]; then
+    # Don't allow settings with no value or settings that start with a number (neo4j converts settings to env variables and you cannot have an env variable that starts with a number)
+    if [[ -n ${value} ]] && [[ ! "${setting}" =~ ^[0-9]+.*$ ]]; then
         if grep -q -F "${setting}=" conf/neo4j.conf; then
             # Remove any lines containing the setting already
             sed --in-place "/${setting}=.*/d" conf/neo4j.conf

--- a/src/3.4/docker-entrypoint.sh
+++ b/src/3.4/docker-entrypoint.sh
@@ -186,13 +186,17 @@ for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
     setting=$(echo ${i} | sed 's|^NEO4J_||' | sed 's|_|.|g' | sed 's|\.\.|_|g')
     value=$(echo ${!i})
     # Don't allow settings with no value or settings that start with a number (neo4j converts settings to env variables and you cannot have an env variable that starts with a number)
-    if [[ -n ${value} ]] && [[ ! "${setting}" =~ ^[0-9]+.*$ ]]; then
-        if grep -q -F "${setting}=" conf/neo4j.conf; then
-            # Remove any lines containing the setting already
-            sed --in-place "/${setting}=.*/d" conf/neo4j.conf
+    if [[ -n ${value} ]]; then
+        if [[ ! "${setting}" =~ ^[0-9]+.*$ ]]; then
+            if grep -q -F "${setting}=" conf/neo4j.conf; then
+                # Remove any lines containing the setting already
+                sed --in-place "/${setting}=.*/d" conf/neo4j.conf
+            fi
+            # Then always append setting to file
+            echo "${setting}=${value}" >> conf/neo4j.conf
+        else
+            echo >&2 "WARNING: ${setting} not written to conf file because settings that start with a number are not permitted"
         fi
-        # Then always append setting to file
-        echo "${setting}=${value}" >> conf/neo4j.conf
     fi
 done
 

--- a/src/3.5/docker-entrypoint.sh
+++ b/src/3.5/docker-entrypoint.sh
@@ -185,7 +185,8 @@ unset NEO4J_AUTH NEO4J_SHA256 NEO4J_TARBALL
 for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
     setting=$(echo ${i} | sed 's|^NEO4J_||' | sed 's|_|.|g' | sed 's|\.\.|_|g')
     value=$(echo ${!i})
-    if [[ -n ${value} ]]; then
+    # Don't allow settings with no value or settings that start with a number (neo4j converts settings to env variables and you cannot have an env variable that starts with a number)
+    if [[ -n ${value} ]] && [[ ! "${setting}" =~ ^[0-9]+.*$ ]]; then
         if grep -q -F "${setting}=" conf/neo4j.conf; then
             # Remove any lines containing the setting already
             sed --in-place "/${setting}=.*/d" conf/neo4j.conf

--- a/src/3.5/docker-entrypoint.sh
+++ b/src/3.5/docker-entrypoint.sh
@@ -186,13 +186,17 @@ for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
     setting=$(echo ${i} | sed 's|^NEO4J_||' | sed 's|_|.|g' | sed 's|\.\.|_|g')
     value=$(echo ${!i})
     # Don't allow settings with no value or settings that start with a number (neo4j converts settings to env variables and you cannot have an env variable that starts with a number)
-    if [[ -n ${value} ]] && [[ ! "${setting}" =~ ^[0-9]+.*$ ]]; then
-        if grep -q -F "${setting}=" conf/neo4j.conf; then
-            # Remove any lines containing the setting already
-            sed --in-place "/${setting}=.*/d" conf/neo4j.conf
+    if [[ -n ${value} ]]; then
+        if [[ ! "${setting}" =~ ^[0-9]+.*$ ]]; then
+            if grep -q -F "${setting}=" conf/neo4j.conf; then
+                # Remove any lines containing the setting already
+                sed --in-place "/${setting}=.*/d" conf/neo4j.conf
+            fi
+            # Then always append setting to file
+            echo "${setting}=${value}" >> conf/neo4j.conf
+        else
+            echo >&2 "WARNING: ${setting} not written to conf file because settings that start with a number are not permitted"
         fi
-        # Then always append setting to file
-        echo "${setting}=${value}" >> conf/neo4j.conf
     fi
 done
 

--- a/test/test-ignore-numeric-vars
+++ b/test/test-ignore-numeric-vars
@@ -6,6 +6,7 @@ set -o errexit -o nounset
 . "$(dirname "$0")/helpers.sh"
 
 readonly image="$1"
+readonly series="$2"
 readonly cname="neo4j-$(uuidgen)"
 
 docker_run "$image" "$cname" "NEO4J_1a=1 NEO4J_AUTH=none"
@@ -13,7 +14,14 @@ readonly ip="$(docker_ip "${cname}")"
 neo4j_wait "${ip}"
 
 stderr="$((docker logs "${cname}" 1>/dev/null) 2>&1)"
-if [[ "${stderr}" != "" ]]; then
+
+if [[ "${series}" == "2.3" ]]; then
+  expected_err=""
+else
+  expected_err="WARNING: 1a not written to conf file because settings that start with a number are not permitted"
+fi
+
+if [[ "${stderr}" != "${expected_err}" ]]; then
     echo "Unexpected output from container:"
     echo "${stderr}"
     exit 1

--- a/test/test-ignore-numeric-vars
+++ b/test/test-ignore-numeric-vars
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset
+
+[[ -n "${TRACE:-}" ]] && set -o xtrace
+
+. "$(dirname "$0")/helpers.sh"
+
+readonly image="$1"
+readonly cname="neo4j-$(uuidgen)"
+
+docker_run "$image" "$cname" "NEO4J_1a=1 NEO4J_AUTH=none"
+readonly ip="$(docker_ip "${cname}")"
+neo4j_wait "${ip}"
+
+stderr="$((docker logs "${cname}" 1>/dev/null) 2>&1)"
+if [[ "${stderr}" != "" ]]; then
+    echo "Unexpected output from container:"
+    echo "${stderr}"
+    exit 1
+fi


### PR DESCRIPTION
but start with a number to the neo4j.conf

It causes neo4j to fail with very confusing errors.

N.b. this would be a problem if in future we had conf settings that start with numbers but that seems unlikely since A) it would cause the neo4j shell script to barf and B) it doesn't fit our naming convention.

full list of config settings is here for reference
https://neo4j.com/docs/operations-manual/current/reference/configuration-settings/