### PR TITLE
Fix file permission errors on upgrade from 3.5.5 and earlier to latest 3.5

### DIFF
--- a/docker-image-src/3.3/docker-entrypoint.sh
+++ b/docker-image-src/3.3/docker-entrypoint.sh
@@ -12,7 +12,8 @@ function secure_mode_enabled
     test "${SECURE_FILE_PERMISSIONS:=no}" = "yes"
 }
 
-containsElement () {
+function containsElement
+{
   local e match="$1"
   shift
   for e; do [[ "$e" == "$match" ]] && return 0; done
@@ -45,20 +46,33 @@ function is_readable
     return 1
 }
 
-function is_not_writable
+function is_writable
 {
+    # It would be nice if this and the is_readable function could combine somehow
     local _file=${1}
-    # Not using "test -w ${_file}" here because we need to check if the neo4j user or supplied user
-    # has write access to the file, and this script might not be running as that user.
+    perm=$(stat -c %a "${_file}")
 
-    # echo "comparing to ${userid}:${groupid}"
-    test "$(stat -c %U ${_file})" != "${userid}"  &&  \
-    test "$(stat -c %u ${_file})" != "${userid}" && \
-    ! containsElement "$(stat -c %g ${_file})" "${groups[@]}" && \
-    ! containsElement "$(stat -c %G ${_file})" "${groups[@]}"
+    # everyone permission
+    if containsElement ${perm:2:1} 2 3 6 7; then
+        return 0
+    fi
+    # owner permissions
+    if containsElement ${perm:0:1} 2 3 6 7; then
+        if [[ "$(stat -c %U ${_file})" = "${userid}" ]] || [[ "$(stat -c %u ${_file})" = "${userid}" ]]; then
+            return 0
+        fi
+    fi
+    # group permissions
+    if containsElement ${perm:1:1} 2 3 6 7; then
+        if containsElement "$(stat -c %g ${_file})" "${groups[@]}" || containsElement "$(stat -c %G ${_file})" "${groups[@]}" ; then
+            return 0
+        fi
+    fi
+    return 1
 }
 
-function print_permissions_advice_and_fail ()
+
+function print_permissions_advice_and_fail
 {
     _directory=${1}
     echo >&2 "
@@ -107,7 +121,7 @@ function check_mounted_folder_with_chown
 
     local mountFolder=${1}
     if running_as_root; then
-        if is_not_writable "${mountFolder}" && ! secure_mode_enabled; then
+        if ! is_writable "${mountFolder}" && ! secure_mode_enabled; then
             # warn that we're about to chown the folder and then chown it
             echo "Warning: Folder mounted to \"${mountFolder}\" is not writable from inside container. Changing folder owner to ${userid}."
             chown -R "${userid}":"${groupid}" "${mountFolder}"
@@ -299,6 +313,12 @@ fi
 if [ -d /logs ]; then
     check_mounted_folder_with_chown "/logs"
     : ${NEO4J_dbms_directories_logs:="/logs"}
+    if [ -d /data/databases ]; then
+        check_mounted_folder_with_chown "/data/databases"
+    fi
+    if [ -d /data/dbms ]; then
+        check_mounted_folder_with_chown "/data/dbms"
+    fi
 fi
 
 if [ -d /data ]; then
@@ -410,7 +430,7 @@ fi
 [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
 
 if [ "${cmd}" == "dump-config" ]; then
-    if is_not_writable "/conf"; then
+    if ! is_writable "/conf"; then
         print_permissions_advice_and_fail "/conf"
     fi
     cp --recursive "${NEO4J_HOME}"/conf/* /conf

--- a/docker-image-src/3.4/docker-entrypoint.sh
+++ b/docker-image-src/3.4/docker-entrypoint.sh
@@ -12,7 +12,8 @@ function secure_mode_enabled
     test "${SECURE_FILE_PERMISSIONS:=no}" = "yes"
 }
 
-containsElement () {
+function containsElement
+{
   local e match="$1"
   shift
   for e; do [[ "$e" == "$match" ]] && return 0; done
@@ -45,20 +46,33 @@ function is_readable
     return 1
 }
 
-function is_not_writable
+function is_writable
 {
+    # It would be nice if this and the is_readable function could combine somehow
     local _file=${1}
-    # Not using "test -w ${_file}" here because we need to check if the neo4j user or supplied user
-    # has write access to the file, and this script might not be running as that user.
+    perm=$(stat -c %a "${_file}")
 
-    # echo "comparing to ${userid}:${groupid}"
-    test "$(stat -c %U ${_file})" != "${userid}"  &&  \
-    test "$(stat -c %u ${_file})" != "${userid}" && \
-    ! containsElement "$(stat -c %g ${_file})" "${groups[@]}" && \
-    ! containsElement "$(stat -c %G ${_file})" "${groups[@]}"
+    # everyone permission
+    if containsElement ${perm:2:1} 2 3 6 7; then
+        return 0
+    fi
+    # owner permissions
+    if containsElement ${perm:0:1} 2 3 6 7; then
+        if [[ "$(stat -c %U ${_file})" = "${userid}" ]] || [[ "$(stat -c %u ${_file})" = "${userid}" ]]; then
+            return 0
+        fi
+    fi
+    # group permissions
+    if containsElement ${perm:1:1} 2 3 6 7; then
+        if containsElement "$(stat -c %g ${_file})" "${groups[@]}" || containsElement "$(stat -c %G ${_file})" "${groups[@]}" ; then
+            return 0
+        fi
+    fi
+    return 1
 }
 
-function print_permissions_advice_and_fail ()
+
+function print_permissions_advice_and_fail
 {
     _directory=${1}
     echo >&2 "
@@ -107,7 +121,7 @@ function check_mounted_folder_with_chown
 
     local mountFolder=${1}
     if running_as_root; then
-        if is_not_writable "${mountFolder}" && ! secure_mode_enabled; then
+        if ! is_writable "${mountFolder}" && ! secure_mode_enabled; then
             # warn that we're about to chown the folder and then chown it
             echo "Warning: Folder mounted to \"${mountFolder}\" is not writable from inside container. Changing folder owner to ${userid}."
             chown -R "${userid}":"${groupid}" "${mountFolder}"
@@ -299,6 +313,12 @@ fi
 if [ -d /logs ]; then
     check_mounted_folder_with_chown "/logs"
     : ${NEO4J_dbms_directories_logs:="/logs"}
+    if [ -d /data/databases ]; then
+        check_mounted_folder_with_chown "/data/databases"
+    fi
+    if [ -d /data/dbms ]; then
+        check_mounted_folder_with_chown "/data/dbms"
+    fi
 fi
 
 if [ -d /data ]; then
@@ -410,7 +430,7 @@ fi
 [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
 
 if [ "${cmd}" == "dump-config" ]; then
-    if is_not_writable "/conf"; then
+    if ! is_writable "/conf"; then
         print_permissions_advice_and_fail "/conf"
     fi
     cp --recursive "${NEO4J_HOME}"/conf/* /conf

--- a/docker-image-src/3.5/docker-entrypoint.sh
+++ b/docker-image-src/3.5/docker-entrypoint.sh
@@ -12,7 +12,8 @@ function secure_mode_enabled
     test "${SECURE_FILE_PERMISSIONS:=no}" = "yes"
 }
 
-containsElement () {
+function containsElement
+{
   local e match="$1"
   shift
   for e; do [[ "$e" == "$match" ]] && return 0; done
@@ -45,20 +46,33 @@ function is_readable
     return 1
 }
 
-function is_not_writable
+function is_writable
 {
+    # It would be nice if this and the is_readable function could combine somehow
     local _file=${1}
-    # Not using "test -w ${_file}" here because we need to check if the neo4j user or supplied user
-    # has write access to the file, and this script might not be running as that user.
+    perm=$(stat -c %a "${_file}")
 
-    # echo "comparing to ${userid}:${groupid}"
-    test "$(stat -c %U ${_file})" != "${userid}"  &&  \
-    test "$(stat -c %u ${_file})" != "${userid}" && \
-    ! containsElement "$(stat -c %g ${_file})" "${groups[@]}" && \
-    ! containsElement "$(stat -c %G ${_file})" "${groups[@]}"
+    # everyone permission
+    if containsElement ${perm:2:1} 2 3 6 7; then
+        return 0
+    fi
+    # owner permissions
+    if containsElement ${perm:0:1} 2 3 6 7; then
+        if [[ "$(stat -c %U ${_file})" = "${userid}" ]] || [[ "$(stat -c %u ${_file})" = "${userid}" ]]; then
+            return 0
+        fi
+    fi
+    # group permissions
+    if containsElement ${perm:1:1} 2 3 6 7; then
+        if containsElement "$(stat -c %g ${_file})" "${groups[@]}" || containsElement "$(stat -c %G ${_file})" "${groups[@]}" ; then
+            return 0
+        fi
+    fi
+    return 1
 }
 
-function print_permissions_advice_and_fail ()
+
+function print_permissions_advice_and_fail
 {
     _directory=${1}
     echo >&2 "
@@ -107,7 +121,7 @@ function check_mounted_folder_with_chown
 
     local mountFolder=${1}
     if running_as_root; then
-        if is_not_writable "${mountFolder}" && ! secure_mode_enabled; then
+        if ! is_writable "${mountFolder}" && ! secure_mode_enabled; then
             # warn that we're about to chown the folder and then chown it
             echo "Warning: Folder mounted to \"${mountFolder}\" is not writable from inside container. Changing folder owner to ${userid}."
             chown -R "${userid}":"${groupid}" "${mountFolder}"
@@ -299,6 +313,12 @@ fi
 
 if [ -d /data ]; then
     check_mounted_folder_with_chown "/data"
+    if [ -d /data/databases ]; then
+        check_mounted_folder_with_chown "/data/databases"
+    fi
+    if [ -d /data/dbms ]; then
+        check_mounted_folder_with_chown "/data/dbms"
+    fi
 fi
 
 
@@ -406,7 +426,7 @@ fi
 [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
 
 if [ "${cmd}" == "dump-config" ]; then
-    if is_not_writable "/conf"; then
+    if ! is_writable "/conf"; then
         print_permissions_advice_and_fail "/conf"
     fi
     cp --recursive "${NEO4J_HOME}"/conf/* /conf

--- a/docker-image-src/4.0/docker-entrypoint.sh
+++ b/docker-image-src/4.0/docker-entrypoint.sh
@@ -12,7 +12,8 @@ function secure_mode_enabled
     test "${SECURE_FILE_PERMISSIONS:=no}" = "yes"
 }
 
-containsElement () {
+function containsElement
+{
   local e match="$1"
   shift
   for e; do [[ "$e" == "$match" ]] && return 0; done
@@ -45,20 +46,33 @@ function is_readable
     return 1
 }
 
-function is_not_writable
+function is_writable
 {
+    # It would be nice if this and the is_readable function could combine somehow
     local _file=${1}
-    # Not using "test -w ${_file}" here because we need to check if the neo4j user or supplied user
-    # has write access to the file, and this script might not be running as that user.
+    perm=$(stat -c %a "${_file}")
 
-    # echo "comparing to ${userid}:${groupid}"
-    test "$(stat -c %U ${_file})" != "${userid}"  &&  \
-    test "$(stat -c %u ${_file})" != "${userid}" && \
-    ! containsElement "$(stat -c %g ${_file})" "${groups[@]}" && \
-    ! containsElement "$(stat -c %G ${_file})" "${groups[@]}"
+    # everyone permission
+    if containsElement ${perm:2:1} 2 3 6 7; then
+        return 0
+    fi
+    # owner permissions
+    if containsElement ${perm:0:1} 2 3 6 7; then
+        if [[ "$(stat -c %U ${_file})" = "${userid}" ]] || [[ "$(stat -c %u ${_file})" = "${userid}" ]]; then
+            return 0
+        fi
+    fi
+    # group permissions
+    if containsElement ${perm:1:1} 2 3 6 7; then
+        if containsElement "$(stat -c %g ${_file})" "${groups[@]}" || containsElement "$(stat -c %G ${_file})" "${groups[@]}" ; then
+            return 0
+        fi
+    fi
+    return 1
 }
 
-function print_permissions_advice_and_fail ()
+
+function print_permissions_advice_and_fail
 {
     _directory=${1}
     echo >&2 "
@@ -107,7 +121,7 @@ function check_mounted_folder_with_chown
 
     local mountFolder=${1}
     if running_as_root; then
-        if is_not_writable "${mountFolder}" && ! secure_mode_enabled; then
+        if ! is_writable "${mountFolder}" && ! secure_mode_enabled; then
             # warn that we're about to chown the folder and then chown it
             echo "Warning: Folder mounted to \"${mountFolder}\" is not writable from inside container. Changing folder owner to ${userid}."
             chown -R "${userid}":"${groupid}" "${mountFolder}"
@@ -299,6 +313,12 @@ fi
 
 if [ -d /data ]; then
     check_mounted_folder_with_chown "/data"
+    if [ -d /data/databases ]; then
+        check_mounted_folder_with_chown "/data/databases"
+    fi
+    if [ -d /data/dbms ]; then
+        check_mounted_folder_with_chown "/data/dbms"
+    fi
 fi
 
 
@@ -422,7 +442,7 @@ fi
 [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
 
 if [ "${cmd}" == "dump-config" ]; then
-    if is_not_writable "/conf"; then
+    if ! is_writable "/conf"; then
         print_permissions_advice_and_fail "/conf"
     fi
     cp --recursive "${NEO4J_HOME}"/conf/* /conf

--- a/docker-image-src/4.1/docker-entrypoint.sh
+++ b/docker-image-src/4.1/docker-entrypoint.sh
@@ -12,7 +12,8 @@ function secure_mode_enabled
     test "${SECURE_FILE_PERMISSIONS:=no}" = "yes"
 }
 
-containsElement () {
+function containsElement
+{
   local e match="$1"
   shift
   for e; do [[ "$e" == "$match" ]] && return 0; done
@@ -45,20 +46,33 @@ function is_readable
     return 1
 }
 
-function is_not_writable
+function is_writable
 {
+    # It would be nice if this and the is_readable function could combine somehow
     local _file=${1}
-    # Not using "test -w ${_file}" here because we need to check if the neo4j user or supplied user
-    # has write access to the file, and this script might not be running as that user.
+    perm=$(stat -c %a "${_file}")
 
-    # echo "comparing to ${userid}:${groupid}"
-    test "$(stat -c %U ${_file})" != "${userid}"  &&  \
-    test "$(stat -c %u ${_file})" != "${userid}" && \
-    ! containsElement "$(stat -c %g ${_file})" "${groups[@]}" && \
-    ! containsElement "$(stat -c %G ${_file})" "${groups[@]}"
+    # everyone permission
+    if containsElement ${perm:2:1} 2 3 6 7; then
+        return 0
+    fi
+    # owner permissions
+    if containsElement ${perm:0:1} 2 3 6 7; then
+        if [[ "$(stat -c %U ${_file})" = "${userid}" ]] || [[ "$(stat -c %u ${_file})" = "${userid}" ]]; then
+            return 0
+        fi
+    fi
+    # group permissions
+    if containsElement ${perm:1:1} 2 3 6 7; then
+        if containsElement "$(stat -c %g ${_file})" "${groups[@]}" || containsElement "$(stat -c %G ${_file})" "${groups[@]}" ; then
+            return 0
+        fi
+    fi
+    return 1
 }
 
-function print_permissions_advice_and_fail ()
+
+function print_permissions_advice_and_fail
 {
     _directory=${1}
     echo >&2 "
@@ -107,7 +121,7 @@ function check_mounted_folder_with_chown
 
     local mountFolder=${1}
     if running_as_root; then
-        if is_not_writable "${mountFolder}" && ! secure_mode_enabled; then
+        if ! is_writable "${mountFolder}" && ! secure_mode_enabled; then
             # warn that we're about to chown the folder and then chown it
             echo "Warning: Folder mounted to \"${mountFolder}\" is not writable from inside container. Changing folder owner to ${userid}."
             chown -R "${userid}":"${groupid}" "${mountFolder}"
@@ -299,6 +313,12 @@ fi
 
 if [ -d /data ]; then
     check_mounted_folder_with_chown "/data"
+    if [ -d /data/databases ]; then
+        check_mounted_folder_with_chown "/data/databases"
+    fi
+    if [ -d /data/dbms ]; then
+        check_mounted_folder_with_chown "/data/dbms"
+    fi
 fi
 
 
@@ -422,7 +442,7 @@ fi
 [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
 
 if [ "${cmd}" == "dump-config" ]; then
-    if is_not_writable "/conf"; then
+    if ! is_writable "/conf"; then
         print_permissions_advice_and_fail "/conf"
     fi
     cp --recursive "${NEO4J_HOME}"/conf/* /conf

--- a/pom.xml
+++ b/pom.xml
@@ -10,9 +10,9 @@
 	<packaging>jar</packaging>
 
 	<properties>
-		<neo4j.version>${env.NEO4JVERSION}</neo4j.version>
+		<neo4j.version>4.0.0-rc01</neo4j.version>
 		<!-- set java.version to either 1.8 or 11 but don't commit with it set to 11 -->
-		<java.version>1.8</java.version>
+		<java.version>11</java.version>
 	</properties>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -10,9 +10,9 @@
 	<packaging>jar</packaging>
 
 	<properties>
-		<neo4j.version>4.0.0-rc01</neo4j.version>
+		<neo4j.version>${env.NEO4JVERSION}</neo4j.version>
 		<!-- set java.version to either 1.8 or 11 but don't commit with it set to 11 -->
-		<java.version>11</java.version>
+		<java.version>1.8</java.version>
 	</properties>
 
 	<build>

--- a/src/test/java/com/neo4j/docker/TestConfSettings.java
+++ b/src/test/java/com/neo4j/docker/TestConfSettings.java
@@ -103,7 +103,7 @@ public class TestConfSettings {
                 .withEnv( "NEO4J_dbms_directories_data", "/notdefaultdata" )
                 .withCommand("dump-config") )
         {
-            Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "conf-", "/conf" );
+            Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "conf-overriddenbyenv-", "/conf" );
             conf = confMount.resolve( "neo4j.conf" ).toFile();
             container.setWaitStrategy(
                     Wait.forLogMessage( ".*Config Dumped.*", 1 ).withStartupTimeout( Duration.ofSeconds( 30 ) ) );
@@ -148,8 +148,8 @@ public class TestConfSettings {
         try(GenericContainer container = createContainer())
         {
             //Mount /conf
-            Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "conf-", "/conf" );
-            Path logMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-", "/logs" );
+            Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "conf-confisread-", "/conf" );
+            Path logMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-confisread-", "/logs" );
             debugLog = logMount.resolve("debug.log");
             SetContainerUser.nonRootUser( container );
             //Create ReadConf.conf file with the custom env variables
@@ -172,7 +172,7 @@ public class TestConfSettings {
         try(GenericContainer container = createContainer())
         {
             //Mount /conf
-            Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "conf-", "/conf" );
+            Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "conf-replacedbydefault-", "/conf" );
             conf = confMount.resolve( "neo4j.conf" ).toFile();
             SetContainerUser.nonRootUser( container );
             //Create ConfsReplaced.conf file
@@ -200,7 +200,7 @@ public class TestConfSettings {
         try(GenericContainer container = createContainer())
         {
             //Mount /conf
-            Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "conf-", "/conf" );
+            Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "conf-notoverriddenbydefault-", "/conf" );
             conf = confMount.resolve( "neo4j.conf" ).toFile();
             SetContainerUser.nonRootUser( container );
             //Create ConfsNotOverriden.conf file
@@ -227,8 +227,8 @@ public class TestConfSettings {
         Path debugLog;
         try(GenericContainer container = createContainer().withEnv("NEO4J_dbms_memory_pagecache_size", "512m"))
         {
-            Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "conf-", "/conf" );
-            Path logMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-", "/logs" );
+            Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "conf-envoverrideworks-", "/conf" );
+            Path logMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-envoverrideworks-", "/logs" );
             debugLog = logMount.resolve( "debug.log" );
             SetContainerUser.nonRootUser( container );
             //Create EnvVarsOverride.conf file
@@ -252,7 +252,7 @@ public class TestConfSettings {
         try(GenericContainer container = createContainer().withEnv("NEO4J_dbms_memory_pagecache_size", "512m"))
         {
             //Mount /logs
-            Path logMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-", "/logs" );
+            Path logMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-enterpriseonlysettings-", "/logs" );
             SetContainerUser.nonRootUser( container );
             //Start the container
             container.setWaitStrategy( Wait.forHttp( "/" ).forPort( 7474 ).forStatusCode( 200 ) );
@@ -275,7 +275,7 @@ public class TestConfSettings {
         try(GenericContainer container = createContainer().withEnv("NEO4J_dbms_memory_pagecache_size", "512m"))
         {
             //Mount /logs
-            Path logMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-", "/logs" );
+            Path logMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-enterprisesettingsnotincommunity-", "/logs" );
             debugLog = logMount.resolve( "debug.log" );
             SetContainerUser.nonRootUser( container );
             //Start the container
@@ -295,8 +295,8 @@ public class TestConfSettings {
         try(GenericContainer container = createContainer())
         {
             //Mount /conf
-            Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "conf-", "/conf" );
-            logMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-", "/logs" );
+            Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "conf-jvmaddnotoverridden-", "/conf" );
+            logMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-jvmaddnotoverridden-", "/logs" );
             SetContainerUser.nonRootUser( container );
             //Create JvmAdditionalNotOverriden.conf file
             Path confFile = Paths.get( "src", "test", "resources", "confs", "JvmAdditionalNotOverriden.conf" );

--- a/src/test/java/com/neo4j/docker/TestMounting.java
+++ b/src/test/java/com/neo4j/docker/TestMounting.java
@@ -64,7 +64,8 @@ public class TestMounting
 
     private void verifySingleFolder( Path folderToCheck, boolean shouldBeWritable )
     {
-        String folderForDiagnostics = TestSettings.TEST_TMP_FOLDER.relativize( folderToCheck ).toString();
+        //String folderForDiagnostics = TestSettings.TEST_TMP_FOLDER.relativize( folderToCheck ).toString();
+        String folderForDiagnostics = folderToCheck.toAbsolutePath().toString();
 
         Assertions.assertTrue( folderToCheck.toFile().exists(), "did not create " + folderForDiagnostics + " folder on host" );
         if( shouldBeWritable )
@@ -101,7 +102,7 @@ public class TestMounting
     {
         try(GenericContainer container = setupBasicContainer( true, false ))
         {
-            Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "conf-", "/conf" );
+            Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "conf-dumpconfig-", "/conf" );
             container.setWaitStrategy(
                     Wait.forLogMessage( ".*Config Dumped.*", 1 ).withStartupTimeout( Duration.ofSeconds( 30 ) ) );
             container.withCommand( "dump-config" );
@@ -123,7 +124,7 @@ public class TestMounting
 
         try(GenericContainer container = setupBasicContainer( asCurrentUser, isSecurityFlagSet ))
         {
-            Path dataMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "data-", "/data" );
+            Path dataMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "data-canmountjustdata-", "/data" );
             container.start();
 
             // neo4j should now have started, so there'll be stuff in the data folder
@@ -141,7 +142,7 @@ public class TestMounting
 
         try(GenericContainer container = setupBasicContainer( asCurrentUser, isSecurityFlagSet ))
         {
-            Path logsMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-", "/logs" );
+            Path logsMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-canmountjustlogs-", "/logs" );
             container.start();
 
             verifyLogsFolderContentsArePresentOnHost( logsMount, asCurrentUser );
@@ -157,8 +158,8 @@ public class TestMounting
 
         try(GenericContainer container = setupBasicContainer( asCurrentUser, isSecurityFlagSet ))
         {
-            Path dataMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "data-", "/data" );
-            Path logsMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-", "/logs" );
+            Path dataMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "data-canmountdataandlogs-", "/data" );
+            Path logsMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-canmountdataandlogs-", "/logs" );
             container.start();
 
             verifyDataFolderContentsArePresentOnHost( dataMount, asCurrentUser );
@@ -174,7 +175,7 @@ public class TestMounting
 
         try(GenericContainer container = setupBasicContainer( false, true ))
         {
-            HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "data-", "/data" );
+            HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "data-nopermissioninsecuremode-", "/data" );
 
             // currently Neo4j will try to start and fail. It should be fixed to throw an error and not try starting
             // container.setWaitStrategy( Wait.forLogMessage( "[fF]older /data is not accessible for user", 1 ).withStartupTimeout( Duration.ofSeconds( 20 ) ) );
@@ -193,7 +194,7 @@ public class TestMounting
 
         try(GenericContainer container = setupBasicContainer( false, true ))
         {
-            HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-", "/logs" );
+            HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-nopermissioninsecuremode-", "/logs" );
 
             // currently Neo4j will try to start and fail. It should be fixed to throw an error and not try starting
             // container.setWaitStrategy( Wait.forLogMessage( "[fF]older /logs is not accessible for user", 1 ).withStartupTimeout( Duration.ofSeconds( 20 ) ) );

--- a/src/test/java/com/neo4j/docker/TestUpgrade.java
+++ b/src/test/java/com/neo4j/docker/TestUpgrade.java
@@ -1,0 +1,59 @@
+package com.neo4j.docker;
+
+import com.neo4j.docker.utils.DatabaseIO;
+import com.neo4j.docker.utils.HostFileSystemOperations;
+import com.neo4j.docker.utils.Neo4jVersion;
+import com.neo4j.docker.utils.TestSettings;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+
+import java.nio.file.Path;
+
+public class TestUpgrade
+{
+	private static final Logger log = LoggerFactory.getLogger( TestUpgrade.class );
+	private final String user = "neo4j";
+	private final String password = "quality";
+
+	private GenericContainer makeContainer(String image)
+	{
+        GenericContainer container = new GenericContainer( image );
+        container.withEnv( "NEO4J_AUTH", user + "/" + password )
+                 .withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
+                 .withExposedPorts( 7474 )
+                 .withExposedPorts( 7687 )
+                 .withLogConsumer( new Slf4jLogConsumer( log ) );
+        return container;
+	}
+
+	@Test
+	void canUpgradeFromBeforeFilePermissionFix() throws Exception
+	{
+		Neo4jVersion beforeFix = new Neo4jVersion( 3,5,3 );
+		String beeforeFixImage = (TestSettings.EDITION == TestSettings.Edition.ENTERPRISE)?  "neo4j:3.5.3-enterprise":"neo4j:3.5.3";
+		Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isNewerThan( beforeFix ) );
+
+		Path dataMount = HostFileSystemOperations.createTempFolder( "data-upgrade-" );
+		log.info( "created folder " + dataMount.toString() + " to test upgrade" );
+
+		try(GenericContainer container = makeContainer( beeforeFixImage ))
+		{
+			HostFileSystemOperations.mountHostFolderAsVolume( container, dataMount, "/data" );
+			container.start();
+			DatabaseIO db = new DatabaseIO( container );
+			db.putInitialDataIntoContainer( user, password );
+		}
+
+		try(GenericContainer container = makeContainer( TestSettings.IMAGE_ID ))
+		{
+			HostFileSystemOperations.mountHostFolderAsVolume( container, dataMount, "/data" );
+			container.start();
+			DatabaseIO db = new DatabaseIO( container );
+			db.verifyDataInContainer( user, password );
+		}
+	}
+}

--- a/src/test/java/com/neo4j/docker/TestUpgrade.java
+++ b/src/test/java/com/neo4j/docker/TestUpgrade.java
@@ -34,13 +34,15 @@ public class TestUpgrade
 	void canUpgradeFromBeforeFilePermissionFix() throws Exception
 	{
 		Neo4jVersion beforeFix = new Neo4jVersion( 3,5,3 );
-		String beeforeFixImage = (TestSettings.EDITION == TestSettings.Edition.ENTERPRISE)?  "neo4j:3.5.3-enterprise":"neo4j:3.5.3";
-		Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isNewerThan( beforeFix ) );
+		String beforeFixImage = (TestSettings.EDITION == TestSettings.Edition.ENTERPRISE)?  "neo4j:3.5.3-enterprise":"neo4j:3.5.3";
+		Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isNewerThan( beforeFix ), "test only applicable to latest 3.5 and 4.0 versions" );
+		Assumptions.assumeFalse( TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 4,1,0 )),
+								"test only applicable to latest 3.5 and 4.0 versions" );
 
 		Path dataMount = HostFileSystemOperations.createTempFolder( "data-upgrade-" );
 		log.info( "created folder " + dataMount.toString() + " to test upgrade" );
 
-		try(GenericContainer container = makeContainer( beeforeFixImage ))
+		try(GenericContainer container = makeContainer( beforeFixImage ))
 		{
 			HostFileSystemOperations.mountHostFolderAsVolume( container, dataMount, "/data" );
 			container.start();

--- a/src/test/java/com/neo4j/docker/TestUpgrade.java
+++ b/src/test/java/com/neo4j/docker/TestUpgrade.java
@@ -31,13 +31,13 @@ public class TestUpgrade
 	}
 
 	@Test
-	void canUpgradeFromBeforeFilePermissionFix() throws Exception
+	void canUpgradeFromBeforeFilePermissionFix35() throws Exception
 	{
 		Neo4jVersion beforeFix = new Neo4jVersion( 3,5,3 );
 		String beforeFixImage = (TestSettings.EDITION == TestSettings.Edition.ENTERPRISE)?  "neo4j:3.5.3-enterprise":"neo4j:3.5.3";
-		Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isNewerThan( beforeFix ), "test only applicable to latest 3.5 and 4.0 versions" );
-		Assumptions.assumeFalse( TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 4,1,0 )),
-								"test only applicable to latest 3.5 and 4.0 versions" );
+		Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isNewerThan( beforeFix ), "test only applicable to latest 3.5 docker" );
+		Assumptions.assumeFalse( TestSettings.NEO4J_VERSION.isAtLeastVersion( Neo4jVersion.NEO4J_VERSION_400 ),
+								"test only applicable to latest 3.5 docker" );
 
 		Path dataMount = HostFileSystemOperations.createTempFolder( "data-upgrade-" );
 		log.info( "created folder " + dataMount.toString() + " to test upgrade" );
@@ -58,4 +58,6 @@ public class TestUpgrade
 			db.verifyDataInContainer( user, password );
 		}
 	}
+
+	// todo add test for 4.0 when I can figure out how to close a container cleanly
 }


### PR DESCRIPTION
Our file permission checks were testing whether the `neo4j` user is in the correct group to write to mounted `/data` (and other) directories but don't check that those directories allow group write permissions.
This was causing system lock errors when mounting `/data` folders created by Neo4j versions from before 3.5.6 because the `/data/databases` folder for some reason denied group write access but was still owned by the `neo4j` group.

Fixes #212 