### PR TITLE
removed overrides incompatible with windows networking

### DIFF
--- a/docker-image-src/3.4/docker-entrypoint.sh
+++ b/docker-image-src/3.4/docker-entrypoint.sh
@@ -406,13 +406,9 @@ COMMUNITY=(
 )
 
 ENTERPRISE=(
-     [causal_clustering.transaction_listen_address]="0.0.0.0:6000"
-     [causal_clustering.raft_listen_address]="0.0.0.0:7000"
-     [causal_clustering.discovery_listen_address]="0.0.0.0:5000"
 )
 
 for conf in ${!COMMUNITY[@]} ; do
-
     if ! grep -q "^$conf" "${NEO4J_HOME}"/conf/neo4j.conf
     then
         echo -e "\n"$conf=${COMMUNITY[$conf]} >> "${NEO4J_HOME}"/conf/neo4j.conf
@@ -420,7 +416,6 @@ for conf in ${!COMMUNITY[@]} ; do
 done
 
 for conf in ${!ENTERPRISE[@]} ; do
-
     if [ "${NEO4J_EDITION}" == "enterprise" ];
     then
        if ! grep -q "^$conf" "${NEO4J_HOME}"/conf/neo4j.conf

--- a/docker-image-src/3.5/docker-entrypoint.sh
+++ b/docker-image-src/3.5/docker-entrypoint.sh
@@ -402,13 +402,9 @@ COMMUNITY=(
 )
 
 ENTERPRISE=(
-     [causal_clustering.transaction_listen_address]="0.0.0.0:6000"
-     [causal_clustering.raft_listen_address]="0.0.0.0:7000"
-     [causal_clustering.discovery_listen_address]="0.0.0.0:5000"
 )
 
 for conf in ${!COMMUNITY[@]} ; do
-
     if ! grep -q "^$conf" "${NEO4J_HOME}"/conf/neo4j.conf
     then
         echo -e "\n"$conf=${COMMUNITY[$conf]} >> "${NEO4J_HOME}"/conf/neo4j.conf
@@ -416,7 +412,6 @@ for conf in ${!COMMUNITY[@]} ; do
 done
 
 for conf in ${!ENTERPRISE[@]} ; do
-
     if [ "${NEO4J_EDITION}" == "enterprise" ];
     then
        if ! grep -q "^$conf" "${NEO4J_HOME}"/conf/neo4j.conf

--- a/docker-image-src/4.0/docker-entrypoint.sh
+++ b/docker-image-src/4.0/docker-entrypoint.sh
@@ -403,7 +403,7 @@ if [ "${cmd}" == "neo4j" ]; then
 fi
 
 declare -A COMMUNITY
-# declare -A ENTERPRISE
+declare -A ENTERPRISE
 
 COMMUNITY=(
      [dbms.tx_log.rotation.retention_policy]="100M size"
@@ -411,24 +411,25 @@ COMMUNITY=(
      [dbms.default_listen_address]="0.0.0.0"
 )
 
-for conf in ${!COMMUNITY[@]} ; do
+ENTERPRISE=(
+)
 
+for conf in ${!COMMUNITY[@]} ; do
     if ! grep -q "^$conf" "${NEO4J_HOME}"/conf/neo4j.conf
     then
         echo -e "\n"$conf=${COMMUNITY[$conf]} >> "${NEO4J_HOME}"/conf/neo4j.conf
     fi
 done
 
-#for conf in ${!ENTERPRISE[@]} ; do
-#
-#    if [ "${NEO4J_EDITION}" == "enterprise" ];
-#    then
-#       if ! grep -q "^$conf" "${NEO4J_HOME}"/conf/neo4j.conf
-#       then
-#        echo -e "\n"$conf=${ENTERPRISE[$conf]} >> "${NEO4J_HOME}"/conf/neo4j.conf
-#       fi
-#    fi
-#done
+for conf in ${!ENTERPRISE[@]} ; do
+    if [ "${NEO4J_EDITION}" == "enterprise" ];
+    then
+       if ! grep -q "^$conf" "${NEO4J_HOME}"/conf/neo4j.conf
+       then
+        echo -e "\n"$conf=${ENTERPRISE[$conf]} >> "${NEO4J_HOME}"/conf/neo4j.conf
+       fi
+    fi
+done
 
 # save NEO4J_HOME to a temp variable that doesn't begin with NEO4J_ so it doesn't get added to the conf
 temp_neo4j_home="${NEO4J_HOME}"

--- a/docker-image-src/4.0/docker-entrypoint.sh
+++ b/docker-image-src/4.0/docker-entrypoint.sh
@@ -403,21 +403,12 @@ if [ "${cmd}" == "neo4j" ]; then
 fi
 
 declare -A COMMUNITY
-declare -A ENTERPRISE
+# declare -A ENTERPRISE
 
 COMMUNITY=(
      [dbms.tx_log.rotation.retention_policy]="100M size"
      [dbms.memory.pagecache.size]="512M"
      [dbms.default_listen_address]="0.0.0.0"
-     [dbms.connector.https.advertised_address]="0.0.0.0:7473"
-     [dbms.connector.http.advertised_address]="0.0.0.0:7474"
-     [dbms.connector.bolt.advertised_address]="0.0.0.0:7687"
-)
-
-ENTERPRISE=(
-     [causal_clustering.transaction_listen_address]="0.0.0.0:6000"
-     [causal_clustering.raft_listen_address]="0.0.0.0:7000"
-     [causal_clustering.discovery_listen_address]="0.0.0.0:5000"
 )
 
 for conf in ${!COMMUNITY[@]} ; do
@@ -428,16 +419,16 @@ for conf in ${!COMMUNITY[@]} ; do
     fi
 done
 
-for conf in ${!ENTERPRISE[@]} ; do
-
-    if [ "${NEO4J_EDITION}" == "enterprise" ];
-    then
-       if ! grep -q "^$conf" "${NEO4J_HOME}"/conf/neo4j.conf
-       then
-        echo -e "\n"$conf=${ENTERPRISE[$conf]} >> "${NEO4J_HOME}"/conf/neo4j.conf
-       fi
-    fi
-done
+#for conf in ${!ENTERPRISE[@]} ; do
+#
+#    if [ "${NEO4J_EDITION}" == "enterprise" ];
+#    then
+#       if ! grep -q "^$conf" "${NEO4J_HOME}"/conf/neo4j.conf
+#       then
+#        echo -e "\n"$conf=${ENTERPRISE[$conf]} >> "${NEO4J_HOME}"/conf/neo4j.conf
+#       fi
+#    fi
+#done
 
 # save NEO4J_HOME to a temp variable that doesn't begin with NEO4J_ so it doesn't get added to the conf
 temp_neo4j_home="${NEO4J_HOME}"

--- a/docker-image-src/4.1/docker-entrypoint.sh
+++ b/docker-image-src/4.1/docker-entrypoint.sh
@@ -403,7 +403,7 @@ if [ "${cmd}" == "neo4j" ]; then
 fi
 
 declare -A COMMUNITY
-# declare -A ENTERPRISE
+declare -A ENTERPRISE
 
 COMMUNITY=(
      [dbms.tx_log.rotation.retention_policy]="100M size"
@@ -411,24 +411,25 @@ COMMUNITY=(
      [dbms.default_listen_address]="0.0.0.0"
 )
 
-for conf in ${!COMMUNITY[@]} ; do
+ENTERPRISE=(
+)
 
+for conf in ${!COMMUNITY[@]} ; do
     if ! grep -q "^$conf" "${NEO4J_HOME}"/conf/neo4j.conf
     then
         echo -e "\n"$conf=${COMMUNITY[$conf]} >> "${NEO4J_HOME}"/conf/neo4j.conf
     fi
 done
 
-#for conf in ${!ENTERPRISE[@]} ; do
-#
-#    if [ "${NEO4J_EDITION}" == "enterprise" ];
-#    then
-#       if ! grep -q "^$conf" "${NEO4J_HOME}"/conf/neo4j.conf
-#       then
-#        echo -e "\n"$conf=${ENTERPRISE[$conf]} >> "${NEO4J_HOME}"/conf/neo4j.conf
-#       fi
-#    fi
-#done
+for conf in ${!ENTERPRISE[@]} ; do
+    if [ "${NEO4J_EDITION}" == "enterprise" ];
+    then
+       if ! grep -q "^$conf" "${NEO4J_HOME}"/conf/neo4j.conf
+       then
+        echo -e "\n"$conf=${ENTERPRISE[$conf]} >> "${NEO4J_HOME}"/conf/neo4j.conf
+       fi
+    fi
+done
 
 # save NEO4J_HOME to a temp variable that doesn't begin with NEO4J_ so it doesn't get added to the conf
 temp_neo4j_home="${NEO4J_HOME}"

--- a/docker-image-src/4.1/docker-entrypoint.sh
+++ b/docker-image-src/4.1/docker-entrypoint.sh
@@ -403,21 +403,12 @@ if [ "${cmd}" == "neo4j" ]; then
 fi
 
 declare -A COMMUNITY
-declare -A ENTERPRISE
+# declare -A ENTERPRISE
 
 COMMUNITY=(
      [dbms.tx_log.rotation.retention_policy]="100M size"
      [dbms.memory.pagecache.size]="512M"
      [dbms.default_listen_address]="0.0.0.0"
-     [dbms.connector.https.advertised_address]="0.0.0.0:7473"
-     [dbms.connector.http.advertised_address]="0.0.0.0:7474"
-     [dbms.connector.bolt.advertised_address]="0.0.0.0:7687"
-)
-
-ENTERPRISE=(
-     [causal_clustering.transaction_listen_address]="0.0.0.0:6000"
-     [causal_clustering.raft_listen_address]="0.0.0.0:7000"
-     [causal_clustering.discovery_listen_address]="0.0.0.0:5000"
 )
 
 for conf in ${!COMMUNITY[@]} ; do
@@ -428,16 +419,16 @@ for conf in ${!COMMUNITY[@]} ; do
     fi
 done
 
-for conf in ${!ENTERPRISE[@]} ; do
-
-    if [ "${NEO4J_EDITION}" == "enterprise" ];
-    then
-       if ! grep -q "^$conf" "${NEO4J_HOME}"/conf/neo4j.conf
-       then
-        echo -e "\n"$conf=${ENTERPRISE[$conf]} >> "${NEO4J_HOME}"/conf/neo4j.conf
-       fi
-    fi
-done
+#for conf in ${!ENTERPRISE[@]} ; do
+#
+#    if [ "${NEO4J_EDITION}" == "enterprise" ];
+#    then
+#       if ! grep -q "^$conf" "${NEO4J_HOME}"/conf/neo4j.conf
+#       then
+#        echo -e "\n"$conf=${ENTERPRISE[$conf]} >> "${NEO4J_HOME}"/conf/neo4j.conf
+#       fi
+#    fi
+#done
 
 # save NEO4J_HOME to a temp variable that doesn't begin with NEO4J_ so it doesn't get added to the conf
 temp_neo4j_home="${NEO4J_HOME}"

--- a/src/test/java/com/neo4j/docker/TestCausalCluster.java
+++ b/src/test/java/com/neo4j/docker/TestCausalCluster.java
@@ -64,7 +64,11 @@ public class TestCausalCluster
         DockerComposeContainer clusteringContainer = new DockerComposeContainer(compose_file)
                 .withLocalCompose(true)
                 .withExposedService("core1", DEFAULT_BOLT_PORT )
-                .withExposedService("core1", 7474, Wait.forHttp( "/" ).forPort( 7474 ).forStatusCode( 200 ).withStartupTimeout( Duration.ofSeconds( 300 ) ))
+                .withExposedService("core1", 7474,
+									Wait.forHttp( "/" )
+										.forPort( 7474 )
+										.forStatusCode( 200 )
+										.withStartupTimeout( Duration.ofSeconds( 300 ) ))
                 .withExposedService("readreplica1", DEFAULT_BOLT_PORT);
 
         clusteringContainer.start();

--- a/src/test/java/com/neo4j/docker/TestConfSettings.java
+++ b/src/test/java/com/neo4j/docker/TestConfSettings.java
@@ -4,8 +4,10 @@ import com.neo4j.docker.utils.HostFileSystemOperations;
 import com.neo4j.docker.utils.Neo4jVersion;
 import com.neo4j.docker.utils.SetContainerUser;
 import com.neo4j.docker.utils.TestSettings;
+import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -264,27 +266,29 @@ public class TestConfSettings {
         }
     }
 
-//    @Test
-//    void testCommunityDoesNotHaveEnterpriseConfigs() throws Exception
-//    {
-//        Assumptions.assumeTrue(TestSettings.EDITION == TestSettings.Edition.COMMUNITY,
-//                               "This is testing only COMMUNITY EDITION configs");
-//        Path debugLog;
-//        try(GenericContainer container = createContainer().withEnv("NEO4J_dbms_memory_pagecache_size", "512m"))
-//        {
-//            //Mount /logs
-//            Path logMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-enterprisesettingsnotincommunity-", "/logs" );
-//            debugLog = logMount.resolve( "debug.log" );
-//            SetContainerUser.nonRootUser( container );
-//            //Start the container
-//            container.setWaitStrategy( Wait.forHttp( "/" ).forPort( 7474 ).forStatusCode( 200 ) );
-//            container.start();
-//        }
-//
-//        //Read debug.log to check that causal_clustering confs are not present
-//        Assertions.assertFalse(isStringPresentInDebugLog( debugLog, "causal_clustering.transaction_listen_address" ),
-//                               "causal_clustering.transaction_listen_address should not be on the Community debug.log");
-//    }
+    @Disabled
+    @Test
+    void testCommunityDoesNotHaveEnterpriseConfigs() throws Exception
+    {
+		Assert.fail( "This test should not have run!" );
+        Assumptions.assumeTrue(TestSettings.EDITION == TestSettings.Edition.COMMUNITY,
+                               "This is testing only COMMUNITY EDITION configs");
+        Path debugLog;
+        try(GenericContainer container = createContainer().withEnv("NEO4J_dbms_memory_pagecache_size", "512m"))
+        {
+            //Mount /logs
+            Path logMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-enterprisesettingsnotincommunity-", "/logs" );
+            debugLog = logMount.resolve( "debug.log" );
+            SetContainerUser.nonRootUser( container );
+            //Start the container
+            container.setWaitStrategy( Wait.forHttp( "/" ).forPort( 7474 ).forStatusCode( 200 ) );
+            container.start();
+        }
+
+        //Read debug.log to check that causal_clustering confs are not present
+        Assertions.assertFalse(isStringPresentInDebugLog( debugLog, "causal_clustering.transaction_listen_address" ),
+                               "causal_clustering.transaction_listen_address should not be on the Community debug.log");
+    }
 
     @Test
     void testJvmAdditionalNotOverridden() throws Exception

--- a/src/test/java/com/neo4j/docker/TestConfSettings.java
+++ b/src/test/java/com/neo4j/docker/TestConfSettings.java
@@ -213,9 +213,9 @@ public class TestConfSettings {
 
         //Read the config file to check if the config is not overriden
         Map<String, String> configurations = parseConfFile(conf);
-        Assertions.assertTrue(configurations.containsKey("dbms.connector.https.listen_address"), "conf settings not set correctly by docker-entrypoint");
-        Assertions.assertEquals(":8483",
-                                configurations.get("dbms.connector.https.listen_address"),
+        Assertions.assertTrue(configurations.containsKey("dbms.memory.pagecache.size"), "conf settings not set correctly by docker-entrypoint");
+        Assertions.assertEquals("1024M",
+                                configurations.get("dbms.memory.pagecache.size"),
                                 "docker-entrypoint has overriden custom setting set from user's conf");
     }
 
@@ -264,27 +264,28 @@ public class TestConfSettings {
         }
     }
 
-    @Test
-    void testCommunityDoesNotHaveEnterpriseConfigs() throws Exception
-    {
-        Assumptions.assumeTrue(TestSettings.EDITION == TestSettings.Edition.COMMUNITY,
-                               "This is testing only COMMUNITY EDITION configs");
-        Path debugLog;
-        try(GenericContainer container = createContainer().withEnv("NEO4J_dbms_memory_pagecache_size", "512m"))
-        {
-            //Mount /logs
-            Path logMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-enterprisesettingsnotincommunity-", "/logs" );
-            debugLog = logMount.resolve( "debug.log" );
-            SetContainerUser.nonRootUser( container );
-            //Start the container
-            container.setWaitStrategy( Wait.forHttp( "/" ).forPort( 7474 ).forStatusCode( 200 ) );
-            container.start();
-        }
+//    @Test
+//    void testCommunityDoesNotHaveEnterpriseConfigs() throws Exception
+//    {
+//        Assumptions.assumeTrue(TestSettings.EDITION == TestSettings.Edition.COMMUNITY,
+//                               "This is testing only COMMUNITY EDITION configs");
+//        Path debugLog;
+//        try(GenericContainer container = createContainer().withEnv("NEO4J_dbms_memory_pagecache_size", "512m"))
+//        {
+//            //Mount /logs
+//            Path logMount = HostFileSystemOperations.createTempFolderAndMountAsVolume( container, "logs-enterprisesettingsnotincommunity-", "/logs" );
+//            debugLog = logMount.resolve( "debug.log" );
+//            SetContainerUser.nonRootUser( container );
+//            //Start the container
+//            container.setWaitStrategy( Wait.forHttp( "/" ).forPort( 7474 ).forStatusCode( 200 ) );
+//            container.start();
+//        }
+//
+//        //Read debug.log to check that causal_clustering confs are not present
+//        Assertions.assertFalse(isStringPresentInDebugLog( debugLog, "causal_clustering.transaction_listen_address" ),
+//                               "causal_clustering.transaction_listen_address should not be on the Community debug.log");
+//    }
 
-        //Read debug.log to check that causal_clustering confs are not present
-        Assertions.assertFalse(isStringPresentInDebugLog( debugLog, "causal_clustering.transaction_listen_address" ),
-                               "causal_clustering.transaction_listen_address should not be on the Community debug.log");
-    }
     @Test
     void testJvmAdditionalNotOverridden() throws Exception
     {

--- a/src/test/resources/confs/ConfsNotOverriden.conf
+++ b/src/test/resources/confs/ConfsNotOverriden.conf
@@ -1,1 +1,1 @@
-dbms.connector.https.listen_address=:8483
+dbms.memory.pagecache.size=1024M


### PR DESCRIPTION
Removing several unnecessary advertised and listen address overrides from the entrypoint.
In Linux `0.0.0.0` automatically resolves to `localhost`, but this is not true in Windows.
Removing the uneccessary overrides from the docker configuration should make docker more closely match the non-docker settings.

This should fix issue #240