### PR TITLE
Allow tmp root to vary per system

### DIFF
--- a/devenv
+++ b/devenv
@@ -5,6 +5,20 @@ PATH="./build:${PATH}"
 # MacOS specific checks
 if [ "$(uname)" == "Darwin" ] ; then
 
+  # We use temporary directories during testing that need to be
+  # accessible to the Docker daemon. By default on Macs, $TMPDIR
+  # (which mktemp responds to) is set to a user-specific location that
+  # the Docker daemon cannot read from.
+  #
+  # In some environments, such as TeamCity, $TMPDIR is intentionally
+  # pointed elsewhere, so we only want to override the default
+  # value. (We don't currently run these builds on Macs, but you never
+  # know.) This default seems to be in /private/var/folders on some
+  # Macs and /var/folders on others, so we accommodate both.
+  if [[ "${TMPDIR}" == */var/folders* ]]; then
+    export TMPDIR=/tmp
+  fi
+
   echo "Setting PATH with MacOS specific locations"
   export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
   export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"

--- a/test/test-dumps-config
+++ b/test/test-dumps-config
@@ -7,8 +7,7 @@ readonly image="$1"
 readonly series="$2"
 readonly cname="neo4j-$(uuidgen)"
 
-# mktemp on OSX by default uses /var/folders/ which is not available to docker
-readonly dir=$(mktemp --directory --tmpdir=/tmp/)
+readonly dir=$(mktemp --directory)
 
 GID="$(gid_of "${dir}")"
 readonly GID

--- a/test/test-neo4j-admin-conf-override
+++ b/test/test-neo4j-admin-conf-override
@@ -21,8 +21,7 @@ fi
 . "$(dirname "$0")/helpers.sh"
 readonly cname="neo4j-$(uuidgen)"
 
-# mktemp on OSX by default uses /var/folders/ which is not available to docker
-readonly dir=$(mktemp --directory --tmpdir=/tmp/)
+readonly dir=$(mktemp --directory)
 touch "${dir}/neo4j.conf"
 
 docker run --rm --volume="${dir}:/var/lib/neo4j/conf" \

--- a/test/test-starts-up-with-data-volume-and-user
+++ b/test/test-starts-up-with-data-volume-and-user
@@ -7,8 +7,7 @@ readonly image="$1"
 readonly series="$2"
 readonly cname="neo4j-$(uuidgen)"
 
-# mktemp on OSX by default uses /var/folders/ which is not available to docker
-readonly datadir=$(mktemp --directory --tmpdir=/tmp/)
+readonly datadir=$(mktemp --directory)
 GID="$(gid_of "${datadir}")"
 readonly GID
 

--- a/test/test-starts-up-with-data-volume-default-user
+++ b/test/test-starts-up-with-data-volume-default-user
@@ -7,8 +7,7 @@ readonly image="$1"
 readonly series="$2"
 readonly cname="neo4j-$(uuidgen)"
 
-# mktemp on OSX by default uses /var/folders/ which is not available to docker
-readonly datadir=$(mktemp --directory --tmpdir=/tmp/)
+readonly datadir=$(mktemp --directory)
 GID="$(gid_of "${datadir}")"
 readonly GID
 


### PR DESCRIPTION
mktemp uses $TMPDIR as the tmp root if it is set and defaults to /tmp
if it is not. So there is no reason to specify --tmpdir=/tmp. On Linux
TMPDIR is not set by default, and /tmp will be used. On OSX it is set
and uses some user-specific location. On TeamCity $TMPDIR is set to a
build-specific location.

It's actually the TeamCity behaviour that we're doing this for. Using
/tmp there is problematic because that is very small on our build
agents, so we need to use $TMPDIR instead.