### PR TITLE
Switch to using the latest neo4j driver (beta)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 		<dependency>
 			<groupId>org.neo4j.driver</groupId>
 			<artifactId>neo4j-java-driver</artifactId>
-			<version>2.0.0-alpha02</version>
+			<version>4.0.0-beta01</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/test/java/com/neo4j/docker/TestPasswords.java
+++ b/src/test/java/com/neo4j/docker/TestPasswords.java
@@ -103,7 +103,7 @@ public class TestPasswords
     {
         String boltUri = getBoltURIFromContainer(container);
         Assertions.assertThrows( org.neo4j.driver.exceptions.AuthenticationException.class,
-                () -> GraphDatabase.driver( boltUri, AuthTokens.basic( "neo4j", password ), TEST_DRIVER_CONFIG ) );
+                () -> GraphDatabase.driver( boltUri, AuthTokens.basic( "neo4j", password ), TEST_DRIVER_CONFIG ).verifyConnectivity() );
     }
 
     // when junit 5.5.0 is released, @ValueSource should support booleans.


### PR DESCRIPTION
currently these docker tests are using an older alpha
n.b. the latest drivers don't connect when you create them - so they won't throw an AuthenticationError unless you call the `verifyConnectivity()` method.