### PR TITLE
Switch to AdoptOpenJDK-based JVM base image

### DIFF
--- a/src/3.1/Dockerfile
+++ b/src/3.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine
+FROM adoptopenjdk/openjdk8:alpine-jre
 
 RUN addgroup -S neo4j && adduser -S -H -h /var/lib/neo4j -G neo4j neo4j
 

--- a/src/3.2/Dockerfile
+++ b/src/3.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine
+FROM adoptopenjdk/openjdk8:alpine-jre
 
 RUN addgroup -S neo4j && adduser -S -H -h /var/lib/neo4j -G neo4j neo4j
 

--- a/src/3.3/Dockerfile
+++ b/src/3.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine
+FROM adoptopenjdk/openjdk8:alpine-jre
 
 ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \

--- a/src/3.4/Dockerfile
+++ b/src/3.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine
+FROM adoptopenjdk/openjdk8:alpine-jre
 
 ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \

--- a/src/3.5/Dockerfile
+++ b/src/3.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine
+FROM adoptopenjdk/openjdk8:alpine-jre
 
 ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \


### PR DESCRIPTION
The background here is that - again - the Debian OpenJDK builds turn out
to have the wrong version numbers on them, with the package being
stamped as a java update that was released after the package was built.

See https://mail.openjdk.java.net/pipermail/jdk8u-dev/2019-May/009330.html

We don't use the Debian packages, we use Alpine, but inspecting the
provenance of the Alpine OpenJDK packaging, it seems to suffer from the same
issue. The current latest alpine OpenJDK has versioning that does not
seem to line up. At the very least, the source of those builds is of a
similar kind to Debian.

This moves our base image to images provided by AdoptOpenJDK, a well
regarded source of up-to-date OpenJDK builds. The base image remains
Alpine Linux.