### PR TITLE
explicitly set neo4j uid and gid to 7474 in Docker

### DIFF
--- a/docker-image-src/4.0/Dockerfile
+++ b/docker-image-src/4.0/Dockerfile
@@ -8,7 +8,7 @@ ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     TINI_SHA256="12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855"
 ARG NEO4J_URI=%%NEO4J_DIST_SITE%%/%%NEO4J_TARBALL%%
 
-RUN addgroup --system neo4j && adduser --system --no-create-home --home "${NEO4J_HOME}" --ingroup neo4j neo4j
+RUN addgroup --gid 7474 --system neo4j && adduser --uid 7474 --system --no-create-home --home "${NEO4J_HOME}" --ingroup neo4j neo4j
 
 COPY ./local-package/* /tmp/
 

--- a/docker-image-src/4.1/Dockerfile
+++ b/docker-image-src/4.1/Dockerfile
@@ -8,7 +8,7 @@ ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     TINI_SHA256="12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855"
 ARG NEO4J_URI=%%NEO4J_DIST_SITE%%/%%NEO4J_TARBALL%%
 
-RUN addgroup --system neo4j && adduser --system --no-create-home --home "${NEO4J_HOME}" --ingroup neo4j neo4j
+RUN addgroup --gid 7474 --system neo4j && adduser --uid 7474 --system --no-create-home --home "${NEO4J_HOME}" --ingroup neo4j neo4j
 
 COPY ./local-package/* /tmp/
 

--- a/docker-image-src/4.2/Dockerfile
+++ b/docker-image-src/4.2/Dockerfile
@@ -8,7 +8,7 @@ ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     TINI_SHA256="12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855"
 ARG NEO4J_URI=%%NEO4J_DIST_SITE%%/%%NEO4J_TARBALL%%
 
-RUN addgroup --system neo4j && adduser --system --no-create-home --home "${NEO4J_HOME}" --ingroup neo4j neo4j
+RUN addgroup --gid 7474 --system neo4j && adduser --uid 7474 --system --no-create-home --home "${NEO4J_HOME}" --ingroup neo4j neo4j
 
 COPY ./local-package/* /tmp/
 


### PR DESCRIPTION
Suggested fix for #252 and following recommended practice from Docker: 
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user

There may be some side effects I haven't thought of though if we assign a uid/gid to the new user. I set the value quite high so it's less likely to conflict with something that already exists.