### PR TITLE
Fixing permission errors, fixed password bug with default user

### DIFF
--- a/src/3.3/Dockerfile
+++ b/src/3.3/Dockerfile
@@ -1,12 +1,12 @@
 FROM openjdk:8-jre-alpine
 
-RUN addgroup -S neo4j && adduser -S -H -h /var/lib/neo4j -G neo4j neo4j
-
 ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \
     NEO4J_EDITION=%%NEO4J_EDITION%% \
     NEO4J_HOME="/var/lib/neo4j"
 ARG NEO4J_URI=%%NEO4J_DIST_SITE%%/%%NEO4J_TARBALL%%
+
+RUN addgroup -S neo4j && adduser -S -H -h "${NEO4J_HOME}" -G neo4j neo4j
 
 COPY ./local-package/* /tmp/
 
@@ -21,9 +21,9 @@ RUN apk add --no-cache --quiet \
     && mv /var/lib/neo4j-* "${NEO4J_HOME}" \
     && rm ${NEO4J_TARBALL} \
     && mv "${NEO4J_HOME}"/data /data \
+    && mv "${NEO4J_HOME}"/logs /logs \
     && chown -R neo4j:neo4j /data \
     && chmod -R 777 /data \
-    && mv "${NEO4J_HOME}"/logs /logs \
     && chown -R neo4j:neo4j /logs \
     && chmod -R 777 /logs \
     && chown -R neo4j:neo4j "${NEO4J_HOME}" \

--- a/src/3.4/Dockerfile
+++ b/src/3.4/Dockerfile
@@ -1,12 +1,12 @@
 FROM openjdk:8-jre-alpine
 
-RUN addgroup -S neo4j && adduser -S -H -h /var/lib/neo4j -G neo4j neo4j
-
 ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \
     NEO4J_EDITION=%%NEO4J_EDITION%% \
     NEO4J_HOME="/var/lib/neo4j"
 ARG NEO4J_URI=%%NEO4J_DIST_SITE%%/%%NEO4J_TARBALL%%
+
+RUN addgroup -S neo4j && adduser -S -H -h "${NEO4J_HOME}" -G neo4j neo4j
 
 COPY ./local-package/* /tmp/
 
@@ -21,9 +21,9 @@ RUN apk add --no-cache --quiet \
     && mv /var/lib/neo4j-* "${NEO4J_HOME}" \
     && rm ${NEO4J_TARBALL} \
     && mv "${NEO4J_HOME}"/data /data \
+    && mv "${NEO4J_HOME}"/logs /logs \
     && chown -R neo4j:neo4j /data \
     && chmod -R 777 /data \
-    && mv "${NEO4J_HOME}"/logs /logs \
     && chown -R neo4j:neo4j /logs \
     && chmod -R 777 /logs \
     && chown -R neo4j:neo4j "${NEO4J_HOME}" \

--- a/src/3.4/docker-entrypoint.sh
+++ b/src/3.4/docker-entrypoint.sh
@@ -7,6 +7,76 @@ function running_as_root
     test "$(id -u)" = "0"
 }
 
+function is_not_writable
+{
+    _file=${1}
+#    echo "File ${_file} owner stats: $(stat -c %U ${_file}):$(stat -c %G ${_file}) and $(stat -c %u ${_file}):$(stat -c %g ${_file})"
+#    echo "comparing to ${userid}:${groupid}"
+    test "$(stat -c %U ${_file})" != "${userid}"  &&  \
+    test "$(stat -c %u ${_file})" != "${userid}"
+}
+
+function print_permissions_advice_and_fail ()
+{
+    _directory=${1}
+    echo >&2 "
+Folder ${_directory} is not writable for user: ${userid} or group ${groupid}, this is commonly a file permissions issue on the mounted folder.
+
+Hints to solve the issue:
+1) Make sure the folder exists before mounting it. Docker will create the folder using root permissions before starting the Neo4j container. The root permissions disallow Neo4j from writing to the mounted folder.
+2) Pass the folder owner's user ID and group ID to docker run, so that docker runs as that user.
+If the folder is owned by the current user, this can be done by adding this flag to your docker run command:
+  --user=\$(id -u):\$(id -g)
+       "
+    exit 1
+}
+
+function check_mounted_folder
+{
+    _directory=${1}
+    if is_not_writable "${_directory}"; then
+        print_permissions_advice_and_fail "${_directory}"
+    fi
+}
+
+function check_mounted_folder_with_chown
+{
+# The /data and /log directory are a bit different because they are very likely to be mounted by the user but not
+# necessarily writable.
+# This depends on whether a user ID is passed to the container and which folders are mounted.
+#
+#   No user ID passed to container:
+#   1) No folders are mounted.
+#      The /data and /log folder are owned by neo4j by default, so should be writable already.
+#   2) Both /log and /data are mounted.
+#      This means on start up, /data and /logs are owned by an unknown user and we should chown them to neo4j for
+#      backwards compatibility.
+#
+#   User ID passed to container:
+#   1) Both /data and /logs are mounted
+#      The /data and /logs folders are owned by an unknown user but we *should* have rw permission to them.
+#      That should be verified and error (helpfully) if not.
+#   2) User mounts /data or /logs *but not both*
+#      The  unmounted folder is still owned by neo4j, which should already be writable. The mounted folder should
+#      have rw permissions through user id. This should be verified.
+#   4) No folders are mounted.
+#      The /data and /log folder are owned by neo4j by default, and these are already writable by the user.
+#      (This is a very unlikely use case).
+
+    mountFolder=${1}
+    if running_as_root; then
+        if is_not_writable "${mountFolder}"; then
+            # warn that we're about to chown the /data folder and then chown it
+            echo >&2 "Warning: Folder mounted to \"${mountFolder}\" is not writable from inside container. Changing folder owner to ${userid}."
+            chown -R "${userid}":"${groupid}" "${mountFolder}"
+        fi
+    else
+        if [ ! -w "${mountFolder}" ]  && [[ "$(stat -c %U ${mountFolder})" != "neo4j" ]]; then
+            print_permissions_advice_and_fail "${mountFolder}"
+        fi
+    fi
+}
+
 # If we're running as root, then run as the neo4j user. Otherwise
 # docker is running with --user and we simply use that user.  Note
 # that su-exec, despite its name, does not replicate the functionality
@@ -28,40 +98,27 @@ readonly exec_cmd
 # volume here (notably a conf volume). So take care not to chown
 # volumes (stuff not owned by neo4j)
 if running_as_root; then
-  # Non-recursive chown for the base directory
-  chown "${userid}":"${groupid}" "${NEO4J_HOME}"
-  chmod 700 "${NEO4J_HOME}"
+    # Non-recursive chown for the base directory
+    chown "${userid}":"${groupid}" "${NEO4J_HOME}"
+    chmod 700 "${NEO4J_HOME}"
+    find "${NEO4J_HOME}" -type d -mindepth 1 -maxdepth 1 -user root -exec chown -R ${userid}:${groupid} {} \;
+    find "${NEO4J_HOME}" -type d -mindepth 1 -maxdepth 1 -user root -exec chmod 700 {} \;
 fi
 
-while IFS= read -r -d '' dir
-do
-  if running_as_root && [[ "$(stat -c %U "${dir}")" = "neo4j" ]]; then
-    # Using mindepth 1 to avoid the base directory here so recursive is OK
-    chown -R "${userid}":"${groupid}" "${dir}"
-    chmod -R 700 "${dir}"
-  fi
-done <   <(find "${NEO4J_HOME}" -type d -mindepth 1 -maxdepth 1 -print0)
+if [ "${cmd}" == "dump-config" ]; then
+  check_mounted_folder "/conf"
+  ${exec_cmd} cp --recursive "${NEO4J_HOME}"/conf/* /conf
+  exit 0
+fi
 
-# Data dir is chowned later
-
-if [[ "${cmd}" != *"neo4j"* ]]; then
-  if [ "${cmd}" == "dump-config" ]; then
-    if [ -d /conf ]; then
-      ${exec_cmd} cp --recursive "${NEO4J_HOME}"/conf/* /conf
-      exit 0
-    else
-      echo >&2 "You must provide a /conf volume"
-      exit 1
-    fi
-  fi
-else
+if [[ "${cmd}" == *"neo4j"* ]]; then
   # Only prompt for license agreement if command contains "neo4j" in it
-  if [ "$NEO4J_EDITION" == "enterprise" ]; then
+  if [ "${NEO4J_EDITION}" == "enterprise" ]; then
     if [ "${NEO4J_ACCEPT_LICENSE_AGREEMENT:=no}" != "yes" ]; then
       echo >&2 "
 In order to use Neo4j Enterprise Edition you must accept the license agreement.
 
-(c) Network Engine for Objects in Lund AB.  2017.  All Rights Reserved.
+(c) Neo4j Sweden AB.  2019.  All Rights Reserved.
 Use of this Software without a proper commercial license with Neo4j,
 Inc. or its affiliates is prohibited.
 
@@ -144,28 +201,39 @@ unset NEO4J_dbms_txLog_rotation_retentionPolicy NEO4J_UDC_SOURCE \
 : ${NEO4J_causal__clustering_raft__advertised__address:=$(hostname):7000}
 
 if [ -d /conf ]; then
+    check_mounted_folder "/conf"
     find /conf -type f -exec cp {} "${NEO4J_HOME}"/conf \;
 fi
 
 if [ -d /ssl ]; then
+    check_mounted_folder "/ssl"
     NEO4J_dbms_directories_certificates="/ssl"
 fi
 
 if [ -d /plugins ]; then
+    check_mounted_folder "/plugins"
     NEO4J_dbms_directories_plugins="/plugins"
 fi
 
-if [ -d /logs ]; then
-    NEO4J_dbms_directories_logs="/logs"
-fi
-
 if [ -d /import ]; then
+    check_mounted_folder "/import"
     NEO4J_dbms_directories_import="/import"
 fi
 
 if [ -d /metrics ]; then
+    check_mounted_folder "/metrics"
     NEO4J_dbms_directories_metrics="/metrics"
 fi
+
+if [ -d /logs ]; then
+    check_mounted_folder_with_chown "/logs"
+    NEO4J_dbms_directories_logs="/logs"
+fi
+
+if [ -d /data ]; then
+    check_mounted_folder_with_chown "/data"
+fi
+
 
 # set the neo4j initial password only if you run the database server
 if [ "${cmd}" == "neo4j" ]; then
@@ -177,8 +245,16 @@ if [ "${cmd}" == "neo4j" ]; then
             echo >&2 "Invalid value for password. It cannot be 'neo4j', which is the default."
             exit 1
         fi
+
+        if running_as_root; then
+            # running set-initial-password as root will create subfolders to /data as root, causing startup fail when neo4j can't read or write the /data/dbms folder
+            # creating the folder first will avoid that
+            mkdir -p /data/dbms
+            chown "${userid}":"${groupid}" /data/dbms
+        fi
         # Will exit with error if users already exist (and print a message explaining that)
-        bin/neo4j-admin set-initial-password "${password}" || true
+        # we probably don't want the message though, since it throws an error message on restarting the container.
+        neo4j-admin set-initial-password "${password}" 2>/dev/null || true
     elif [ -n "${NEO4J_AUTH:-}" ]; then
         echo >&2 "Invalid value for NEO4J_AUTH: '${NEO4J_AUTH}'"
         exit 1
@@ -205,30 +281,6 @@ for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
     fi
 done
 
-# Chown the data dir now that (maybe) an initial password has been
-# set (this is a file in the data dir)
-if running_as_root; then
-  chmod -R 777 /data
-  chown -R "${userid}":"${groupid}" /data
-fi
-
-# if we're running as root and the logs directory is not writable by the neo4j user, then chown it.
-# this situation happens if no user is passed to docker run and the /logs directory is mounted.
-if running_as_root && [[ "$(stat -c %U /logs)" != "neo4j" ]]; then
-#if [[ $(stat -c %u /logs) != $(id -u "${userid}") ]]; then
-    echo "/logs directory is not writable. Changing the directory owner to ${userid}:${groupid}"
-    # chown the log dir if it's not writable
-    chmod -R 777 /logs
-    chown -R "${userid}":"${groupid}" /logs
-fi
-
-# If we're running as a non-default user and we can't write to the logs directory then user needs to change directory permissions manually.
-# This happens if a user is passed to docker run and an unwritable log directory is mounted.
-if ! running_as_root && [[ ! -w /logs ]]; then
-    echo "User does not have write permissions to mounted log directory."
-    echo "Manually grant write permissions for the directory and try again."
-    exit 1
-fi
 
 [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
 

--- a/src/3.5/Dockerfile
+++ b/src/3.5/Dockerfile
@@ -42,6 +42,5 @@ COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 EXPOSE 7474 7473 7687
 
-#USER neo4j:neo4j
 ENTRYPOINT ["/sbin/tini", "-g", "--", "/docker-entrypoint.sh"]
 CMD ["neo4j"]

--- a/src/3.5/Dockerfile
+++ b/src/3.5/Dockerfile
@@ -22,12 +22,12 @@ RUN apk add --no-cache --quiet \
     && rm ${NEO4J_TARBALL} \
     && mv "${NEO4J_HOME}"/data /data \
     && mv "${NEO4J_HOME}"/logs /logs \
-    && chown -R neo4j:neo4j "${NEO4J_HOME}" \
-    && chmod -R 777 "${NEO4J_HOME}" \
     && chown -R neo4j:neo4j /data \
     && chmod -R 777 /data \
     && chown -R neo4j:neo4j /logs \
     && chmod -R 777 /logs \
+    && chown -R neo4j:neo4j "${NEO4J_HOME}" \
+    && chmod -R 777 "${NEO4J_HOME}" \
     && ln -s /data "${NEO4J_HOME}"/data \
     && ln -s /logs "${NEO4J_HOME}"/logs \
     && apk del curl
@@ -42,5 +42,6 @@ COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 EXPOSE 7474 7473 7687
 
-#ENTRYPOINT ["/sbin/tini", "-g", "--", "/docker-entrypoint.sh"]
-#CMD ["neo4j"]
+#USER neo4j:neo4j
+ENTRYPOINT ["/sbin/tini", "-g", "--", "/docker-entrypoint.sh"]
+CMD ["neo4j"]

--- a/src/3.5/Dockerfile
+++ b/src/3.5/Dockerfile
@@ -1,12 +1,12 @@
 FROM openjdk:8-jre-alpine
 
-RUN addgroup -S neo4j && adduser -S -H -h /var/lib/neo4j -G neo4j neo4j
-
 ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \
     NEO4J_EDITION=%%NEO4J_EDITION%% \
     NEO4J_HOME="/var/lib/neo4j"
 ARG NEO4J_URI=%%NEO4J_DIST_SITE%%/%%NEO4J_TARBALL%%
+
+RUN addgroup -S neo4j && adduser -S -H -h "${NEO4J_HOME}" -G neo4j neo4j
 
 COPY ./local-package/* /tmp/
 
@@ -21,15 +21,15 @@ RUN apk add --no-cache --quiet \
     && mv /var/lib/neo4j-* "${NEO4J_HOME}" \
     && rm ${NEO4J_TARBALL} \
     && mv "${NEO4J_HOME}"/data /data \
-    && chown -R neo4j:neo4j /data \
     && mv "${NEO4J_HOME}"/logs /logs \
-    && chown -R neo4j:neo4j /logs \
     && chown -R neo4j:neo4j "${NEO4J_HOME}" \
     && chmod -R 777 "${NEO4J_HOME}" \
+    && chown -R neo4j:neo4j /data \
+    && chmod -R 777 /data \
+    && chown -R neo4j:neo4j /logs \
+    && chmod -R 777 /logs \
     && ln -s /data "${NEO4J_HOME}"/data \
     && ln -s /logs "${NEO4J_HOME}"/logs \
-    && for _dir in "/data /logs";do find ${_dir} -type d -exec chmod 750 {} ";";done \
-    && for _dir in "/data /logs";do find ${_dir} -type f -exec chmod 640 {} ";";done \
     && apk del curl
 
 ENV PATH "${NEO4J_HOME}"/bin:$PATH
@@ -42,5 +42,5 @@ COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 EXPOSE 7474 7473 7687
 
-ENTRYPOINT ["/sbin/tini", "-g", "--", "/docker-entrypoint.sh"]
-CMD ["neo4j"]
+#ENTRYPOINT ["/sbin/tini", "-g", "--", "/docker-entrypoint.sh"]
+#CMD ["neo4j"]

--- a/src/3.5/docker-entrypoint.sh
+++ b/src/3.5/docker-entrypoint.sh
@@ -255,8 +255,17 @@ if [ "${cmd}" == "neo4j" ]; then
             echo >&2 "Invalid value for password. It cannot be 'neo4j', which is the default."
             exit 1
         fi
+
+        if running_as_root; then
+            # running set-initial-password as root will create subfolders to /data as root, causing startup fail when
+            # neo4j can't read or write the /data/dbms folders
+            # creating the folder first will avoid that
+            mkdir -p /data/dbms
+            chown "${userid}":"${groupid}" /data/dbms
+        fi
         # Will exit with error if users already exist (and print a message explaining that)
-        ${exec_cmd} bin/neo4j-admin set-initial-password "${password}" || true
+        # we probably don't want the message though?
+        neo4j-admin set-initial-password "${password}" 2>/dev/null || true
     elif [ -n "${NEO4J_AUTH:-}" ]; then
         echo >&2 "Invalid value for NEO4J_AUTH: '${NEO4J_AUTH}'"
         exit 1

--- a/src/3.5/docker-entrypoint.sh
+++ b/src/3.5/docker-entrypoint.sh
@@ -10,32 +10,71 @@ function running_as_root
 function is_not_writable
 {
     _file=${1}
-    echo "File ${_file} owner stats: $(stat -c %U ${_file}):$(stat -c %G ${_file}) and $(stat -c %u ${_file}):$(stat -c %g ${_file})"
-    echo "comparing to ${userid}:${groupid}"
+#    echo "File ${_file} owner stats: $(stat -c %U ${_file}):$(stat -c %G ${_file}) and $(stat -c %u ${_file}):$(stat -c %g ${_file})"
+#    echo "comparing to ${userid}:${groupid}"
     test "$(stat -c %U ${_file})" != "${userid}"  &&  \
     test "$(stat -c %u ${_file})" != "${userid}"
 }
 
-function check_write_or_fail ()
+function print_permissions_advice_and_fail ()
 {
-  _directory=${1}
-  if [[ ! -d "${_directory}" ]]; then
-    echo >&2 "Not a directory: ${_directory}"
-    exit 1
-  fi
+    _directory=${1}
+    echo >&2 "
+Folder ${_directory} is not writable for user: ${userid} or group ${groupid}, this is commonly a file permissions issue on the mounted folder.
 
-  if is_not_writable "${_directory}"; then
-       echo >&2 "
-Folder ${_directory} is not writable for user: ${userid} or group ${groupid}, this looks like a file permissions
-issue on the mounted folder.
-
-Hint to solve the issue:
-chown -R ${userid}:${groupid} /path/to/mount_dir
-sudo find /path/to/mount_dir -type d -exec chmod 750 {} \";\"
-sudo find /path/to/mount_dir -type f -exec chmod 640 {} \";\"
+Hints to solve the issue:
+1) Make sure the folder exists before mounting it. Docker will create the folder using root permissions before starting the Neo4j container. The root permissions disallow Neo4j from writing to the mounted folder.
+2) Pass the folder owner's user ID and group ID to docker run, so that docker runs as that user.
+This can be done by adding this flag to your docker run command:
+  --user=\$(id -u):\$(id -g)
        "
-       exit 1
-  fi
+    exit 1
+}
+
+function check_mounted_folder
+{
+    _directory=${1}
+    if is_not_writable "${_directory}"; then
+        print_permissions_advice_and_fail "${_directory}"
+    fi
+}
+
+function check_mounted_folder_with_chown
+{
+# The /data and /log directory are a bit different because they are very likely to be mounted by the user but not
+# necessarily writable.
+# This depends on whether a user ID is passed to the container and which folders are mounted.
+#
+#   No user ID passed to container:
+#   1) No folders are mounted.
+#      The /data and /log folder are owned by neo4j by default, so should be writable already.
+#   2) Both /log and /data are mounted.
+#      This means on start up, /data and /logs are owned by an unknown user and we should chown them to neo4j for
+#      backwards compatibility.
+#
+#   User ID passed to container:
+#   1) Both /data and /logs are mounted
+#      The /data and /logs folders are owned by an unknown user but we *should* have rw permission to them.
+#      That should be verified and error (helpfully) if not.
+#   2) User mounts /data or /logs *but not both*
+#      The  unmounted folder is still owned by neo4j, which should already be writable. The mounted folder should
+#      have rw permissions through user id. This should be verified.
+#   4) No folders are mounted.
+#      The /data and /log folder are owned by neo4j by default, and these are already writable by the user.
+#      (This is a very unlikely use case).
+
+    mountFolder=${1}
+    if running_as_root; then
+        if is_not_writable "${mountFolder}"; then
+            # warn that we're about to chown the /data folder and then chown it
+            echo >&2 "Warning: Folder mounted to \"${mountFolder}\" is not writable from inside container. Changing folder owner to ${userid}."
+            chown -R "${userid}":"${groupid}" "${mountFolder}"
+        fi
+    else
+        if [ ! -w "${mountFolder}" ]  && [[ "$(stat -c %U ${mountFolder})" != "neo4j" ]]; then
+            print_permissions_advice_and_fail "${mountFolder}"
+        fi
+    fi
 }
 
 # If we're running as root, then run as the neo4j user. Otherwise
@@ -59,25 +98,25 @@ readonly exec_cmd
 # volume here (notably a conf volume). So take care not to chown
 # volumes (stuff not owned by neo4j)
 if running_as_root; then
-  # Non-recursive chown for the base directory
-  chown "${userid}":"${groupid}" "${NEO4J_HOME}"
-  chmod 700 "${NEO4J_HOME}"
-    #  find "${NEO4J_HOME}" -type d -mindepth 1 -maxdepth 1 -exec chown -R ${userid}:${groupid} {} \;
-    #  find "${NEO4J_HOME}" -type d -mindepth 1 -maxdepth 1 -exec chmod 700 {} \;
+    # Non-recursive chown for the base directory
+    chown "${userid}":"${groupid}" "${NEO4J_HOME}"
+    chmod 700 "${NEO4J_HOME}"
+    find "${NEO4J_HOME}" -type d -mindepth 1 -maxdepth 1 -user root -exec chown -R ${userid}:${groupid} {} \;
+    find "${NEO4J_HOME}" -type d -mindepth 1 -maxdepth 1 -user root -exec chmod 700 {} \;
 fi
 
-while IFS= read -r -d '' dir
-do
-  if running_as_root && [[ "$(stat -c %U "${dir}")" = "neo4j" ]]; then
-    # Using mindepth 1 to avoid the base directory here so recursive is OK
-    chown -R "${userid}":"${groupid}" "${dir}"
-    chmod -R 700 "${dir}"
-  fi
-done <   <(find "${NEO4J_HOME}" -type d -mindepth 1 -maxdepth 1 -print0)
+#while IFS= read -r -d '' dir
+#do
+#  if running_as_root && [[ "$(stat -c %U "${dir}")" = "neo4j" ]]; then
+#    # Using mindepth 1 to avoid the base directory here so recursive is OK
+#    chown -R "${userid}":"${groupid}" "${dir}"
+#    chmod -R 700 "${dir}"
+#  fi
+#done <   <(find "${NEO4J_HOME}" -type d -mindepth 1 -maxdepth 1 -print0)
 
 
 if [ "${cmd}" == "dump-config" ]; then
-  check_write_or_fail "/conf"
+  check_mounted_folder "/conf"
   ${exec_cmd} cp --recursive "${NEO4J_HOME}"/conf/* /conf
   exit 0
 fi
@@ -172,46 +211,39 @@ unset NEO4J_dbms_txLog_rotation_retentionPolicy NEO4J_UDC_SOURCE \
 : ${NEO4J_causal__clustering_raft__advertised__address:=$(hostname):7000}
 
 if [ -d /conf ]; then
-    check_write_or_fail "/conf"
+    check_mounted_folder "/conf"
     find /conf -type f -exec cp {} "${NEO4J_HOME}"/conf \;
 fi
 
 if [ -d /ssl ]; then
-    check_write_or_fail "/ssl"
+    check_mounted_folder "/ssl"
     NEO4J_dbms_directories_certificates="/ssl"
 fi
 
 if [ -d /plugins ]; then
-    check_write_or_fail "/plugins"
+    check_mounted_folder "/plugins"
     NEO4J_dbms_directories_plugins="/plugins"
 fi
 
 if [ -d /import ]; then
-    check_write_or_fail "/import"
+    check_mounted_folder "/import"
     NEO4J_dbms_directories_import="/import"
 fi
 
 if [ -d /metrics ]; then
-    check_write_or_fail "/metrics"
+    check_mounted_folder "/metrics"
     NEO4J_dbms_directories_metrics="/metrics"
 fi
 
-if [ -d /data ]; then
-    if is_not_writable "/data"; then
-        # warn that we're about to chown the /data folder and then chown it
-        echo >&2 "Folder mounted to \"/data\" is not writable from inside container."
-        chown -R "${userid}":"${groupid}" /data
-    fi
+if [ -d /logs ]; then
+    check_mounted_folder_with_chown "/logs"
+    NEO4J_dbms_directories_logs="/logs"
 fi
 
-if [ -d /logs ]; then
-    NEO4J_dbms_directories_logs="/logs"
-    if is_not_writable "/logs"; then
-        # warn that we're about to chown the /data folder and then chown it
-        echo >&2 "Folder mounted to \"/logs\" is not writable from inside container."
-        chown -R "${userid}":"${groupid}" /logs
-    fi
+if [ -d /data ]; then
+    check_mounted_folder_with_chown "/data"
 fi
+
 
 # set the neo4j initial password only if you run the database server
 if [ "${cmd}" == "neo4j" ]; then

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -90,7 +90,7 @@ docker_run_with_volume() {
   trap "docker_cleanup ${cid}" EXIT
 }
 
-docker_run_with_data_and_logs_volumes_and_user() {
+docker_run_with_volume_and_user() {
   local l_image="$1" l_cname="$2" l_volume="$3" l_user="$4"; shift; shift; shift; shift
 
   local envs=()
@@ -101,11 +101,7 @@ docker_run_with_data_and_logs_volumes_and_user() {
     envs+=("--env=${env}")
   done
   local cid
-  cid="$(docker run --detach "${envs[@]}" --name="${l_cname}" \
-  --volume="${l_volume}"/data:/data \
-  --volume="${l_volume}"/logs:/logs \
-  --user="${l_user}" \
-  "${l_image}")"
+  cid="$(docker run --detach "${envs[@]}" --name="${l_cname}" --volume="${l_volume}" --user="${l_user}" "${l_image}")"
   echo "log: tmp/out/${cid}.log"
   trap "docker_cleanup ${cid}" EXIT
 }

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -232,7 +232,7 @@ gid_of() {
 
 check_mount_folder_owner_matches()
 {
-    readonly datadir=${1}
+    local mount_folder=${1}
     local expected_UID=${2}
     local expected_GID=${3}
     while IFS= read -r -d '' file
@@ -246,7 +246,7 @@ check_mount_folder_owner_matches()
         echo >&2 Unexpected GID of "${file}" after running with mounted data volume: "$(gid_of "${file}")" != "${expected_GID}"
         exit 1
       fi
-    done <   <(find "${datadir}" -print0)
+    done <   <(find "${mount_folder}" -print0)
 }
 
 check_mount_folder_owner_does_not_match()

--- a/test/test-can-change-workdir
+++ b/test/test-can-change-workdir
@@ -22,9 +22,4 @@ if [[ "${actual_work_dir}" != "${expected_work_dir}" ]]; then
     exit 1
 fi
 
-stderr="$((docker logs "${cname}" 1>/dev/null) 2>&1)"
-if [[ "${stderr}" != "" ]]; then
-    echo "Unexpected output from container:"
-    echo "${stderr}"
-    exit 1
-fi
+check_stderr_is_empty "${cname}"

--- a/test/test-dumps-config
+++ b/test/test-dumps-config
@@ -31,15 +31,4 @@ if [[ "${series}" == "2.3" ]] || [[ "${series}" == "3.0" ]]; then
   exit 0
 fi
 
-while IFS= read -r -d '' file
-do
-  if [[ "${UID}" != "$(uid_of "${file}")" ]]; then
-    echo >&2 Unexpected UID of "${file}" after dumping config: "$(uid_of "${file}")" != "${UID}"
-    exit 1
-  fi
-
-  if [[ "${GID}" != "$(gid_of "${file}")" ]]; then
-    echo >&2 Unexpected GID of "${file}" after dumping config: "$(gid_of "${file}")" != "${GID}"
-    exit 1
-  fi
-done <   <(find "${dir}" -print0)
+check_mount_folder_owner_matches "${dir}" "${UID}" "${GID}"

--- a/test/test-no-unexpected-errors
+++ b/test/test-no-unexpected-errors
@@ -12,9 +12,5 @@ docker_run "$image" "$cname" "NEO4J_AUTH=none"
 readonly ip="$(docker_ip "${cname}")"
 neo4j_wait "${ip}"
 
-stderr="$((docker logs "${cname}" 1>/dev/null) 2>&1)"
-if [[ "${stderr}" != "" ]]; then
-    echo "Unexpected output from container:"
-    echo "${stderr}"
-    exit 1
-fi
+# check no errors were printed to stderr
+check_stderr_is_empty "${cname}"

--- a/test/test-sets-password
+++ b/test/test-sets-password
@@ -5,6 +5,7 @@ set -o errexit -o nounset
 . "$(dirname "$0")/helpers.sh"
 
 readonly image="$1"
+readonly series="$2"
 readonly cname="neo4j-$(uuidgen)"
 
 docker_run_with_args "$image" "$cname" "--env=NEO4J_AUTH=neo4j/foo" "--user=$(id -u):$(id -g)"

--- a/test/test-sets-password
+++ b/test/test-sets-password
@@ -17,4 +17,9 @@ neo4j_wait "$(docker_ip "${cname}")" "neo4j:foo"
 neo4j_createnode "$(docker_ip "${cname}")" "neo4j:foo"
 
 # check no errors were printed to stderr
+if [[ "${series}" == "2.3" ]] || [[ "${series}" == "3.0" ]]  || [[ "${series}" == "3.1" ]] || [[ "${series}" == "3.2" ]]; then
+  echo "Skipping test for error message on change password"
+  exit 0
+fi
+
 check_stderr_is_empty "${cname}"

--- a/test/test-sets-password-default-user
+++ b/test/test-sets-password-default-user
@@ -7,7 +7,7 @@ set -o errexit -o nounset
 readonly image="$1"
 readonly cname="neo4j-$(uuidgen)"
 
-docker_run_with_args "$image" "$cname" "--env=NEO4J_AUTH=neo4j/foo" "--user=$(id -u):$(id -g)"
+docker_run "$image" "$cname" "NEO4J_AUTH=neo4j/foo"
 neo4j_wait "$(docker_ip "${cname}")" "neo4j:foo"
 neo4j_createnode "$(docker_ip "${cname}")" "neo4j:foo"
 

--- a/test/test-sets-password-default-user
+++ b/test/test-sets-password-default-user
@@ -5,6 +5,7 @@ set -o errexit -o nounset
 . "$(dirname "$0")/helpers.sh"
 
 readonly image="$1"
+readonly series="$2"
 readonly cname="neo4j-$(uuidgen)"
 
 docker_run "$image" "$cname" "NEO4J_AUTH=neo4j/foo"

--- a/test/test-sets-password-default-user
+++ b/test/test-sets-password-default-user
@@ -17,4 +17,8 @@ neo4j_wait "$(docker_ip "${cname}")" "neo4j:foo"
 neo4j_createnode "$(docker_ip "${cname}")" "neo4j:foo"
 
 # check no errors were printed to stderr
+if [[ "${series}" == "2.3" ]] || [[ "${series}" == "3.0" ]]  || [[ "${series}" == "3.1" ]] || [[ "${series}" == "3.2" ]]; then
+  echo "Skipping test for error message on change password"
+  exit 0
+fi
 check_stderr_is_empty "${cname}"

--- a/test/test-starts-up-with-data-and-log-volumes
+++ b/test/test-starts-up-with-data-and-log-volumes
@@ -21,15 +21,14 @@ docker_run_with_data_and_logs_volumes() {
     envs+=("--env=${env}")
   done
   #local user
-  #user="$(stat -c %u $l_volumedir):$(stat -c %g $l_volumedir)"
-  echo "temp folder $l_volumedir owned by $(stat -c %u $l_volumedir):$(stat -c %g $l_volumedir)"
-  echo "test running as $(id -u):$(id -g)"
+  mkdir "${data_and_logs_dir}"/data
+  mkdir "${data_and_logs_dir}"/logs
   local cid
   cid="$(docker run --detach "${envs[@]}" --name="${l_cname}" \
-  --user="$(id -u):$(id -g)" \
-  --volume="${l_volumedir}"/data:/data \
-  --volume="${l_volumedir}"/logs:/logs \
-  "${l_image}")"
+      --user="$(id -u):$(id -g)" \
+      --volume="${l_volumedir}"/data:/data \
+      --volume="${l_volumedir}"/logs:/logs \
+      "${l_image}")"
   echo "log: tmp/out/${cid}.log"
   trap "docker_cleanup ${cid}" EXIT
 }

--- a/test/test-starts-up-with-data-and-log-volumes
+++ b/test/test-starts-up-with-data-and-log-volumes
@@ -50,15 +50,4 @@ if [[ "${series}" == "2.3" ]] || [[ "${series}" == "3.0" ]]; then
   exit 0
 fi
 
-while IFS= read -r -d '' file
-do
-  if [[ "0" = "$(uid_of "${file}")" ]]; then
-    echo >&2 "Did not expect UID of ${file} to be root (0) after running with mounted data volume"
-    exit 1
-  fi
-
-  if [[ "$0" = "$(gid_of "${file}")" ]]; then
-    echo >&2 "Did not expect GID of ${file} to be root (0) after running with mounted data volume"
-    exit 1
-  fi
-done <   <(find "${data_and_logs_dir}" -print0)
+check_mount_folder_owner_does_not_match "${data_and_logs_dir}" "0" "$0"

--- a/test/test-starts-up-with-data-and-log-volumes-default-user
+++ b/test/test-starts-up-with-data-and-log-volumes-default-user
@@ -46,15 +46,4 @@ if [[ "${series}" == "2.3" ]] || [[ "${series}" == "3.0" ]]; then
   exit 0
 fi
 
-while IFS= read -r -d '' file
-do
-  if [[ "0" = "$(uid_of "${file}")" ]]; then
-    echo >&2 "Did not expect UID of ${file} to be root (0) after running with mounted data volume"
-    exit 1
-  fi
-
-  if [[ "$0" = "$(gid_of "${file}")" ]]; then
-    echo >&2 "Did not expect GID of ${file} to be root (0) after running with mounted data volume"
-    exit 1
-  fi
-done <   <(find "${data_and_logs_dir}" -print0)
+check_mount_folder_owner_does_not_match "${data_and_logs_dir}" "0" "$0"

--- a/test/test-starts-up-with-data-and-log-volumes-default-user
+++ b/test/test-starts-up-with-data-and-log-volumes-default-user
@@ -20,13 +20,8 @@ docker_run_with_data_and_logs_volumes() {
   for env in "$@"; do
     envs+=("--env=${env}")
   done
-  #local user
-  #user="$(stat -c %u $l_volumedir):$(stat -c %g $l_volumedir)"
-  echo "temp folder $l_volumedir owned by $(stat -c %u $l_volumedir):$(stat -c %g $l_volumedir)"
-  echo "test running as $(id -u):$(id -g)"
   local cid
   cid="$(docker run --detach "${envs[@]}" --name="${l_cname}" \
-  --user="$(id -u):$(id -g)" \
   --volume="${l_volumedir}"/data:/data \
   --volume="${l_volumedir}"/logs:/logs \
   "${l_image}")"

--- a/test/test-starts-up-with-data-volume-and-user
+++ b/test/test-starts-up-with-data-volume-and-user
@@ -7,16 +7,11 @@ readonly image="$1"
 readonly series="$2"
 readonly cname="neo4j-$(uuidgen)"
 
-readonly data_and_logs_dir=$(mktemp --directory)
-mkdir -p ${data_and_logs_dir}/data
-mkdir -p ${data_and_logs_dir}/logs
-sudo chown -R "$(id -u):$(id -g)" ${data_and_logs_dir}
-sudo find ${data_and_logs_dir} -type d -exec chmod 750 {} ";"
-sudo find ${data_and_logs_dir} -type f -exec chmod 640 {} ";"
-GID="$(gid_of "${data_and_logs_dir}")"
+readonly datadir=$(mktemp --directory)
+GID="$(gid_of "${datadir}")"
 readonly GID
 
-docker_run_with_data_and_logs_volumes_and_user "$image" "$cname" "${data_and_logs_dir}" "$(id -u):$(id -g)" "NEO4J_AUTH=none"
+docker_run_with_volume_and_user "$image" "$cname" "${datadir}:/data" "$(id -u):$(id -g)" "NEO4J_AUTH=none"
 readonly ip="$(docker_ip "${cname}")"
 neo4j_wait "${ip}"
 
@@ -36,4 +31,4 @@ do
     echo >&2 Unexpected GID of "${file}" after running with mounted data volume: "$(gid_of "${file}")" != "${GID}"
     exit 1
   fi
-done <   <(find "${data_and_logs_dir}" -print0)
+done <   <(find "${datadir}" -print0)

--- a/test/test-starts-up-with-data-volume-and-user
+++ b/test/test-starts-up-with-data-volume-and-user
@@ -8,6 +8,7 @@ readonly series="$2"
 readonly cname="neo4j-$(uuidgen)"
 
 readonly datadir=$(mktemp --directory)
+mkdir "${datadir}/data"
 GID="$(gid_of "${datadir}")"
 readonly GID
 

--- a/test/test-starts-up-with-data-volume-and-user
+++ b/test/test-starts-up-with-data-volume-and-user
@@ -21,15 +21,4 @@ if [[ "${series}" == "2.3" ]] || [[ "${series}" == "3.0" ]]; then
   exit 0
 fi
 
-while IFS= read -r -d '' file
-do
-  if [[ "${UID}" != "$(uid_of "${file}")" ]]; then
-    echo >&2 Unexpected UID of "${file}" after running with mounted data volume: "$(uid_of "${file}")" != "${UID}"
-    exit 1
-  fi
-
-  if [[ "${GID}" != "$(gid_of "${file}")" ]]; then
-    echo >&2 Unexpected GID of "${file}" after running with mounted data volume: "$(gid_of "${file}")" != "${GID}"
-    exit 1
-  fi
-done <   <(find "${datadir}" -print0)
+check_mount_folder_owner_matches "${datadir}" "$(id -u)" "${GID}"

--- a/test/test-starts-up-with-data-volume-default-user
+++ b/test/test-starts-up-with-data-volume-default-user
@@ -8,9 +8,6 @@ readonly series="$2"
 readonly cname="neo4j-$(uuidgen)"
 
 readonly datadir=$(mktemp --directory)
-sudo chown -R 100:100 ${datadir}
-sudo find ${datadir} -type d -exec chmod 750 {} ";"
-sudo find ${datadir} -type f -exec chmod 640 {} ";"
 GID="$(gid_of "${datadir}")"
 readonly GID
 
@@ -18,20 +15,23 @@ docker_run_with_volume "$image" "$cname" "${datadir}:/data" "NEO4J_AUTH=none"
 readonly ip="$(docker_ip "${cname}")"
 neo4j_wait "${ip}"
 
+#echo "changing permissions on test folder ${datadir} so it can be deleted"
+#sudo chmod -R 777 "${datadir}"
+
 if [[ "${series}" == "2.3" ]] || [[ "${series}" == "3.0" ]]; then
   echo "Skipping: UID checks, code not present pre-3.1"
   exit 0
 fi
 
-while IFS= read -r -d '' file
-do
-  if [[ "0" = "$(uid_of "${file}")" ]]; then
-    echo >&2 "Did not expect UID of ${file} to be root (0) after running with mounted data volume"
-    exit 1
-  fi
-
-  if [[ "$0" = "$(gid_of "${file}")" ]]; then
-    echo >&2 "Did not expect GID of ${file} to be root (0) after running with mounted data volume"
-    exit 1
-  fi
-done <   <(find "${datadir}" -print0)
+#while IFS= read -r -d '' file
+#do
+#  if [[ "0" = "$(uid_of "${file}")" ]]; then
+#    echo >&2 "Did not expect UID of ${file} to be root (0) after running with mounted data volume"
+#    exit 1
+#  fi
+#
+#  if [[ "$0" = "$(gid_of "${file}")" ]]; then
+#    echo >&2 "Did not expect GID of ${file} to be root (0) after running with mounted data volume"
+#    exit 1
+#  fi
+#done <   <(find "${datadir}" -print0)

--- a/test/test-starts-up-with-data-volume-default-user
+++ b/test/test-starts-up-with-data-volume-default-user
@@ -23,15 +23,16 @@ if [[ "${series}" == "2.3" ]] || [[ "${series}" == "3.0" ]]; then
   exit 0
 fi
 
-while IFS= read -r -d '' file
-do
-  if [[ "0" = "$(uid_of "${file}")" ]]; then
-    echo >&2 "Did not expect UID of ${file} to be root (0) after running with mounted data volume"
+# just check top level folder, since the rest is chowned to neo4j user so test cannot read it
+expected_UID="100"
+expected_GID="101"
+if [[ ${expected_UID} != "$(uid_of "${datadir}")" ]]; then
+    echo >&2 "Unexpected UID of "${datadir}" after running with mounted data volume: "$(uid_of "${datadir}")" != ${expected_UID}"
     exit 1
-  fi
+fi
 
-  if [[ "$0" = "$(gid_of "${file}")" ]]; then
-    echo >&2 "Did not expect GID of ${file} to be root (0) after running with mounted data volume"
+if [[ "${expected_GID}" != "$(gid_of "${datadir}")" ]]; then
+    echo >&2 "Unexpected GID of "${datadir}" after running with mounted data volume: "$(gid_of "${datadir}")" != "${expected_GID}""
     exit 1
-  fi
-done <   <(find "${datadir}" -print0)
+fi
+

--- a/test/test-starts-up-with-data-volume-default-user
+++ b/test/test-starts-up-with-data-volume-default-user
@@ -23,15 +23,15 @@ if [[ "${series}" == "2.3" ]] || [[ "${series}" == "3.0" ]]; then
   exit 0
 fi
 
-#while IFS= read -r -d '' file
-#do
-#  if [[ "0" = "$(uid_of "${file}")" ]]; then
-#    echo >&2 "Did not expect UID of ${file} to be root (0) after running with mounted data volume"
-#    exit 1
-#  fi
-#
-#  if [[ "$0" = "$(gid_of "${file}")" ]]; then
-#    echo >&2 "Did not expect GID of ${file} to be root (0) after running with mounted data volume"
-#    exit 1
-#  fi
-#done <   <(find "${datadir}" -print0)
+while IFS= read -r -d '' file
+do
+  if [[ "0" = "$(uid_of "${file}")" ]]; then
+    echo >&2 "Did not expect UID of ${file} to be root (0) after running with mounted data volume"
+    exit 1
+  fi
+
+  if [[ "$0" = "$(gid_of "${file}")" ]]; then
+    echo >&2 "Did not expect GID of ${file} to be root (0) after running with mounted data volume"
+    exit 1
+  fi
+done <   <(find "${datadir}" -print0)


### PR DESCRIPTION
- Stopped Neo4j from granting read/write permissions to *all* on mounted folders. It will still change the folder owner if the docker container is not started using the `--user` flag though (for backwards compatibility).
- Improved warning messages when mounting folders.
- Added helpful error message for when mounting folders fails, including troubleshooting tips.
- Refactored tests and added a few new test cases I encountered

includes PR #165 
Hopefully fixes:
#164 
#130 

As I was making changes I noticed a bug when setting passwords that occurs when running docker without `--user` flag. I fixed that too (hopefully). 
I believe this may also solve #147 and #163 