### PR TITLE
generate ARM64 compatible images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ series := $(shell echo "$(NEO4JVERSION)" | sed -E 's/^([0-9]+\.[0-9]+)\..*/\1/')
 # the value of variable is passed to the maven test property. For more info see https://maven.apache.org/surefire/maven-surefire-plugin/examples/single-test.html
 # by default this is empty which means all tests will be run
 TESTS?=""
+NEO4J_BASE_IMAGE?="openjdk:11-jdk-slim"
 
 all: test
 .PHONY: all
@@ -92,6 +93,7 @@ tmp/image-%/.sentinel: docker-image-src/$(series)/Dockerfile docker-image-src/$(
 > cp $(filter %/docker-entrypoint.sh,$^) $(@D)/docker-entrypoint.sh
 > sha=$$(shasum --algorithm=256 $(filter %.tar.gz,$^) | cut -d' ' -f1)
 > <$(filter %/Dockerfile,$^) sed \
+    -e "s|%%NEO4J_BASE_IMAGE%%|${NEO4J_BASE_IMAGE}|" \
     -e "s|%%NEO4J_SHA%%|$${sha}|" \
     -e "s|%%NEO4J_TARBALL%%|$(call tarball,$*,$(NEO4JVERSION))|" \
     -e "s|%%NEO4J_EDITION%%|$*|" \

--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,12 @@
-SHELL := bash
-.ONESHELL:
-.SHELLFLAGS := -eu -o pipefail -c
-.DELETE_ON_ERROR:
-.SECONDEXPANSION:
-.SECONDARY:
+include make-common.mk
 
-ifeq ($(origin .RECIPEPREFIX), undefined)
-  $(error This Make does not support .RECIPEPREFIX. Please use GNU Make 4.0 or later)
-endif
-.RECIPEPREFIX = >
-
-ifndef NEO4JVERSION
-  $(error NEO4JVERSION is not set)
-endif
-
-tarball = neo4j-$(1)-$(2)-unix.tar.gz
-dist_site := https://dist.neo4j.org
-series := $(shell echo "$(NEO4JVERSION)" | sed -E 's/^([0-9]+\.[0-9]+)\..*/\1/')
+NEO4J_BASE_IMAGE?="openjdk:11-jdk-slim"
 
 # Use make test TESTS='<pattern>' to run specific tests
 # e.g. `make test TESTS='TestCausalCluster'` or `make test TESTS='*Cluster*'`
 # the value of variable is passed to the maven test property. For more info see https://maven.apache.org/surefire/maven-surefire-plugin/examples/single-test.html
 # by default this is empty which means all tests will be run
 TESTS?=""
-NEO4J_BASE_IMAGE?="openjdk:11-jdk-slim"
 
 all: test
 .PHONY: all
@@ -47,23 +30,17 @@ build: tmp/.image-id-community tmp/.image-id-enterprise
 package: package-community package-enterprise
 .PHONY: package
 
-package-community: tmp/.image-id-community out/community/.sentinel
+package-community: tmp/.image-id-community
 > mkdir -p out
 > docker tag $$(cat $<) neo4j:$(NEO4JVERSION)
 > docker save neo4j:$(NEO4JVERSION) > out/neo4j-community-$(NEO4JVERSION)-docker-loadable.tar
 
-package-enterprise: tmp/.image-id-enterprise out/enterprise/.sentinel
+package-enterprise: tmp/.image-id-enterprise
 > mkdir -p out
 > docker tag $$(cat $<) neo4j:$(NEO4JVERSION)-enterprise
 > docker save neo4j:$(NEO4JVERSION)-enterprise > out/neo4j-enterprise-$(NEO4JVERSION)-docker-loadable.tar
 
-out/%/.sentinel: tmp/image-%/.sentinel
-> mkdir -p $(@D)
-> cp -r $(<D)/* $(@D)
-> touch $@
-
-# building the image
-
+# create image from local build context
 tmp/.image-id-%: tmp/local-context-%/.sentinel
 > mkdir -p $(@D)
 > image=test/$$RANDOM
@@ -74,53 +51,3 @@ tmp/.image-id-%: tmp/local-context-%/.sentinel
 > echo "NEO4JVERSION=$(NEO4JVERSION)" > tmp/devenv-${*}.env
 > echo "NEO4J_IMAGE=$$image" >> tmp/devenv-${*}.env
 > echo "NEO4J_EDITION=${*}" >> tmp/devenv-${*}.env
-
-tmp/neo4jlabs-plugins.json: ./neo4jlabs-plugins.json
-> mkdir -p $(@D)
-> cp $< $@
-
-tmp/local-context-%/.sentinel: tmp/image-%/.sentinel in/$(call tarball,%,$(NEO4JVERSION)) tmp/neo4jlabs-plugins.json
-> rm -rf $(@D)
-> mkdir -p $(@D)
-> cp -r $(<D)/* $(@D)
-> cp $(filter %.tar.gz,$^) $(@D)/local-package
-> cp $(filter %.json,$^) $(@D)/local-package
-> touch $@
-
-tmp/image-%/.sentinel: docker-image-src/$(series)/Dockerfile docker-image-src/$(series)/docker-entrypoint.sh \
-                       in/$(call tarball,%,$(NEO4JVERSION)) tmp/neo4jlabs-plugins.json
-> mkdir -p $(@D)
-> cp $(filter %/docker-entrypoint.sh,$^) $(@D)/docker-entrypoint.sh
-> sha=$$(shasum --algorithm=256 $(filter %.tar.gz,$^) | cut -d' ' -f1)
-> <$(filter %/Dockerfile,$^) sed \
-    -e "s|%%NEO4J_BASE_IMAGE%%|${NEO4J_BASE_IMAGE}|" \
-    -e "s|%%NEO4J_SHA%%|$${sha}|" \
-    -e "s|%%NEO4J_TARBALL%%|$(call tarball,$*,$(NEO4JVERSION))|" \
-    -e "s|%%NEO4J_EDITION%%|$*|" \
-    -e "s|%%NEO4J_DIST_SITE%%|$(dist_site)|" \
-    >$(@D)/Dockerfile
-> mkdir -p $(@D)/local-package
-> cp $(filter %.json,$^) $(@D)/local-package
-> touch $(@D)/local-package/.sentinel
-> touch $@
-
-fetch_tarball = curl --fail --silent --show-error --location --remote-name \
-    $(dist_site)/$(call tarball,$(1),$(NEO4JVERSION))
-
-cache: in/neo4j-%-$(NEO4JVERSION)-unix.tar.gz
-.PHONY: cache
-
-in/neo4j-community-$(NEO4JVERSION)-unix.tar.gz:
-> mkdir -p in
-> cd in
-> $(call fetch_tarball,community)
-
-in/neo4j-enterprise-$(NEO4JVERSION)-unix.tar.gz:
-> mkdir -p in
-> cd in
-> $(call fetch_tarball,enterprise)
-
-clean:
-> rm -rf tmp
-> rm -rf out
-.PHONY: clean

--- a/docker-image-src/4.0/Dockerfile
+++ b/docker-image-src/4.0/Dockerfile
@@ -1,12 +1,13 @@
-FROM openjdk:11-jdk-slim
+FROM %%NEO4J_BASE_IMAGE%%
 
 ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \
     NEO4J_EDITION=%%NEO4J_EDITION%% \
     NEO4J_HOME="/var/lib/neo4j" \
-    TINI_VERSION="v0.18.0" \
-    TINI_SHA256="12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855"
+    TINI_VERSION="v0.18.0"
 ARG NEO4J_URI=%%NEO4J_DIST_SITE%%/%%NEO4J_TARBALL%%
+ARG TINI_SHA256="12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855"
+ARG TINI_ARCH=""
 
 RUN addgroup --gid 7474 --system neo4j && adduser --uid 7474 --system --no-create-home --home "${NEO4J_HOME}" --ingroup neo4j neo4j
 
@@ -14,7 +15,7 @@ COPY ./local-package/* /tmp/
 
 RUN apt update \
     && apt install -y curl wget gosu jq \
-    && curl -L --fail --silent --show-error "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini" > /sbin/tini \
+    && curl -L --fail --silent --show-error "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini${TINI_ARCH}" > /sbin/tini \
     && echo "${TINI_SHA256}  /sbin/tini" | sha256sum -c --strict --quiet \
     && chmod +x /sbin/tini \
     && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \

--- a/docker-image-src/4.0/Dockerfile
+++ b/docker-image-src/4.0/Dockerfile
@@ -3,11 +3,10 @@ FROM %%NEO4J_BASE_IMAGE%%
 ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \
     NEO4J_EDITION=%%NEO4J_EDITION%% \
-    NEO4J_HOME="/var/lib/neo4j" \
-    TINI_VERSION="v0.18.0"
+    NEO4J_HOME="/var/lib/neo4j"
 ARG NEO4J_URI=%%NEO4J_DIST_SITE%%/%%NEO4J_TARBALL%%
 ARG TINI_SHA256="12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855"
-ARG TINI_ARCH=""
+ARG TINI_URI="https://github.com/krallin/tini/releases/download/v0.18.0/tini"
 
 RUN addgroup --gid 7474 --system neo4j && adduser --uid 7474 --system --no-create-home --home "${NEO4J_HOME}" --ingroup neo4j neo4j
 
@@ -15,7 +14,7 @@ COPY ./local-package/* /tmp/
 
 RUN apt update \
     && apt install -y curl wget gosu jq \
-    && curl -L --fail --silent --show-error "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini${TINI_ARCH}" > /sbin/tini \
+    && curl -L --fail --silent --show-error ${TINI_URI} > /sbin/tini \
     && echo "${TINI_SHA256}  /sbin/tini" | sha256sum -c --strict --quiet \
     && chmod +x /sbin/tini \
     && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \

--- a/docker-image-src/4.1/Dockerfile
+++ b/docker-image-src/4.1/Dockerfile
@@ -1,12 +1,12 @@
-FROM openjdk:11-jdk-slim
+FROM %%NEO4J_BASE_IMAGE%%
 
 ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \
     NEO4J_EDITION=%%NEO4J_EDITION%% \
-    NEO4J_HOME="/var/lib/neo4j" \
-    TINI_VERSION="v0.18.0" \
-    TINI_SHA256="12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855"
+    NEO4J_HOME="/var/lib/neo4j"
 ARG NEO4J_URI=%%NEO4J_DIST_SITE%%/%%NEO4J_TARBALL%%
+ARG TINI_SHA256="12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855"
+ARG TINI_URI="https://github.com/krallin/tini/releases/download/v0.18.0/tini"
 
 RUN addgroup --gid 7474 --system neo4j && adduser --uid 7474 --system --no-create-home --home "${NEO4J_HOME}" --ingroup neo4j neo4j
 
@@ -14,7 +14,7 @@ COPY ./local-package/* /tmp/
 
 RUN apt update \
     && apt install -y curl wget gosu jq \
-    && curl -L --fail --silent --show-error "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini" > /sbin/tini \
+    && curl -L --fail --silent --show-error ${TINI_URI} > /sbin/tini \
     && echo "${TINI_SHA256}  /sbin/tini" | sha256sum -c --strict --quiet \
     && chmod +x /sbin/tini \
     && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \

--- a/docker-image-src/4.2/Dockerfile
+++ b/docker-image-src/4.2/Dockerfile
@@ -1,12 +1,12 @@
-FROM openjdk:11-jdk-slim
+FROM %%NEO4J_BASE_IMAGE%%
 
 ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \
     NEO4J_EDITION=%%NEO4J_EDITION%% \
-    NEO4J_HOME="/var/lib/neo4j" \
-    TINI_VERSION="v0.18.0" \
-    TINI_SHA256="12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855"
+    NEO4J_HOME="/var/lib/neo4j"
 ARG NEO4J_URI=%%NEO4J_DIST_SITE%%/%%NEO4J_TARBALL%%
+ARG TINI_SHA256="12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855"
+ARG TINI_URI="https://github.com/krallin/tini/releases/download/v0.18.0/tini"
 
 RUN addgroup --gid 7474 --system neo4j && adduser --uid 7474 --system --no-create-home --home "${NEO4J_HOME}" --ingroup neo4j neo4j
 
@@ -14,7 +14,7 @@ COPY ./local-package/* /tmp/
 
 RUN apt update \
     && apt install -y curl wget gosu jq \
-    && curl -L --fail --silent --show-error "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini" > /sbin/tini \
+    && curl -L --fail --silent --show-error ${TINI_URI} > /sbin/tini \
     && echo "${TINI_SHA256}  /sbin/tini" | sha256sum -c --strict --quiet \
     && chmod +x /sbin/tini \
     && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \

--- a/make-arm64.mk
+++ b/make-arm64.mk
@@ -1,0 +1,26 @@
+include make-common.mk
+
+NEO4J_BASE_IMAGE?="arm64v8/openjdk:11-jdk-slim"
+
+package-arm: arm
+> mkdir -p out
+> docker tag $$(cat tmp/.image-id-community-arm) neo4j:$(NEO4JVERSION)-arm64
+> docker save neo4j:$(NEO4JVERSION)-arm64 > out/neo4j-community-$(NEO4JVERSION)-arm64-docker-loadable.tar
+> docker tag $$(cat tmp/.image-id-enterprise-arm) neo4j:$(NEO4JVERSION)-arm64-enterprise
+> docker save neo4j:$(NEO4JVERSION)-arm64-enterprise > out/neo4j-enterprise-$(NEO4JVERSION)-arm64-docker-loadable.tar
+.PHONY: package-arm
+
+# create release images for arm architecture (not for production use!)
+build-arm: tmp/.image-id-community-arm tmp/.image-id-enterprise-arm
+.PHONY: arm
+
+tmp/.image-id-%-arm: tmp/local-context-%/.sentinel
+> image=test/$$RANDOM-arm
+> docker build --tag=$$image \
+    --build-arg="NEO4J_URI=file:///tmp/$(call tarball,$*,$(NEO4JVERSION))" \
+    --build-arg="TINI_URI=https://github.com/krallin/tini/releases/download/v0.18.0/tini-arm64" \
+    --build-arg="TINI_SHA256=7c5463f55393985ee22357d976758aaaecd08defb3c5294d353732018169b019" \
+    $(<D)
+> echo -n $$image >$@
+
+

--- a/make-common.mk
+++ b/make-common.mk
@@ -1,0 +1,82 @@
+SHELL := bash
+.ONESHELL:
+.SHELLFLAGS := -eu -o pipefail -c
+.DELETE_ON_ERROR:
+.SECONDEXPANSION:
+.SECONDARY:
+
+ifeq ($(origin .RECIPEPREFIX), undefined)
+  $(error This Make does not support .RECIPEPREFIX. Please use GNU Make 4.0 or later)
+endif
+.RECIPEPREFIX = >
+
+ifndef NEO4JVERSION
+  $(error NEO4JVERSION is not set)
+endif
+
+tarball = neo4j-$(1)-$(2)-unix.tar.gz
+dist_site := https://dist.neo4j.org
+series := $(shell echo "$(NEO4JVERSION)" | sed -E 's/^([0-9]+\.[0-9]+)\..*/\1/')
+NEO4J_BASE_IMAGE?="openjdk:11-jdk-slim"
+
+out/%/.sentinel: tmp/image-%/.sentinel
+> mkdir -p $(@D)
+> cp -r $(<D)/* $(@D)
+> touch $@
+
+## building the image ##
+
+# tmp/local-context-{community,enterprise} is a local folder containing the
+# Dockerfile/entrypoint/Neo4j/etc required to build a complete image locally.
+tmp/local-context-%/.sentinel: tmp/image-%/.sentinel in/$(call tarball,%,$(NEO4JVERSION)) tmp/neo4jlabs-plugins.json
+> rm -rf $(@D)
+> mkdir -p $(@D)
+> cp -r $(<D)/* $(@D)
+> cp $(filter %.tar.gz,$^) $(@D)/local-package
+> cp $(filter %.json,$^) $(@D)/local-package
+> touch $@
+
+# tmp/image-{community,enterprise} contains the Dockerfile, docker-entrypoint.sh and plugins.json
+# with all the variables (eg tini) filled in, but *NO Neo4j tar*. This is what gets released to dockerhub.
+# You can successfully do `docker build tmp/image-{community,enterprise}` so long as the Neo4j is a released version.
+tmp/image-%/.sentinel: docker-image-src/$(series)/Dockerfile docker-image-src/$(series)/docker-entrypoint.sh \
+                       in/$(call tarball,%,$(NEO4JVERSION)) tmp/neo4jlabs-plugins.json
+> mkdir -p $(@D)
+> cp $(filter %/docker-entrypoint.sh,$^) $(@D)/docker-entrypoint.sh
+> sha=$$(shasum --algorithm=256 $(filter %.tar.gz,$^) | cut -d' ' -f1)
+> <$(filter %/Dockerfile,$^) sed \
+    -e "s|%%NEO4J_BASE_IMAGE%%|${NEO4J_BASE_IMAGE}|" \
+    -e "s|%%NEO4J_SHA%%|$${sha}|" \
+    -e "s|%%NEO4J_TARBALL%%|$(call tarball,$*,$(NEO4JVERSION))|" \
+    -e "s|%%NEO4J_EDITION%%|$*|" \
+    -e "s|%%NEO4J_DIST_SITE%%|$(dist_site)|" \
+    >$(@D)/Dockerfile
+> mkdir -p $(@D)/local-package
+> cp $(filter %.json,$^) $(@D)/local-package
+> touch $(@D)/local-package/.sentinel
+> touch $@
+
+tmp/neo4jlabs-plugins.json: ./neo4jlabs-plugins.json
+> mkdir -p $(@D)
+> cp $< $@
+
+fetch_tarball = curl --fail --silent --show-error --location --remote-name \
+    $(dist_site)/$(call tarball,$(1),$(NEO4JVERSION))
+
+cache: in/neo4j-%-$(NEO4JVERSION)-unix.tar.gz
+.PHONY: cache
+
+in/neo4j-community-$(NEO4JVERSION)-unix.tar.gz:
+> mkdir -p in
+> cd in
+> $(call fetch_tarball,community)
+
+in/neo4j-enterprise-$(NEO4JVERSION)-unix.tar.gz:
+> mkdir -p in
+> cd in
+> $(call fetch_tarball,enterprise)
+
+clean:
+> rm -rf tmp
+> rm -rf out
+.PHONY: clean

--- a/src/test/java/com/neo4j/docker/TestPasswords.java
+++ b/src/test/java/com/neo4j/docker/TestPasswords.java
@@ -43,8 +43,21 @@ public class TestPasswords
         return container;
     }
 
+	@Test
+	void testNoPassword()
+	{
+		// we test that setting NEO4J_AUTH to none lets the database start in TestBasic.java but not that we can read/write the database
+		try(GenericContainer container = createContainer( false ))
+		{
+			container.withEnv( "NEO4J_AUTH", "none" );
+			container.start();
+            DatabaseIO db = new DatabaseIO(container);
+            db.putInitialDataIntoContainer( "neo4j", "none" );
+			db.verifyDataInContainer( "neo4j", "none" );
+		}
+	}
 
-    @Test
+	@Test
     void testPasswordCantBeNeo4j() throws Exception
     {
         try(GenericContainer failContainer = new GenericContainer( TestSettings.IMAGE_ID ).withLogConsumer( new Slf4jLogConsumer( log ) ))

--- a/src/test/java/com/neo4j/docker/utils/DatabaseIO.java
+++ b/src/test/java/com/neo4j/docker/utils/DatabaseIO.java
@@ -3,6 +3,7 @@ package com.neo4j.docker.utils;
 import org.junit.jupiter.api.Assertions;
 import org.testcontainers.containers.GenericContainer;
 
+import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Config;
 import org.neo4j.driver.Driver;
@@ -31,7 +32,7 @@ public class DatabaseIO
 
 	public void putInitialDataIntoContainer( String user, String password )
 	{
-		Driver driver = GraphDatabase.driver( boltUri, AuthTokens.basic( user, password ), TEST_DRIVER_CONFIG );
+		Driver driver = GraphDatabase.driver( boltUri, getToken( user, password ), TEST_DRIVER_CONFIG );
 		try ( Session session = driver.session())
 		{
 			Result rs = session.run( "CREATE (arne:dog {name:'Arne'})-[:SNIFFS]->(bosse:dog {name:'Bosse'}) RETURN arne.name");
@@ -42,7 +43,7 @@ public class DatabaseIO
 
 	public void verifyDataInContainer( String user, String password )
 	{
-		Driver driver = GraphDatabase.driver( boltUri, AuthTokens.basic( user, password ), TEST_DRIVER_CONFIG );
+		Driver driver = GraphDatabase.driver( boltUri, getToken( user, password ), TEST_DRIVER_CONFIG );
 		try ( Session session = driver.session())
 		{
 			Result rs = session.run( "MATCH (a:dog)-[:SNIFFS]->(b:dog) RETURN a.name");
@@ -70,7 +71,7 @@ public class DatabaseIO
 
 	public void runCypherProcedure( String user, String password, String cypher )
 	{
-		Driver driver = GraphDatabase.driver( boltUri, AuthTokens.basic( user, password ), TEST_DRIVER_CONFIG );
+		Driver driver = GraphDatabase.driver( boltUri, getToken( user, password ), TEST_DRIVER_CONFIG );
 		try ( Session session = driver.session())
 		{
 			Result rs = session.run( cypher );
@@ -81,8 +82,20 @@ public class DatabaseIO
 	public void verifyConnectivity( String user, String password )
 	{
 		GraphDatabase.driver( getBoltURIFromContainer(container),
-							  AuthTokens.basic( user, password ),
+							  getToken( user, password ),
 							  TEST_DRIVER_CONFIG )
 					 .verifyConnectivity();
+	}
+
+	private AuthToken getToken(String user, String password)
+	{
+		if(password.equals( "none" ))
+		{
+			return AuthTokens.none();
+		}
+		else
+		{
+			return AuthTokens.basic( user, password );
+		}
 	}
 }


### PR DESCRIPTION
required some refactoring of the Makefile and Dockerfiles since the `tini` tool has architecture specific builds and will need to be downloaded from different URIs depending on the base architecture.