### PR TITLE
Docker entrypoint should not chmod or chown folders

### DIFF
--- a/src/3.5/Dockerfile
+++ b/src/3.5/Dockerfile
@@ -22,14 +22,13 @@ RUN apk add --no-cache --quiet \
     && rm ${NEO4J_TARBALL} \
     && mv "${NEO4J_HOME}"/data /data \
     && chown -R neo4j:neo4j /data \
-    && chmod -R 777 /data \
     && mv "${NEO4J_HOME}"/logs /logs \
     && chown -R neo4j:neo4j /logs \
-    && chmod -R 777 /logs \
     && chown -R neo4j:neo4j "${NEO4J_HOME}" \
-    && chmod -R 777 "${NEO4J_HOME}" \
     && ln -s /data "${NEO4J_HOME}"/data \
     && ln -s /logs "${NEO4J_HOME}"/logs \
+    && for _dir in "/data /logs $NEO4J_HOME";do find ${_dir} -type d -exec chmod 750 {} ";";done \
+    && for _dir in "/data /logs";do find ${_dir} -type f -exec chmod 640 {} ";";done \
     && apk del curl
 
 ENV PATH "${NEO4J_HOME}"/bin:$PATH

--- a/src/3.5/Dockerfile
+++ b/src/3.5/Dockerfile
@@ -25,9 +25,10 @@ RUN apk add --no-cache --quiet \
     && mv "${NEO4J_HOME}"/logs /logs \
     && chown -R neo4j:neo4j /logs \
     && chown -R neo4j:neo4j "${NEO4J_HOME}" \
+    && chmod -R 777 "${NEO4J_HOME}" \
     && ln -s /data "${NEO4J_HOME}"/data \
     && ln -s /logs "${NEO4J_HOME}"/logs \
-    && for _dir in "/data /logs $NEO4J_HOME";do find ${_dir} -type d -exec chmod 750 {} ";";done \
+    && for _dir in "/data /logs";do find ${_dir} -type d -exec chmod 750 {} ";";done \
     && for _dir in "/data /logs";do find ${_dir} -type f -exec chmod 640 {} ";";done \
     && apk del curl
 

--- a/src/3.5/docker-entrypoint.sh
+++ b/src/3.5/docker-entrypoint.sh
@@ -35,7 +35,6 @@ FAIL_MESSAGE
 )
 
 function check_write_or_fail (){
-  id
   _directory=${1}
   if [ -d "${_directory}" ]; then :;else
     echo >&2 "Not a directory: ${_directory}"
@@ -43,10 +42,10 @@ function check_write_or_fail (){
   fi
 
   if running_as_root; then
-    CHECKFILE=$(su -s /bin/bash ${userid} -c "mktemp ${_directory}/output.XXXXXXXXXX") || { echo >&2 ${_directory} ${fail_message}; exit 1;}
+    CHECKFILE=$(su -s /bin/bash ${userid} -c "mktemp ${_directory}/output.XXXXXXXXXX") || { echo -e >&2 "\n${_directory} ${fail_message}"; exit 1;}
     rm ${CHECKFILE}
   else
-    CHECKFILE=$(/bin/bash -c "mktemp ${_directory}/output.XXXXXXXXXX") || { echo >&2 ${_directory} ${fail_message}; exit 1;}
+    CHECKFILE=$(/bin/bash -c "mktemp ${_directory}/output.XXXXXXXXXX") || { echo -e >&2 "\n${_directory} ${fail_message}"; exit 1;}
     rm ${CHECKFILE}
   fi
 }
@@ -210,7 +209,8 @@ for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
     fi
 done
 
-for _dir in 'ssl plugins logs import data logs'; do
+directories_to_check="ssl plugins logs import data logs"
+for _dir in $directories_to_check; do
   if [ -d "/${_dir}" ]; then
       check_write_or_fail "/${_dir}"
   fi

--- a/src/3.5/docker-entrypoint.sh
+++ b/src/3.5/docker-entrypoint.sh
@@ -24,37 +24,42 @@ readonly userid
 readonly groupid
 readonly exec_cmd
 
-# Need to chown the home directory - but a user might have mounted a
-# volume here (notably a conf volume). So take care not to chown
-# volumes (stuff not owned by neo4j)
-if running_as_root; then
-  # Non-recursive chown for the base directory
-  chown "${userid}":"${groupid}" "${NEO4J_HOME}"
-  chmod 700 "${NEO4J_HOME}"
+fail_message=$(cat <<FAIL_MESSAGE
+in container not writable for user: ${userid} or group ${groupid}, this looks like a rights issue
+
+Hint to solve the issue:
+chown -R ${userid}:${groupid} /path/to/mount_dir
+sudo find /path/to/mount_dir -type d -exec chmod 750 {} ";"
+sudo find /path/to/mount_dir -type f -exec chmod 640 {} ";"
+FAIL_MESSAGE
+)
+
+function check_write_or_fail (){
+  id
+  _directory=${1}
+  if [ -d "${_directory}" ]; then :;else
+    echo >&2 "Not a directory: ${_directory}"
+    exit 1
+  fi
+
+  if running_as_root; then
+    CHECKFILE=$(su -s /bin/bash ${userid} -c "mktemp ${_directory}/output.XXXXXXXXXX") || { echo >&2 ${_directory} ${fail_message}; exit 1;}
+    rm ${CHECKFILE}
+  else
+    CHECKFILE=$(/bin/bash -c "mktemp ${_directory}/output.XXXXXXXXXX") || { echo >&2 ${_directory} ${fail_message}; exit 1;}
+    rm ${CHECKFILE}
+  fi
+}
+
+check_write_or_fail "${NEO4J_HOME}"
+
+if [ "${cmd}" == "dump-config" ]; then
+  check_write_or_fail "/conf"
+  ${exec_cmd} cp --recursive "${NEO4J_HOME}"/conf/* /conf
+  exit 0
 fi
 
-while IFS= read -r -d '' dir
-do
-  if running_as_root && [[ "$(stat -c %U "${dir}")" = "neo4j" ]]; then
-    # Using mindepth 1 to avoid the base directory here so recursive is OK
-    chown -R "${userid}":"${groupid}" "${dir}"
-    chmod -R 700 "${dir}"
-  fi
-done <   <(find "${NEO4J_HOME}" -type d -mindepth 1 -maxdepth 1 -print0)
-
-# Data dir is chowned later
-
-if [[ "${cmd}" != *"neo4j"* ]]; then
-  if [ "${cmd}" == "dump-config" ]; then
-    if [ -d /conf ]; then
-      ${exec_cmd} cp --recursive "${NEO4J_HOME}"/conf/* /conf
-      exit 0
-    else
-      echo >&2 "You must provide a /conf volume"
-      exit 1
-    fi
-  fi
-else
+if [[ "${cmd}" == *"neo4j"* ]]; then
   # Only prompt for license agreement if command contains "neo4j" in it
   if [ "$NEO4J_EDITION" == "enterprise" ]; then
     if [ "${NEO4J_ACCEPT_LICENSE_AGREEMENT:=no}" != "yes" ]; then
@@ -205,30 +210,11 @@ for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
     fi
 done
 
-# Chown the data dir now that (maybe) an initial password has been
-# set (this is a file in the data dir)
-if running_as_root; then
-  chmod -R 777 /data
-  chown -R "${userid}":"${groupid}" /data
-fi
-
-# if we're running as root and the logs directory is not writable by the neo4j user, then chown it.
-# this situation happens if no user is passed to docker run and the /logs directory is mounted.
-if running_as_root && [[ "$(stat -c %U /logs)" != "neo4j" ]]; then
-#if [[ $(stat -c %u /logs) != $(id -u "${userid}") ]]; then
-    echo "/logs directory is not writable. Changing the directory owner to ${userid}:${groupid}"
-    # chown the log dir if it's not writable
-    chmod -R 777 /logs
-    chown -R "${userid}":"${groupid}" /logs
-fi
-
-# If we're running as a non-default user and we can't write to the logs directory then user needs to change directory permissions manually.
-# This happens if a user is passed to docker run and an unwritable log directory is mounted.
-if ! running_as_root && [[ ! -w /logs ]]; then
-    echo "User does not have write permissions to mounted log directory."
-    echo "Manually grant write permissions for the directory and try again."
-    exit 1
-fi
+for _dir in 'ssl plugins logs import data logs'; do
+  if [ -d "/${_dir}" ]; then
+      check_write_or_fail "/${_dir}"
+  fi
+done
 
 [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
 

--- a/src/3.5/docker-entrypoint.sh
+++ b/src/3.5/docker-entrypoint.sh
@@ -182,7 +182,7 @@ if [ "${cmd}" == "neo4j" ]; then
             exit 1
         fi
         # Will exit with error if users already exist (and print a message explaining that)
-        bin/neo4j-admin set-initial-password "${password}" || true
+        su -c "bin/neo4j-admin set-initial-password '${password}'" -s /bin/sh ${userid} || true
     elif [ -n "${NEO4J_AUTH:-}" ]; then
         echo >&2 "Invalid value for NEO4J_AUTH: '${NEO4J_AUTH}'"
         exit 1

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -90,7 +90,7 @@ docker_run_with_volume() {
   trap "docker_cleanup ${cid}" EXIT
 }
 
-docker_run_with_volume_and_user() {
+docker_run_with_data_and_logs_volumes_and_user() {
   local l_image="$1" l_cname="$2" l_volume="$3" l_user="$4"; shift; shift; shift; shift
 
   local envs=()
@@ -101,7 +101,11 @@ docker_run_with_volume_and_user() {
     envs+=("--env=${env}")
   done
   local cid
-  cid="$(docker run --detach "${envs[@]}" --name="${l_cname}" --volume="${l_volume}" --user="${l_user}" "${l_image}")"
+  cid="$(docker run --detach "${envs[@]}" --name="${l_cname}" \
+  --volume="${l_volume}"/data:/data \
+  --volume="${l_volume}"/logs:/logs \
+  --user="${l_user}" \
+  "${l_image}")"
   echo "log: tmp/out/${cid}.log"
   trap "docker_cleanup ${cid}" EXIT
 }

--- a/test/test-starts-up-with-data-and-log-volumes
+++ b/test/test-starts-up-with-data-and-log-volumes
@@ -34,6 +34,11 @@ readonly series="$2"
 readonly cname="neo4j-$(uuidgen)"
 
 readonly data_and_logs_dir=$(mktemp --directory)
+mkdir -p ${data_and_logs_dir}/data
+mkdir -p ${data_and_logs_dir}/logs
+sudo chown -R 100:100 ${data_and_logs_dir}
+sudo find ${data_and_logs_dir} -type d -exec chmod 750 {} ";"
+sudo find ${data_and_logs_dir} -type f -exec chmod 640 {} ";"
 GID="$(gid_of "${data_and_logs_dir}")"
 readonly GID
 

--- a/test/test-starts-up-with-data-volume-and-user
+++ b/test/test-starts-up-with-data-volume-and-user
@@ -10,7 +10,7 @@ readonly cname="neo4j-$(uuidgen)"
 readonly data_and_logs_dir=$(mktemp --directory)
 mkdir -p ${data_and_logs_dir}/data
 mkdir -p ${data_and_logs_dir}/logs
-sudo chown -R 100:100 ${data_and_logs_dir}
+sudo chown -R "$(id -u):$(id -g)" ${data_and_logs_dir}
 sudo find ${data_and_logs_dir} -type d -exec chmod 750 {} ";"
 sudo find ${data_and_logs_dir} -type f -exec chmod 640 {} ";"
 GID="$(gid_of "${data_and_logs_dir}")"
@@ -36,4 +36,4 @@ do
     echo >&2 Unexpected GID of "${file}" after running with mounted data volume: "$(gid_of "${file}")" != "${GID}"
     exit 1
   fi
-done <   <(find "${datadir}" -print0)
+done <   <(find "${data_and_logs_dir}" -print0)

--- a/test/test-starts-up-with-data-volume-and-user
+++ b/test/test-starts-up-with-data-volume-and-user
@@ -7,11 +7,16 @@ readonly image="$1"
 readonly series="$2"
 readonly cname="neo4j-$(uuidgen)"
 
-readonly datadir=$(mktemp --directory)
-GID="$(gid_of "${datadir}")"
+readonly data_and_logs_dir=$(mktemp --directory)
+mkdir -p ${data_and_logs_dir}/data
+mkdir -p ${data_and_logs_dir}/logs
+sudo chown -R 100:100 ${data_and_logs_dir}
+sudo find ${data_and_logs_dir} -type d -exec chmod 750 {} ";"
+sudo find ${data_and_logs_dir} -type f -exec chmod 640 {} ";"
+GID="$(gid_of "${data_and_logs_dir}")"
 readonly GID
 
-docker_run_with_volume_and_user "$image" "$cname" "${datadir}:/data" "$(id -u):$(id -g)" "NEO4J_AUTH=none"
+docker_run_with_data_and_logs_volumes_and_user "$image" "$cname" "${data_and_logs_dir}" "$(id -u):$(id -g)" "NEO4J_AUTH=none"
 readonly ip="$(docker_ip "${cname}")"
 neo4j_wait "${ip}"
 

--- a/test/test-starts-up-with-data-volume-default-user
+++ b/test/test-starts-up-with-data-volume-default-user
@@ -8,6 +8,9 @@ readonly series="$2"
 readonly cname="neo4j-$(uuidgen)"
 
 readonly datadir=$(mktemp --directory)
+sudo chown -R 100:100 ${datadir}
+sudo find ${datadir} -type d -exec chmod 750 {} ";"
+sudo find ${datadir} -type f -exec chmod 640 {} ";"
 GID="$(gid_of "${datadir}")"
 readonly GID
 


### PR DESCRIPTION
This PR should solve permission issues with mounted folders.
The idea is that the provider of the mount is responsible for correct permissions for the docker image.

The entrypoint should check the correctness of the used mounts and give correct pointers to the user to help if there are missing permissions.

This PR should solve #164