### PR TITLE
fix removal of pre-existing setting in neo4j.conf

### DIFF
--- a/src/3.0/docker-entrypoint.sh
+++ b/src/3.0/docker-entrypoint.sh
@@ -147,7 +147,7 @@ for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
         if [[ ! "${setting}" =~ ^[0-9]+.*$ ]]; then
             if grep -q -F "${setting}=" conf/neo4j.conf; then
                 # Remove any lines containing the setting already
-                sed --in-place "/${setting}=.*/d" conf/neo4j.conf
+                sed --in-place "/^${setting}=.*/d" conf/neo4j.conf
             fi
             # Then always append setting to file
             echo "${setting}=${value}" >> conf/neo4j.conf

--- a/src/3.1/docker-entrypoint.sh
+++ b/src/3.1/docker-entrypoint.sh
@@ -155,7 +155,7 @@ for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
         if [[ ! "${setting}" =~ ^[0-9]+.*$ ]]; then
             if grep -q -F "${setting}=" "${NEO4J_HOME}"/conf/neo4j.conf; then
                 # Remove any lines containing the setting already
-                sed --in-place "/${setting}=.*/d" "${NEO4J_HOME}"/conf/neo4j.conf
+                sed --in-place "/^${setting}=.*/d" "${NEO4J_HOME}"/conf/neo4j.conf
             fi
             # Then always append setting to file
             echo "${setting}=${value}" >> "${NEO4J_HOME}"/conf/neo4j.conf

--- a/src/3.2/docker-entrypoint.sh
+++ b/src/3.2/docker-entrypoint.sh
@@ -155,7 +155,7 @@ for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
         if [[ ! "${setting}" =~ ^[0-9]+.*$ ]]; then
             if grep -q -F "${setting}=" "${NEO4J_HOME}"/conf/neo4j.conf; then
                 # Remove any lines containing the setting already
-                sed --in-place "/${setting}=.*/d" "${NEO4J_HOME}"/conf/neo4j.conf
+                sed --in-place "/^${setting}=.*/d" "${NEO4J_HOME}"/conf/neo4j.conf
             fi
             # Then always append setting to file
             echo "${setting}=${value}" >> "${NEO4J_HOME}"/conf/neo4j.conf

--- a/src/3.3/docker-entrypoint.sh
+++ b/src/3.3/docker-entrypoint.sh
@@ -202,7 +202,7 @@ for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
         if [[ ! "${setting}" =~ ^[0-9]+.*$ ]]; then
             if grep -q -F "${setting}=" "${NEO4J_HOME}"/conf/neo4j.conf; then
                 # Remove any lines containing the setting already
-                sed --in-place "/${setting}=.*/d" "${NEO4J_HOME}"/conf/neo4j.conf
+                sed --in-place "/^${setting}=.*/d" "${NEO4J_HOME}"/conf/neo4j.conf
             fi
             # Then always append setting to file
             echo "${setting}=${value}" >> "${NEO4J_HOME}"/conf/neo4j.conf

--- a/src/3.4/docker-entrypoint.sh
+++ b/src/3.4/docker-entrypoint.sh
@@ -195,7 +195,7 @@ for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
         if [[ ! "${setting}" =~ ^[0-9]+.*$ ]]; then
             if grep -q -F "${setting}=" "${NEO4J_HOME}"/conf/neo4j.conf; then
                 # Remove any lines containing the setting already
-                sed --in-place "/${setting}=.*/d" "${NEO4J_HOME}"/conf/neo4j.conf
+                sed --in-place "/^${setting}=.*/d" "${NEO4J_HOME}"/conf/neo4j.conf
             fi
             # Then always append setting to file
             echo "${setting}=${value}" >> "${NEO4J_HOME}"/conf/neo4j.conf

--- a/src/3.5/docker-entrypoint.sh
+++ b/src/3.5/docker-entrypoint.sh
@@ -195,7 +195,7 @@ for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
         if [[ ! "${setting}" =~ ^[0-9]+.*$ ]]; then
             if grep -q -F "${setting}=" "${NEO4J_HOME}"/conf/neo4j.conf; then
                 # Remove any lines containing the setting already
-                sed --in-place "/${setting}=.*/d" "${NEO4J_HOME}"/conf/neo4j.conf
+                sed --in-place "/^${setting}=.*/d" "${NEO4J_HOME}"/conf/neo4j.conf
             fi
             # Then always append setting to file
             echo "${setting}=${value}" >> "${NEO4J_HOME}"/conf/neo4j.conf


### PR DESCRIPTION
This PR fixes issue #156.

Proposed solution: when removing pre-existing keys in neo4j.conf start search a begin of line.