### PR TITLE
Try with resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,6 @@
 /target/
 
 # simlinks to dev scripts in https://github.com/neo-technology/teamcity-witchcraft
-DownloadTool.py
+download_tool.py
 docker_tests_get_installers.py
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@
 /devenv.local
 /local-mounts/
 /target/
+
+# simlinks to dev scripts in https://github.com/neo-technology/teamcity-witchcraft
+DownloadTool.py
+docker_tests_get_installers.py
+__pycache__/

--- a/src/test/java/com/neo4j/docker/TestBasic.java
+++ b/src/test/java/com/neo4j/docker/TestBasic.java
@@ -1,6 +1,5 @@
 package com.neo4j.docker;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
@@ -14,7 +13,6 @@ import org.testcontainers.containers.output.ToStringConsumer;
 import org.testcontainers.containers.output.WaitingConsumer;
 import com.neo4j.docker.utils.Neo4jVersion;
 import com.neo4j.docker.utils.TestSettings;
-import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.time.Duration;
@@ -74,7 +72,6 @@ public class TestBasic
         }
     }
 
-
     @Test
     void testLicenseAcceptanceRequired()
     {
@@ -83,6 +80,7 @@ public class TestBasic
         Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 3,3,0 ) ),
                                 "No license checks before version 3.3.0");
 
+        String logsOut;
         try(GenericContainer container = new GenericContainer( TestSettings.IMAGE_ID )
                 .withLogConsumer( new Slf4jLogConsumer( log ) ) )
         {
@@ -91,14 +89,13 @@ public class TestBasic
 
             Assertions.assertDoesNotThrow( () -> container.start(),
                                            "Neo4j did not notify about accepting the license agreement" );
-            String logs = container.getLogs();
-
-            // double check the container didn't warn and start neo4j anyway
-            Assertions.assertTrue( logs.contains( "must accept the license" ),
-                                   "Neo4j did not notify about accepting the license agreement" );
-            Assertions.assertFalse( logs.contains( "Remote interface available" ),
-                                    "Neo4j was started even though the license was not accepted" );
+            logsOut = container.getLogs();
         }
+        // double check the container didn't warn and start neo4j anyway
+        Assertions.assertTrue( logsOut.contains( "must accept the license" ),
+                               "Neo4j did not notify about accepting the license agreement" );
+        Assertions.assertFalse( logsOut.contains( "Remote interface available" ),
+                                "Neo4j was started even though the license was not accepted" );
     }
 
     @Test

--- a/src/test/java/com/neo4j/docker/TestConfSettings.java
+++ b/src/test/java/com/neo4j/docker/TestConfSettings.java
@@ -180,7 +180,7 @@ public class TestConfSettings {
             Files.copy( confFile, confMount.resolve( "neo4j.conf" ) );
             //Start the container
             container.setWaitStrategy(
-                    Wait.forLogMessage( ".*Config Dumped.*", 1 ).withStartupTimeout( Duration.ofSeconds( 10 ) ) );
+                    Wait.forLogMessage( ".*Config Dumped.*", 1 ).withStartupTimeout( Duration.ofSeconds( 30 ) ) );
             container.setCommand( "dump-config" );
             container.start();
         }

--- a/src/test/java/com/neo4j/docker/TestConfSettings.java
+++ b/src/test/java/com/neo4j/docker/TestConfSettings.java
@@ -30,23 +30,6 @@ import java.util.stream.Stream;
 
 public class TestConfSettings {
     private static Logger log = LoggerFactory.getLogger(TestConfSettings.class);
-    private GenericContainer container;
-
-    @AfterEach
-    void killContainer()
-    {
-        if(container != null)
-        {
-            try
-            {
-                container.stop();
-            }
-            catch ( Exception e )
-            {
-                log.warn( "Exception trying to kill container, it was probably already closed." );
-            }
-        }
-    }
 
     private GenericContainer createContainer()
     {
@@ -60,18 +43,22 @@ public class TestConfSettings {
     @Test
     void testIgnoreNumericVars()
     {
-        container = createContainer();
-        container.withEnv( "NEO4J_1a", "1");
-        container.start();
-        Assertions.assertTrue( container.isRunning());
+        try(GenericContainer container = createContainer())
+        {
+            container.withEnv( "NEO4J_1a", "1" );
+            container.start();
+            Assertions.assertTrue( container.isRunning() );
 
-        WaitingConsumer waitingConsumer = new WaitingConsumer();
-        container.followOutput( waitingConsumer);
+            WaitingConsumer waitingConsumer = new WaitingConsumer();
+            container.followOutput( waitingConsumer );
 
-        Assertions.assertDoesNotThrow(() -> waitingConsumer.waitUntil(frame -> frame.getUtf8String()
-                                                                                    .contains("WARNING: 1a not written to conf file because settings that " +
-                                                                                              "start with a number are not permitted"), 15, TimeUnit.SECONDS),
-                                      "Neo4j did not warn about invalid numeric config variable `Neo4j_1a`");
+            Assertions.assertDoesNotThrow( () -> waitingConsumer.waitUntil( frame -> frame.getUtf8String()
+                                                                                          .contains(
+                                                                                                  "WARNING: 1a not written to conf file because settings that " +
+                                                                                                  "start with a number are not permitted" ),
+                                                                            15, TimeUnit.SECONDS ),
+                                           "Neo4j did not warn about invalid numeric config variable `Neo4j_1a`" );
+        }
     }
 
     private Map<String, String> parseConfFile(File conf) throws FileNotFoundException
@@ -97,20 +84,24 @@ public class TestConfSettings {
         Assumptions.assumeTrue(TestSettings.NEO4J_VERSION.isAtLeastVersion(new Neo4jVersion(3, 0, 0)),
                                "No neo4j-admin in 2.3: skipping neo4j-admin-conf-override test");
 
-        container = createContainer()
+        File conf;
+        try(GenericContainer container = createContainer()
                 .withEnv("NEO4J_dbms_memory_pagecache_size", "1000m")
                 .withEnv("NEO4J_dbms_memory_heap_initial__size", "2000m")
                 .withEnv("NEO4J_dbms_memory_heap_max__size", "3000m")
                 .withEnv( "NEO4J_dbms_directories_logs", "/notdefaultlogs" )
                 .withEnv( "NEO4J_dbms_directories_data", "/notdefaultdata" )
-                .withCommand("dump-config");
-        Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume(container, "conf-", "/conf");
-        container.setWaitStrategy(Wait.forLogMessage(".*Config Dumped.*", 1).withStartupTimeout(Duration.ofSeconds(30)));
-        SetContainerUser.nonRootUser(container);
-        container.start();
+                .withCommand("dump-config") )
+        {
+            Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "conf-", "/conf" );
+            conf = confMount.resolve( "neo4j.conf" ).toFile();
+            container.setWaitStrategy(
+                    Wait.forLogMessage( ".*Config Dumped.*", 1 ).withStartupTimeout( Duration.ofSeconds( 30 ) ) );
+            SetContainerUser.nonRootUser( container );
+            container.start();
+        }
 
         // now check the settings we set via env are in the new conf file
-        File conf = confMount.resolve( "neo4j.conf" ).toFile();
         Assertions.assertTrue( conf.exists(), "configuration file not written" );
         Assertions.assertTrue( conf.canRead(), "configuration file not readable for some reason?" );
 
@@ -143,20 +134,24 @@ public class TestConfSettings {
     @Test
     void testReadTheConfFile() throws Exception
     {
-        container = createContainer();
-        //Mount /conf
-        Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume(container, "conf-", "/conf");
-        Path logMount = HostFileSystemOperations.createTempFolderAndMountAsVolume(container, "logs-", "/logs");
-        SetContainerUser.nonRootUser(container);
-        //Create ReadConf.conf file with the custom env variables
-        Path confFile = Paths.get("src", "test", "resources", "confs", "ReadConf.conf");
-        Files.copy(confFile, confMount.resolve("neo4j.conf"));
-        //Start the container
-        container.setWaitStrategy(Wait.forHttp("/").forPort(7474).forStatusCode(200));
-        container.start();
+        Path debugLog;
+        try(GenericContainer container = createContainer())
+        {
+            //Mount /conf
+            Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "conf-", "/conf" );
+            Path logMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-", "/logs" );
+            debugLog = logMount.resolve("debug.log");
+            SetContainerUser.nonRootUser( container );
+            //Create ReadConf.conf file with the custom env variables
+            Path confFile = Paths.get( "src", "test", "resources", "confs", "ReadConf.conf" );
+            Files.copy( confFile, confMount.resolve( "neo4j.conf" ) );
+            //Start the container
+            container.setWaitStrategy( Wait.forHttp( "/" ).forPort( 7474 ).forStatusCode( 200 ) );
+            container.start();
+        }
 
         //Check if the container reads the conf file
-        Stream<String> lines = Files.lines(logMount.resolve("debug.log"));
+        Stream<String> lines = Files.lines(debugLog);
         Optional<String> heapSizeMatch = lines.filter(s -> s.contains("dbms.memory.heap.max_size=512m")).findFirst();
         lines.close();
         Assertions.assertTrue(heapSizeMatch.isPresent(), "dbms.memory.heap.max_size was not set correctly");
@@ -165,46 +160,53 @@ public class TestConfSettings {
     @Test
     void testCommentedConfigsAreReplacedByDefaultOnes() throws Exception
     {
-        //Create container
-        container = createContainer();
-        //Mount /conf
-        Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume(container, "conf-", "/conf");
-        File conf = confMount.resolve("neo4j.conf").toFile();
-        SetContainerUser.nonRootUser(container);
-        //Create ConfsReplaced.conf file
-        Path confFile = Paths.get("src", "test", "resources", "confs", "ConfsReplaced.conf");
-        Files.copy(confFile, confMount.resolve("neo4j.conf"));
-        //Start the container
-        container.setWaitStrategy(Wait.forLogMessage(".*Config Dumped.*", 1).withStartupTimeout(Duration.ofSeconds(10)));
-        container.setCommand("dump-config");
-        container.start();
-
+        File conf;
+        try(GenericContainer container = createContainer())
+        {
+            //Mount /conf
+            Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "conf-", "/conf" );
+            conf = confMount.resolve( "neo4j.conf" ).toFile();
+            SetContainerUser.nonRootUser( container );
+            //Create ConfsReplaced.conf file
+            Path confFile = Paths.get( "src", "test", "resources", "confs", "ConfsReplaced.conf" );
+            Files.copy( confFile, confMount.resolve( "neo4j.conf" ) );
+            //Start the container
+            container.setWaitStrategy(
+                    Wait.forLogMessage( ".*Config Dumped.*", 1 ).withStartupTimeout( Duration.ofSeconds( 10 ) ) );
+            container.setCommand( "dump-config" );
+            container.start();
+        }
         //Read the config file to check if the config is set correctly
-        Map<String, String> configurations = parseConfFile(conf);
-        Assertions.assertTrue(configurations.containsKey("dbms.memory.pagecache.size"), "conf settings not set correctly by docker-entrypoint");
-        Assertions.assertEquals("512M",
-                                configurations.get("dbms.memory.pagecache.size"),
-                                "conf settings not appended correctly by docker-entrypoint");
+        Map<String,String> configurations = parseConfFile( conf );
+        Assertions.assertTrue( configurations.containsKey( "dbms.memory.pagecache.size" ),
+                               "conf settings not set correctly by docker-entrypoint" );
+        Assertions.assertEquals( "512M",
+                                 configurations.get( "dbms.memory.pagecache.size" ),
+                                 "conf settings not appended correctly by docker-entrypoint" );
     }
 
     @Test
     void testConfigsAreNotOverridenByDockerentrypoint() throws Exception
     {
-        //Create container
-        container = createContainer();
-        //Mount /conf
-        Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume(container, "conf-", "/conf");
-        SetContainerUser.nonRootUser(container);
-        //Create ConfsNotOverriden.conf file
-        Path confFile = Paths.get("src", "test", "resources", "confs", "ConfsNotOverriden.conf");
-        Files.copy(confFile, confMount.resolve("neo4j.conf"));
-        //Start the container
-        container.setWaitStrategy(Wait.forLogMessage(".*Config Dumped.*", 1).withStartupTimeout(Duration.ofSeconds(30)));
-        container.setCommand("dump-config");
-        container.start();
+        File conf;
+        try(GenericContainer container = createContainer())
+        {
+            //Mount /conf
+            Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "conf-", "/conf" );
+            conf = confMount.resolve( "neo4j.conf" ).toFile();
+            SetContainerUser.nonRootUser( container );
+            //Create ConfsNotOverriden.conf file
+            Path confFile = Paths.get( "src", "test", "resources", "confs", "ConfsNotOverriden.conf" );
+            Files.copy( confFile, confMount.resolve( "neo4j.conf" ) );
+            //Start the container
+            container.setWaitStrategy(
+                    Wait.forLogMessage( ".*Config Dumped.*", 1 ).withStartupTimeout( Duration.ofSeconds( 30 ) ) );
+            container.setCommand( "dump-config" );
+            container.start();
+        }
 
         //Read the config file to check if the config is not overriden
-        Map<String, String> configurations = parseConfFile(confMount.resolve("neo4j.conf").toFile());
+        Map<String, String> configurations = parseConfFile(conf);
         Assertions.assertTrue(configurations.containsKey("dbms.connector.https.listen_address"), "conf settings not set correctly by docker-entrypoint");
         Assertions.assertEquals(":8483",
                                 configurations.get("dbms.connector.https.listen_address"),
@@ -214,22 +216,23 @@ public class TestConfSettings {
     @Test
     void testEnvVarsOverride() throws Exception
     {
-        //Create container
-        container = createContainer()
-                .withEnv("NEO4J_dbms_memory_pagecache_size", "512m");
-        //Mount /conf /logs
-        Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume(container, "conf-", "/conf");
-        Path logMount = HostFileSystemOperations.createTempFolderAndMountAsVolume(container, "logs-", "/logs");
-        SetContainerUser.nonRootUser(container);
-        //Create EnvVarsOverride.conf file
-        Path confFile = Paths.get("src", "test", "resources", "confs", "EnvVarsOverride.conf");
-        Files.copy(confFile, confMount.resolve("EnvVarsOverride.conf"));
-        //Start the container
-        container.setWaitStrategy(Wait.forHttp("/").forPort(7474).forStatusCode(200));
-        container.start();
+        Path debugLog;
+        try(GenericContainer container = createContainer().withEnv("NEO4J_dbms_memory_pagecache_size", "512m"))
+        {
+            Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "conf-", "/conf" );
+            Path logMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-", "/logs" );
+            debugLog = logMount.resolve( "debug.log" );
+            SetContainerUser.nonRootUser( container );
+            //Create EnvVarsOverride.conf file
+            Path confFile = Paths.get( "src", "test", "resources", "confs", "EnvVarsOverride.conf" );
+            Files.copy( confFile, confMount.resolve( "EnvVarsOverride.conf" ) );
+            //Start the container
+            container.setWaitStrategy( Wait.forHttp( "/" ).forPort( 7474 ).forStatusCode( 200 ) );
+            container.start();
+        }
 
         //Read the debug.log to check that dbms.memory.pagecache.size was set correctly
-        Stream<String> lines = Files.lines(logMount.resolve("debug.log"));
+        Stream<String> lines = Files.lines(debugLog);
         Optional<String> heapSizeMatch = lines.filter(s -> s.contains("dbms.memory.pagecache.size=512m")).findFirst();
         lines.close();
         Assertions.assertTrue(heapSizeMatch.isPresent(), "dbms.memory.pagecache.size was not set correctly");
@@ -240,21 +243,26 @@ public class TestConfSettings {
     {
         Assumptions.assumeTrue(TestSettings.EDITION == TestSettings.Edition.ENTERPRISE,
                                "This is testing only ENTERPRISE EDITION configs");
-        //Create container
-        container = createContainer();
-        //Mount /logs
-        Path logMount = HostFileSystemOperations.createTempFolderAndMountAsVolume(container, "logs-", "/logs");
-        SetContainerUser.nonRootUser(container);
-        //Start the container
-        container.setWaitStrategy(Wait.forHttp("/").forPort(7474).forStatusCode(200));
-        container.start();
-        //Read debug.log to check that causal_clustering confs are set successfully
-        String expectedTxAddress = container.getContainerId().substring( 0, 12 ) + ":6000";
 
-        Stream<String> lines = Files.lines(logMount.resolve("debug.log"));
-        Optional<String> ccPresent = lines.filter(s -> s.contains("causal_clustering.transaction_advertised_address="+expectedTxAddress)).findFirst();
-        lines.close();
-        Assertions.assertTrue(ccPresent.isPresent(), "causal_clustering.transaction_advertised_address was not set correctly");
+        try(GenericContainer container = createContainer().withEnv("NEO4J_dbms_memory_pagecache_size", "512m"))
+        {
+            //Mount /logs
+            Path logMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-", "/logs" );
+            SetContainerUser.nonRootUser( container );
+            //Start the container
+            container.setWaitStrategy( Wait.forHttp( "/" ).forPort( 7474 ).forStatusCode( 200 ) );
+            container.start();
+            //Read debug.log to check that causal_clustering confs are set successfully
+            String expectedTxAddress = container.getContainerId().substring( 0, 12 ) + ":6000";
+
+            Stream<String> lines = Files.lines( logMount.resolve( "debug.log" ) );
+            Optional<String> ccPresent = lines.filter(
+                    s -> s.contains( "causal_clustering.transaction_advertised_address=" + expectedTxAddress ) )
+                                              .findFirst();
+            lines.close();
+            Assertions.assertTrue( ccPresent.isPresent(),
+                                   "causal_clustering.transaction_advertised_address was not set correctly" );
+        }
     }
 
     @Test
@@ -262,17 +270,20 @@ public class TestConfSettings {
     {
         Assumptions.assumeTrue(TestSettings.EDITION == TestSettings.Edition.COMMUNITY,
                                "This is testing only COMMUNITY EDITION configs");
-        //Create container
-        container = createContainer();
-        //Mount /logs
-        Path logMount = HostFileSystemOperations.createTempFolderAndMountAsVolume(container, "logs-", "/logs");
-        SetContainerUser.nonRootUser(container);
-        //Start the container
-        container.setWaitStrategy(Wait.forHttp("/").forPort(7474).forStatusCode(200));
-        container.start();
+        Path debugLog;
+        try(GenericContainer container = createContainer().withEnv("NEO4J_dbms_memory_pagecache_size", "512m"))
+        {
+            //Mount /logs
+            Path logMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-", "/logs" );
+            debugLog = logMount.resolve( "debug.log" );
+            SetContainerUser.nonRootUser( container );
+            //Start the container
+            container.setWaitStrategy( Wait.forHttp( "/" ).forPort( 7474 ).forStatusCode( 200 ) );
+            container.start();
+        }
 
         //Read debug.log to check that causal_clustering confs are not present
-        Stream<String> lines = Files.lines(logMount.resolve("debug.log"));
+        Stream<String> lines = Files.lines(debugLog);
         Optional<String> ccNotPresent = lines.filter(s -> s.contains("causal_clustering.transaction_listen_address")).findFirst();
         lines.close();
         Assertions.assertFalse(ccNotPresent.isPresent(), "causal_clustering.transaction_listen_address should not be on the Community debug.log");

--- a/src/test/java/com/neo4j/docker/TestMounting.java
+++ b/src/test/java/com/neo4j/docker/TestMounting.java
@@ -178,7 +178,7 @@ public class TestMounting
 
             // currently Neo4j will try to start and fail. It should be fixed to throw an error and not try starting
             // container.setWaitStrategy( Wait.forLogMessage( "[fF]older /data is not accessible for user", 1 ).withStartupTimeout( Duration.ofSeconds( 20 ) ) );
-            container.setWaitStrategy( Wait.forListeningPort().withStartupTimeout( Duration.ofSeconds( 10 ) ) );
+            container.setWaitStrategy( Wait.forListeningPort().withStartupTimeout( Duration.ofSeconds( 20 ) ) );
             Assertions.assertThrows( org.testcontainers.containers.ContainerLaunchException.class,
                                      () -> container.start(),
                                      "Neo4j should not start in secure mode if data folder is unwritable" );
@@ -197,7 +197,7 @@ public class TestMounting
 
             // currently Neo4j will try to start and fail. It should be fixed to throw an error and not try starting
             // container.setWaitStrategy( Wait.forLogMessage( "[fF]older /logs is not accessible for user", 1 ).withStartupTimeout( Duration.ofSeconds( 20 ) ) );
-            container.setWaitStrategy( Wait.forListeningPort().withStartupTimeout( Duration.ofSeconds( 10 ) ) );
+            container.setWaitStrategy( Wait.forListeningPort().withStartupTimeout( Duration.ofSeconds( 20 ) ) );
             Assertions.assertThrows( org.testcontainers.containers.ContainerLaunchException.class,
                                      () -> container.start(),
                                      "Neo4j should not start in secure mode if logs folder is unwritable" );

--- a/src/test/java/com/neo4j/docker/TestMounting.java
+++ b/src/test/java/com/neo4j/docker/TestMounting.java
@@ -1,7 +1,6 @@
 package com.neo4j.docker;
 
 import com.neo4j.docker.utils.HostFileSystemOperations;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
@@ -27,16 +26,6 @@ import java.util.stream.Stream;
 public class TestMounting
 {
     private static Logger log = LoggerFactory.getLogger( TestMounting.class );
-    private Neo4jContainer container;
-
-    @AfterEach
-    void killContainer()
-    {
-        if(container != null)
-        {
-            container.stop();
-        }
-    }
 
     static Stream<Arguments> defaultUserFlagSecurePermissionsFlag()
     {
@@ -50,7 +39,7 @@ public class TestMounting
                 Arguments.arguments(  true, true  ));
     }
 
-    private Neo4jContainer setupBasicContainer( boolean asCurrentUser, boolean isSecurityFlagSet )
+    private GenericContainer setupBasicContainer( boolean asCurrentUser, boolean isSecurityFlagSet )
     {
         log.info( "Running as user {}, {}",
                   asCurrentUser?"non-root":"root",
@@ -58,9 +47,9 @@ public class TestMounting
 
         Neo4jContainer container = new Neo4jContainer( TestSettings.IMAGE_ID );
         container.withExposedPorts( 7474, 7687 )
-                .withLogConsumer( new Slf4jLogConsumer( log ) )
-                .withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
-                .withEnv( "NEO4J_AUTH", "none" );
+                 .withLogConsumer( new Slf4jLogConsumer( log ) )
+                 .withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
+                 .withEnv( "NEO4J_AUTH", "none" );
 
         if(asCurrentUser)
         {
@@ -110,14 +99,18 @@ public class TestMounting
     @Test
     void testDumpConfig( ) throws Exception
     {
-        container = setupBasicContainer( true, false );
-        Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "conf-", "/conf" );
-        container.setWaitStrategy( Wait.forLogMessage( ".*Config Dumped.*" , 1 ).withStartupTimeout( Duration.ofSeconds( 30 ) ) );
-        container.withCommand( "dump-config" );
-        container.start();
+        try(GenericContainer container = setupBasicContainer( true, false ))
+        {
+            Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "conf-", "/conf" );
+            container.setWaitStrategy(
+                    Wait.forLogMessage( ".*Config Dumped.*", 1 ).withStartupTimeout( Duration.ofSeconds( 30 ) ) );
+            container.withCommand( "dump-config" );
+            container.start();
 
-        Path expectedConfDumpFile = confMount.resolve( "neo4j.conf" );
-        Assertions.assertTrue( expectedConfDumpFile.toFile().exists(), "dump-config did not dump the config file to "+confMount.toString() );
+            Path expectedConfDumpFile = confMount.resolve( "neo4j.conf" );
+            Assertions.assertTrue( expectedConfDumpFile.toFile().exists(),
+                                   "dump-config did not dump the config file to " + confMount.toString() );
+        }
     }
 
 
@@ -128,13 +121,15 @@ public class TestMounting
         Assumptions.assumeTrue(TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 3,1,0 ) ),
                                "User checks not valid before 3.1" );
 
-        container = setupBasicContainer( asCurrentUser, isSecurityFlagSet );
-        Path dataMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "data-", "/data" );
-        container.start();
+        try(GenericContainer container = setupBasicContainer( asCurrentUser, isSecurityFlagSet ))
+        {
+            Path dataMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "data-", "/data" );
+            container.start();
 
-        // neo4j should now have started, so there'll be stuff in the data folder
-        // we need to check that stuff is readable and owned by the correct user
-        verifyDataFolderContentsArePresentOnHost( dataMount, asCurrentUser );
+            // neo4j should now have started, so there'll be stuff in the data folder
+            // we need to check that stuff is readable and owned by the correct user
+            verifyDataFolderContentsArePresentOnHost( dataMount, asCurrentUser );
+        }
     }
 
     @ParameterizedTest(name = "asUser={0}, secureFlag={1}")
@@ -144,11 +139,13 @@ public class TestMounting
         Assumptions.assumeTrue(TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 3,1,0 ) ),
                                "User checks not valid before 3.1" );
 
-        container = setupBasicContainer( asCurrentUser, isSecurityFlagSet );
-        Path logsMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-", "/logs" );
-        container.start();
+        try(GenericContainer container = setupBasicContainer( asCurrentUser, isSecurityFlagSet ))
+        {
+            Path logsMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-", "/logs" );
+            container.start();
 
-        verifyLogsFolderContentsArePresentOnHost( logsMount, asCurrentUser );
+            verifyLogsFolderContentsArePresentOnHost( logsMount, asCurrentUser );
+        }
     }
 
     @ParameterizedTest(name = "asUser={0}, secureFlag={1}")
@@ -158,13 +155,15 @@ public class TestMounting
         Assumptions.assumeTrue(TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 3,1,0 ) ),
                                "User checks not valid before 3.1" );
 
-        container = setupBasicContainer( asCurrentUser, isSecurityFlagSet );
-        Path dataMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "data-", "/data" );
-        Path logsMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-", "/logs" );
-        container.start();
+        try(GenericContainer container = setupBasicContainer( asCurrentUser, isSecurityFlagSet ))
+        {
+            Path dataMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "data-", "/data" );
+            Path logsMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-", "/logs" );
+            container.start();
 
-        verifyDataFolderContentsArePresentOnHost( dataMount, asCurrentUser );
-        verifyLogsFolderContentsArePresentOnHost( logsMount, asCurrentUser );
+            verifyDataFolderContentsArePresentOnHost( dataMount, asCurrentUser );
+            verifyLogsFolderContentsArePresentOnHost( logsMount, asCurrentUser );
+        }
     }
 
     @Test
@@ -173,15 +172,17 @@ public class TestMounting
         Assumptions.assumeTrue(TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 3,1,0 ) ),
                                "User checks not valid before 3.1" );
 
-        container = setupBasicContainer( false, true );
-        HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "data-", "/data" );
+        try(GenericContainer container = setupBasicContainer( false, true ))
+        {
+            HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "data-", "/data" );
 
-        // currently Neo4j will try to start and fail. It should be fixed to throw an error and not try starting
-        // container.setWaitStrategy( Wait.forLogMessage( "[fF]older /data is not accessible for user", 1 ).withStartupTimeout( Duration.ofSeconds( 20 ) ) );
-        container.setWaitStrategy( Wait.forListeningPort().withStartupTimeout( Duration.ofSeconds( 10 )) );
-        Assertions.assertThrows( org.testcontainers.containers.ContainerLaunchException.class,
-                                 () -> container.start(),
-                                 "Neo4j should not start in secure mode if data folder is unwritable");
+            // currently Neo4j will try to start and fail. It should be fixed to throw an error and not try starting
+            // container.setWaitStrategy( Wait.forLogMessage( "[fF]older /data is not accessible for user", 1 ).withStartupTimeout( Duration.ofSeconds( 20 ) ) );
+            container.setWaitStrategy( Wait.forListeningPort().withStartupTimeout( Duration.ofSeconds( 10 ) ) );
+            Assertions.assertThrows( org.testcontainers.containers.ContainerLaunchException.class,
+                                     () -> container.start(),
+                                     "Neo4j should not start in secure mode if data folder is unwritable" );
+        }
     }
 
     @Test
@@ -190,14 +191,16 @@ public class TestMounting
         Assumptions.assumeTrue(TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 3,1,0 ) ),
                                "User checks not valid before 3.1" );
 
-        container = setupBasicContainer( false, true );
-        HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-", "/logs" );
+        try(GenericContainer container = setupBasicContainer( false, true ))
+        {
+            HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-", "/logs" );
 
-        // currently Neo4j will try to start and fail. It should be fixed to throw an error and not try starting
-        // container.setWaitStrategy( Wait.forLogMessage( "[fF]older /logs is not accessible for user", 1 ).withStartupTimeout( Duration.ofSeconds( 20 ) ) );
-        container.setWaitStrategy( Wait.forListeningPort().withStartupTimeout( Duration.ofSeconds( 10 )) );
-        Assertions.assertThrows( org.testcontainers.containers.ContainerLaunchException.class,
-                                 () -> container.start(),
-                                 "Neo4j should not start in secure mode if logs folder is unwritable");
+            // currently Neo4j will try to start and fail. It should be fixed to throw an error and not try starting
+            // container.setWaitStrategy( Wait.forLogMessage( "[fF]older /logs is not accessible for user", 1 ).withStartupTimeout( Duration.ofSeconds( 20 ) ) );
+            container.setWaitStrategy( Wait.forListeningPort().withStartupTimeout( Duration.ofSeconds( 10 ) ) );
+            Assertions.assertThrows( org.testcontainers.containers.ContainerLaunchException.class,
+                                     () -> container.start(),
+                                     "Neo4j should not start in secure mode if logs folder is unwritable" );
+        }
     }
 }


### PR DESCRIPTION
TestContainers doesn't handle closing an already terminated container very well, and NOT closing the containers after each test leads to stray containers running and consuming memory, leading to test failures.
I've changed the unit tests to take advantage of the container's autoclosable ability, so that the containers is automatically closed after the try with resources goes out of scope.