### PR TITLE
Clean environment a bit

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -32,7 +32,7 @@ For local development it's expected that `in` will contain symlinks to
 the tarballs to make it easy to rebuild Neo4j and test the results.
 
     ln -s $NEO4J_SRC/packaging/standalone/target/neo4j-*-3.4.0-SNAPSHOT-unix.tar.gz in
-    make NEO4J_VERSION=3.4.0-SNAPSHOT
+    make NEO4JVERSION=3.4.0-SNAPSHOT
 
 For building images of released versions, they can be downloaded into
 `in`.
@@ -42,7 +42,7 @@ For building images of released versions, they can be downloaded into
       curl --remote-name $DOWNLOAD_ROOT/neo4j-3.3.5-community-unix.tar.gz
       curl --remote-name $DOWNLOAD_ROOT/neo4j-3.3.5-enterprise-unix.tar.gz
     )
-    make NEO4J_VERSION=3.3.5
+    make NEO4JVERSION=3.3.5
 
 To avoid having to pass the version to make every time you can set it
 in the environment by copying `devenv.local` from

--- a/Makefile
+++ b/Makefile
@@ -10,20 +10,20 @@ ifeq ($(origin .RECIPEPREFIX), undefined)
 endif
 .RECIPEPREFIX = >
 
-ifndef NEO4J_VERSION
-  $(error NEO4J_VERSION is not set)
+ifndef NEO4JVERSION
+  $(error NEO4JVERSION is not set)
 endif
 
 tarball = neo4j-$(1)-$(2)-unix.tar.gz
 dist_site := https://dist.neo4j.org
-series := $(shell echo "$(NEO4J_VERSION)" | sed -E 's/^([0-9]+\.[0-9]+)\..*/\1/')
+series := $(shell echo "$(NEO4JVERSION)" | sed -E 's/^([0-9]+\.[0-9]+)\..*/\1/')
 
 all: test
 .PHONY: all
 
 test: tmp/.image-id-community tmp/.image-id-enterprise
-> mvn test -Dimage=$$(cat tmp/.image-id-community) -Dedition=community -Dversion=$(NEO4J_VERSION)
-> mvn test -Dimage=$$(cat tmp/.image-id-enterprise) -Dedition=enterprise -Dversion=$(NEO4J_VERSION)
+> mvn test -Dimage=$$(cat tmp/.image-id-community) -Dedition=community -Dversion=$(NEO4JVERSION)
+> mvn test -Dimage=$$(cat tmp/.image-id-enterprise) -Dedition=enterprise -Dversion=$(NEO4JVERSION)
 .PHONY: test
 
 # just build the images, don't test or package
@@ -36,13 +36,13 @@ package: package-community package-enterprise
 
 package-community: tmp/.image-id-community out/community/.sentinel
 > mkdir -p out
-> docker tag $$(cat $<) neo4j:$(NEO4J_VERSION)
-> docker save neo4j:$(NEO4J_VERSION) > out/neo4j-community-$(NEO4J_VERSION)-docker-loadable.tar
+> docker tag $$(cat $<) neo4j:$(NEO4JVERSION)
+> docker save neo4j:$(NEO4JVERSION) > out/neo4j-community-$(NEO4JVERSION)-docker-loadable.tar
 
 package-enterprise: tmp/.image-id-enterprise out/enterprise/.sentinel
 > mkdir -p out
-> docker tag $$(cat $<) neo4j:$(NEO4J_VERSION)-enterprise
-> docker save neo4j:$(NEO4J_VERSION)-enterprise > out/neo4j-enterprise-$(NEO4J_VERSION)-docker-loadable.tar
+> docker tag $$(cat $<) neo4j:$(NEO4JVERSION)-enterprise
+> docker save neo4j:$(NEO4JVERSION)-enterprise > out/neo4j-enterprise-$(NEO4JVERSION)-docker-loadable.tar
 
 out/%/.sentinel: tmp/image-%/.sentinel
 > mkdir -p $(@D)
@@ -55,7 +55,7 @@ tmp/.image-id-%: tmp/local-context-%/.sentinel
 > mkdir -p $(@D)
 > image=test/$$RANDOM
 > docker build --tag=$$image \
-    --build-arg="NEO4J_URI=file:///tmp/$(call tarball,$*,$(NEO4J_VERSION))" \
+    --build-arg="NEO4J_URI=file:///tmp/$(call tarball,$*,$(NEO4JVERSION))" \
     $(<D)
 > echo -n $$image >$@
 
@@ -63,7 +63,7 @@ tmp/neo4jlabs-plugins.json: ./neo4jlabs-plugins.json
 > mkdir -p $(@D)
 > cp $< $@
 
-tmp/local-context-%/.sentinel: tmp/image-%/.sentinel in/$(call tarball,%,$(NEO4J_VERSION)) tmp/neo4jlabs-plugins.json
+tmp/local-context-%/.sentinel: tmp/image-%/.sentinel in/$(call tarball,%,$(NEO4JVERSION)) tmp/neo4jlabs-plugins.json
 > rm -rf $(@D)
 > mkdir -p $(@D)
 > cp -r $(<D)/* $(@D)
@@ -72,13 +72,13 @@ tmp/local-context-%/.sentinel: tmp/image-%/.sentinel in/$(call tarball,%,$(NEO4J
 > touch $@
 
 tmp/image-%/.sentinel: docker-image-src/$(series)/Dockerfile docker-image-src/$(series)/docker-entrypoint.sh \
-                       in/$(call tarball,%,$(NEO4J_VERSION)) tmp/neo4jlabs-plugins.json
+                       in/$(call tarball,%,$(NEO4JVERSION)) tmp/neo4jlabs-plugins.json
 > mkdir -p $(@D)
 > cp $(filter %/docker-entrypoint.sh,$^) $(@D)/docker-entrypoint.sh
 > sha=$$(shasum --algorithm=256 $(filter %.tar.gz,$^) | cut -d' ' -f1)
 > <$(filter %/Dockerfile,$^) sed \
     -e "s|%%NEO4J_SHA%%|$${sha}|" \
-    -e "s|%%NEO4J_TARBALL%%|$(call tarball,$*,$(NEO4J_VERSION))|" \
+    -e "s|%%NEO4J_TARBALL%%|$(call tarball,$*,$(NEO4JVERSION))|" \
     -e "s|%%NEO4J_EDITION%%|$*|" \
     -e "s|%%NEO4J_DIST_SITE%%|$(dist_site)|" \
     >$(@D)/Dockerfile
@@ -88,17 +88,17 @@ tmp/image-%/.sentinel: docker-image-src/$(series)/Dockerfile docker-image-src/$(
 > touch $@
 
 fetch_tarball = curl --fail --silent --show-error --location --remote-name \
-    $(dist_site)/$(call tarball,$(1),$(NEO4J_VERSION))
+    $(dist_site)/$(call tarball,$(1),$(NEO4JVERSION))
 
-cache: in/neo4j-%-$(NEO4J_VERSION)-unix.tar.gz
+cache: in/neo4j-%-$(NEO4JVERSION)-unix.tar.gz
 .PHONY: cache
 
-in/neo4j-community-$(NEO4J_VERSION)-unix.tar.gz:
+in/neo4j-community-$(NEO4JVERSION)-unix.tar.gz:
 > mkdir -p in
 > cd in
 > $(call fetch_tarball,community)
 
-in/neo4j-enterprise-$(NEO4J_VERSION)-unix.tar.gz:
+in/neo4j-enterprise-$(NEO4JVERSION)-unix.tar.gz:
 > mkdir -p in
 > cd in
 > $(call fetch_tarball,enterprise)

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,9 @@ tmp/.image-id-%: tmp/local-context-%/.sentinel
     --build-arg="NEO4J_URI=file:///tmp/$(call tarball,$*,$(NEO4JVERSION))" \
     $(<D)
 > echo -n $$image >$@
+> echo "NEO4JVERSION=$(NEO4JVERSION)" > tmp/devenv-${*}.env
+> echo "NEO4J_IMAGE=$$image" >> tmp/devenv-${*}.env
+> echo "NEO4J_EDITION=${*}" >> tmp/devenv-${*}.env
 
 tmp/neo4jlabs-plugins.json: ./neo4jlabs-plugins.json
 > mkdir -p $(@D)

--- a/src/test/java/com/neo4j/docker/TestPluginInstallation.java
+++ b/src/test/java/com/neo4j/docker/TestPluginInstallation.java
@@ -84,7 +84,7 @@ public class TestPluginInstallation
     {
         File versionsJson = pluginsDir.resolve( versions ).toFile();
 
-        Files.write( getResource( "versions.json" ).replace( "$NEO4J_VERSION", NEO4J_VERSION.toString() ), versionsJson, StandardCharsets.UTF_8 );
+        Files.write( getResource( "versions.json" ).replace( "$NEO4JVERSION", NEO4J_VERSION.toString() ), versionsJson, StandardCharsets.UTF_8 );
 
         File myPluginJar = pluginsDir.resolve( myPlugin ).toFile();
 

--- a/src/test/java/com/neo4j/docker/utils/TestSettings.java
+++ b/src/test/java/com/neo4j/docker/utils/TestSettings.java
@@ -24,9 +24,9 @@ public class TestSettings
         String verStr = System.getProperty( "version" );
         if(verStr == null)
         {
-            verStr = System.getenv( "NEO4J_VERSION" );
+            verStr = System.getenv( "NEO4JVERSION" );
         }
-        Assert.assertNotNull("Neo4j version has not been specified, either use mvn argument -Dversion or set env NEO4J_VERSION", verStr);
+        Assert.assertNotNull("Neo4j version has not been specified, either use mvn argument -Dversion or set env NEO4JVERSION", verStr);
         return verStr;
     }
 

--- a/src/test/resources/versions.json
+++ b/src/test/resources/versions.json
@@ -1,6 +1,6 @@
 [
   {
-    "neo4j": "$NEO4J_VERSION",
+    "neo4j": "$NEO4JVERSION",
     "_testing": "SNAPSHOT",
     "jar": "http://host.testcontainers.internal:3000/myPlugin.jar"
   }


### PR DESCRIPTION
We used to use `NEO4J_VERSION` in some contexts and `NEO4JVERSION` in others. This is updated to just `NEO4JVERSION` everywhere, to be consistent with itself and our teamcity infrastructure.

Makefile now outputs a `devenv-community.env` and `devenv-enterprise.env` to make developing the neo4j image slightly easier.