### PR TITLE
Remove apt cache based on Dockerfile Best practices 

### DIFF
--- a/docker-image-src/3.3/Dockerfile
+++ b/docker-image-src/3.3/Dockerfile
@@ -31,7 +31,9 @@ RUN apt update \
     && chown -R neo4j:neo4j "${NEO4J_HOME}" \
     && chmod -R 777 "${NEO4J_HOME}" \
     && ln -s /data "${NEO4J_HOME}"/data \
-    && ln -s /logs "${NEO4J_HOME}"/logs
+    && ln -s /logs "${NEO4J_HOME}"/logs \
+    && rm -rf /tmp/* \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV PATH "${NEO4J_HOME}"/bin:$PATH
 

--- a/docker-image-src/3.4/Dockerfile
+++ b/docker-image-src/3.4/Dockerfile
@@ -31,7 +31,9 @@ RUN apt update \
     && chown -R neo4j:neo4j "${NEO4J_HOME}" \
     && chmod -R 777 "${NEO4J_HOME}" \
     && ln -s /data "${NEO4J_HOME}"/data \
-    && ln -s /logs "${NEO4J_HOME}"/logs
+    && ln -s /logs "${NEO4J_HOME}"/logs \
+    && rm -rf /tmp/* \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV PATH "${NEO4J_HOME}"/bin:$PATH
 

--- a/docker-image-src/3.5/Dockerfile
+++ b/docker-image-src/3.5/Dockerfile
@@ -31,7 +31,9 @@ RUN apt update \
     && chown -R neo4j:neo4j "${NEO4J_HOME}" \
     && chmod -R 777 "${NEO4J_HOME}" \
     && ln -s /data "${NEO4J_HOME}"/data \
-    && ln -s /logs "${NEO4J_HOME}"/logs
+    && ln -s /logs "${NEO4J_HOME}"/logs \
+    && rm -rf /tmp/* \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV PATH "${NEO4J_HOME}"/bin:$PATH
 


### PR DESCRIPTION
see https://docs.docker.com/develop/develop-images/dockerfile_best-practices/

prevents cache bugs and shaves a few percent of the docker image size.