### PR TITLE
fixed issue #243, file permission problems under /var/lib/neo4j

### DIFF
--- a/docker-image-src/3.4/docker-entrypoint.sh
+++ b/docker-image-src/3.4/docker-entrypoint.sh
@@ -234,7 +234,7 @@ if running_as_root; then
     # Non-recursive chown for the base directory
     chown "${userid}":"${groupid}" "${NEO4J_HOME}"
     chmod 700 "${NEO4J_HOME}"
-    find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -user root -type d -exec chown -R ${userid}:${groupid} {} \;
+    find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -type d -exec chown -R ${userid}:${groupid} {} \;
     find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -type d -exec chmod -R 700 {} \;
 fi
 

--- a/docker-image-src/3.5/docker-entrypoint.sh
+++ b/docker-image-src/3.5/docker-entrypoint.sh
@@ -234,7 +234,7 @@ if running_as_root; then
     # Non-recursive chown for the base directory
     chown "${userid}":"${groupid}" "${NEO4J_HOME}"
     chmod 700 "${NEO4J_HOME}"
-    find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -user root -type d -exec chown -R ${userid}:${groupid} {} \;
+    find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -type d -exec chown -R ${userid}:${groupid} {} \;
     find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -type d -exec chmod -R 700 {} \;
 fi
 

--- a/docker-image-src/4.0/docker-entrypoint.sh
+++ b/docker-image-src/4.0/docker-entrypoint.sh
@@ -234,7 +234,7 @@ if running_as_root; then
     # Non-recursive chown for the base directory
     chown "${userid}":"${groupid}" "${NEO4J_HOME}"
     chmod 700 "${NEO4J_HOME}"
-    find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -user root -type d -exec chown -R ${userid}:${groupid} {} \;
+    find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -type d -exec chown -R ${userid}:${groupid} {} \;
     find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -type d -exec chmod -R 700 {} \;
 fi
 

--- a/docker-image-src/4.1/docker-entrypoint.sh
+++ b/docker-image-src/4.1/docker-entrypoint.sh
@@ -234,7 +234,7 @@ if running_as_root; then
     # Non-recursive chown for the base directory
     chown "${userid}":"${groupid}" "${NEO4J_HOME}"
     chmod 700 "${NEO4J_HOME}"
-    find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -user root -type d -exec chown -R ${userid}:${groupid} {} \;
+    find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -type d -exec chown -R ${userid}:${groupid} {} \;
     find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -type d -exec chmod -R 700 {} \;
 fi
 

--- a/src/test/java/com/neo4j/docker/TestConfSettings.java
+++ b/src/test/java/com/neo4j/docker/TestConfSettings.java
@@ -266,6 +266,7 @@ public class TestConfSettings {
         }
     }
 
+    // disabled because there are currently no enterprise-only settings
     @Disabled
     @Test
     void testCommunityDoesNotHaveEnterpriseConfigs() throws Exception


### PR DESCRIPTION
folders mounted under neo4j home were only give read access to `root` instead of `neo4j`.

Change #237 applied a chmod 700 to *all* files and folders under home instead of ones that were only owned by root. This meant that all mounted files under home which were not owned by neo4j became unreadable.