### PR TITLE
Remove udc.source from 4.0.x

### DIFF
--- a/docker-image-src/4.0/docker-entrypoint.sh
+++ b/docker-image-src/4.0/docker-entrypoint.sh
@@ -439,17 +439,6 @@ for conf in ${!ENTERPRISE[@]} ; do
     fi
 done
 
-#The udc.source=tarball should be replaced by udc.source=docker in both dbms.jvm.additional and wrapper.java.additional
-#Using sed to replace only this part will allow the custom configs to be added after, separated by a ,.
-if grep -q "udc.source=tarball" "${NEO4J_HOME}"/conf/neo4j.conf; then
-     sed -i -e 's/udc.source=tarball/udc.source=docker/g' "${NEO4J_HOME}"/conf/neo4j.conf
-fi
-#The udc.source should always be set to docker by default and we have to allow also custom configs to be added after that.
-#In this case, this piece of code helps to add the default value and a , to support custom configs after.
-if ! grep -q "dbms.jvm.additional=-Dunsupported.dbms.udc.source=docker" "${NEO4J_HOME}"/conf/neo4j.conf; then
-  sed -i -e 's/dbms.jvm.additional=/dbms.jvm.additional=-Dunsupported.dbms.udc.source=docker,/g' "${NEO4J_HOME}"/conf/neo4j.conf
-fi
-
 # save NEO4J_HOME to a temp variable that doesn't begin with NEO4J_ so it doesn't get added to the conf
 temp_neo4j_home="${NEO4J_HOME}"
 # list env variables with prefix NEO4J_ and create settings from them

--- a/docker-image-src/4.1/docker-entrypoint.sh
+++ b/docker-image-src/4.1/docker-entrypoint.sh
@@ -439,17 +439,6 @@ for conf in ${!ENTERPRISE[@]} ; do
     fi
 done
 
-#The udc.source=tarball should be replaced by udc.source=docker in both dbms.jvm.additional and wrapper.java.additional
-#Using sed to replace only this part will allow the custom configs to be added after, separated by a ,.
-if grep -q "udc.source=tarball" "${NEO4J_HOME}"/conf/neo4j.conf; then
-     sed -i -e 's/udc.source=tarball/udc.source=docker/g' "${NEO4J_HOME}"/conf/neo4j.conf
-fi
-#The udc.source should always be set to docker by default and we have to allow also custom configs to be added after that.
-#In this case, this piece of code helps to add the default value and a , to support custom configs after.
-if ! grep -q "dbms.jvm.additional=-Dunsupported.dbms.udc.source=docker" "${NEO4J_HOME}"/conf/neo4j.conf; then
-  sed -i -e 's/dbms.jvm.additional=/dbms.jvm.additional=-Dunsupported.dbms.udc.source=docker,/g' "${NEO4J_HOME}"/conf/neo4j.conf
-fi
-
 # save NEO4J_HOME to a temp variable that doesn't begin with NEO4J_ so it doesn't get added to the conf
 temp_neo4j_home="${NEO4J_HOME}"
 # list env variables with prefix NEO4J_ and create settings from them

--- a/src/test/java/com/neo4j/docker/TestConfSettings.java
+++ b/src/test/java/com/neo4j/docker/TestConfSettings.java
@@ -313,7 +313,7 @@ public class TestConfSettings {
         lines.close();
         Assertions.assertTrue(isStringPresentInDebugLog( logMount.resolve("debug.log"),
                 "dbms.jvm.additional=-Dunsupported.dbms.udc.source=docker,-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"),
-            "dbms.jvm.additional was is overriden by ker-entrypoint");
+            "dbms.jvm.additional is overriden by Docker-entrypoint");
     }
 
     @Test

--- a/src/test/java/com/neo4j/docker/TestConfSettings.java
+++ b/src/test/java/com/neo4j/docker/TestConfSettings.java
@@ -294,6 +294,7 @@ public class TestConfSettings {
 
         try(GenericContainer container = createContainer())
         {
+            Assumptions.assumeFalse( TestSettings.NEO4J_VERSION.isAtLeastVersion( Neo4jVersion.NEO4J_VERSION_400), "test not applicable in versions newer than 4.0." );
             //Mount /conf
             Path confMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "conf-jvmaddnotoverridden-", "/conf" );
             logMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-jvmaddnotoverridden-", "/logs" );
@@ -307,7 +308,6 @@ public class TestConfSettings {
         }
 
         //Read the debug.log to check that dbms.jvm.additional was set correctly
-        Assumptions.assumeFalse( TestSettings.NEO4J_VERSION.isAtLeastVersion( Neo4jVersion.NEO4J_VERSION_400), "test not applicable in versions newer than 4.0." );
         Stream<String> lines = Files.lines(logMount.resolve("debug.log"));
         Optional<String> jvmAdditionalMatch = lines.filter(s -> s.contains("dbms.jvm.additional=-Dunsupported.dbms.udc.source=docker,-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005")).findFirst();
         lines.close();

--- a/src/test/java/com/neo4j/docker/TestConfSettings.java
+++ b/src/test/java/com/neo4j/docker/TestConfSettings.java
@@ -307,12 +307,13 @@ public class TestConfSettings {
         }
 
         //Read the debug.log to check that dbms.jvm.additional was set correctly
+        Assumptions.assumeFalse( TestSettings.NEO4J_VERSION.isAtLeastVersion( Neo4jVersion.NEO4J_VERSION_400), "test not applicable in versions newer than 4.0." );
         Stream<String> lines = Files.lines(logMount.resolve("debug.log"));
         Optional<String> jvmAdditionalMatch = lines.filter(s -> s.contains("dbms.jvm.additional=-Dunsupported.dbms.udc.source=docker,-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005")).findFirst();
         lines.close();
         Assertions.assertTrue(isStringPresentInDebugLog( logMount.resolve("debug.log"),
                 "dbms.jvm.additional=-Dunsupported.dbms.udc.source=docker,-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"),
-            "dbms.jvm.additional was is overriden by docker-entrypoint");
+            "dbms.jvm.additional was is overriden by ker-entrypoint");
     }
 
     @Test


### PR DESCRIPTION
Since udc.source is deprecated starting from neo4j 4.0 there is no sense into keeping it in the docker image.