### PR TITLE
Attempt to fix neo4j.conf permission errors

### DIFF
--- a/docker-image-src/3.4/docker-entrypoint.sh
+++ b/docker-image-src/3.4/docker-entrypoint.sh
@@ -235,7 +235,7 @@ if running_as_root; then
     chown "${userid}":"${groupid}" "${NEO4J_HOME}"
     chmod 700 "${NEO4J_HOME}"
     find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -user root -type d -exec chown -R ${userid}:${groupid} {} \;
-    find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -user root -type d -exec chmod -R 700 {} \;
+    find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -type d -exec chmod -R 700 {} \;
 fi
 
 # Only prompt for license agreement if command contains "neo4j" in it

--- a/docker-image-src/3.5/docker-entrypoint.sh
+++ b/docker-image-src/3.5/docker-entrypoint.sh
@@ -235,7 +235,7 @@ if running_as_root; then
     chown "${userid}":"${groupid}" "${NEO4J_HOME}"
     chmod 700 "${NEO4J_HOME}"
     find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -user root -type d -exec chown -R ${userid}:${groupid} {} \;
-    find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -user root -type d -exec chmod -R 700 {} \;
+    find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -type d -exec chmod -R 700 {} \;
 fi
 
 # Only prompt for license agreement if command contains "neo4j" in it

--- a/docker-image-src/4.0/docker-entrypoint.sh
+++ b/docker-image-src/4.0/docker-entrypoint.sh
@@ -235,7 +235,7 @@ if running_as_root; then
     chown "${userid}":"${groupid}" "${NEO4J_HOME}"
     chmod 700 "${NEO4J_HOME}"
     find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -user root -type d -exec chown -R ${userid}:${groupid} {} \;
-    find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -user root -type d -exec chmod -R 700 {} \;
+    find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -type d -exec chmod -R 700 {} \;
 fi
 
 # Only prompt for license agreement if command contains "neo4j" in it

--- a/docker-image-src/4.1/docker-entrypoint.sh
+++ b/docker-image-src/4.1/docker-entrypoint.sh
@@ -235,7 +235,7 @@ if running_as_root; then
     chown "${userid}":"${groupid}" "${NEO4J_HOME}"
     chmod 700 "${NEO4J_HOME}"
     find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -user root -type d -exec chown -R ${userid}:${groupid} {} \;
-    find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -user root -type d -exec chmod -R 700 {} \;
+    find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -type d -exec chmod -R 700 {} \;
 fi
 
 # Only prompt for license agreement if command contains "neo4j" in it


### PR DESCRIPTION
Some customers report permissions errors on start up, even when no volumes are mounted.
I haven't been able to replicate it, but I noticed this line was not actually setting ownership on the folders under neo4j_home. Perhaps fixing this will help??
https://github.com/neo4j/docker-neo4j/issues/223