### PR TITLE
can now set non-root user via envoriment variable.

### DIFF
--- a/src/test/java/com/neo4j/docker/TestCausalCluster.java
+++ b/src/test/java/com/neo4j/docker/TestCausalCluster.java
@@ -50,7 +50,7 @@ public class TestCausalCluster
         for (String line : contentLines) {
             editedLines[i] = line.replaceAll("%%IMAGE%%", TestSettings.IMAGE_ID);
             editedLines[i] = editedLines[i].replaceAll("%%LOGS_DIR%%", tmpDir.toAbsolutePath().toString());
-            editedLines[i] = editedLines[i].replaceAll("%%USERIDGROUPID%%", SetContainerUser.getCurrentlyRunningUserString());
+            editedLines[i] = editedLines[i].replaceAll("%%USERIDGROUPID%%", SetContainerUser.getNonRootUserString());
             i++;
         }
 

--- a/src/test/java/com/neo4j/docker/TestConfSettings.java
+++ b/src/test/java/com/neo4j/docker/TestConfSettings.java
@@ -16,7 +16,6 @@ import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -83,7 +82,7 @@ public class TestConfSettings
                 .withEnv( "NEO4J_dbms_memory_heap_max__size", "3000m" )
                 .withCommand( "echo running" );
         container.setWaitStrategy( null );
-        SetContainerUser.currentlyRunningUser( container );
+        SetContainerUser.nonRootUser( container );
         Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "conf-", "/var/lib/neo4j/conf" );
 
         container.start();
@@ -120,7 +119,7 @@ public class TestConfSettings
         //Mount /conf
         Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "conf-", "/conf" );
         Path logMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-", "/logs" );
-        SetContainerUser.currentlyRunningUser( container );
+        SetContainerUser.nonRootUser( container );
         //Create neo4j.conf file with the custom env variables
         Path confFile = Paths.get( "src", "test", "resources", "neo4j.conf" );
         Files.copy(confFile, confMount.resolve("neo4j.conf"));

--- a/src/test/java/com/neo4j/docker/TestHACluster.java
+++ b/src/test/java/com/neo4j/docker/TestHACluster.java
@@ -79,7 +79,7 @@ public class TestHACluster
         // read the HA compose file template and replace placeholders
         String composeContent = new String( Files.readAllBytes( composeTemplate ) );
         composeContent = composeContent
-                .replaceAll( "%%USERIDGROUPID%%", SetContainerUser.getCurrentlyRunningUserString() )
+                .replaceAll( "%%USERIDGROUPID%%", SetContainerUser.getNonRootUserString() )
                 .replaceAll( "%%IMAGE%%", TestSettings.IMAGE_ID )
                 .replaceAll( "%%LOGS_DIR%%", logDir.toAbsolutePath().toString() );
 

--- a/src/test/java/com/neo4j/docker/TestMounting.java
+++ b/src/test/java/com/neo4j/docker/TestMounting.java
@@ -40,6 +40,10 @@ public class TestMounting
 
     private Neo4jContainer setupBasicContainer( boolean asCurrentUser, boolean isSecurityFlagSet )
     {
+        log.info( "Running as user {}, {}",
+                  asCurrentUser?"non-root":"root",
+                  isSecurityFlagSet?"with secure file permissions":"with unsecured file permissions" );
+
         Neo4jContainer container = new Neo4jContainer( TestSettings.IMAGE_ID );
         container.withExposedPorts( 7474, 7687 )
                 .withLogConsumer( new Slf4jLogConsumer( log ) )
@@ -48,7 +52,7 @@ public class TestMounting
 
         if(asCurrentUser)
         {
-            SetContainerUser.currentlyRunningUser( container );
+            SetContainerUser.nonRootUser( container );
         }
         if(isSecurityFlagSet)
         {

--- a/src/test/java/com/neo4j/docker/TestPasswords.java
+++ b/src/test/java/com/neo4j/docker/TestPasswords.java
@@ -38,7 +38,7 @@ public class TestPasswords
 
         if(asCurrentUser.toLowerCase().equals( "true" ))
         {
-            SetContainerUser.currentlyRunningUser( container );
+            SetContainerUser.nonRootUser( container );
         }
 
         return container;

--- a/src/test/java/com/neo4j/docker/utils/SetContainerUser.java
+++ b/src/test/java/com/neo4j/docker/utils/SetContainerUser.java
@@ -2,26 +2,34 @@ package com.neo4j.docker.utils;
 
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.sun.security.auth.module.UnixSystem;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.Neo4jContainer;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Random;
+import java.lang.reflect.Parameter;
 import java.util.function.Consumer;
 
 public class SetContainerUser
 {
 
-    public static void currentlyRunningUser( GenericContainer container )
+    public static void nonRootUser( GenericContainer container )
     {
-        container.withCreateContainerCmdModifier( (Consumer<CreateContainerCmd>) cmd -> cmd.withUser( getCurrentlyRunningUserString() ) );
+        container.withCreateContainerCmdModifier( (Consumer<CreateContainerCmd>) cmd -> cmd.withUser( getNonRootUserString() ) );
     }
-    public static String getCurrentlyRunningUserString()
+
+    public static String getNonRootUserString()
+    {
+        // check if the non root user environment variable is set, if so use that. Otherwise use current user.
+        String user = System.getenv( "NON_ROOT_USER_ID" );
+        if(user == null)
+        {
+            return getCurrentlyRunningUser();
+        }
+        else
+        {
+            return user;
+        }
+    }
+
+    private static String getCurrentlyRunningUser()
     {
         UnixSystem fs = new UnixSystem();
         return fs.getUid() + ":" + fs.getGid();


### PR DESCRIPTION
This is to enable the tests to run inside a docker container, even though they themselves spawn new containers.
It was failing in our CI pipeline because of permission errors on mounted folders when testing mounting as non-root users.