### PR TITLE
making sure neo4j home folder gets recursively chowned

### DIFF
--- a/docker-image-src/4.0/docker-entrypoint.sh
+++ b/docker-image-src/4.0/docker-entrypoint.sh
@@ -234,14 +234,10 @@ readonly groups
 readonly exec_cmd
 
 
-# Need to chown the home directory - but a user might have mounted a
-# volume here (notably a conf volume). So take care not to chown
-# volumes (stuff not owned by neo4j)
+# Need to chown the home directory
 if running_as_root; then
-    # Non-recursive chown for the base directory
-    chown "${userid}":"${groupid}" "${NEO4J_HOME}"
+    chown -R "${userid}":"${groupid}" "${NEO4J_HOME}"
     chmod 700 "${NEO4J_HOME}"
-    find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -type d -exec chown -R ${userid}:${groupid} {} \;
     find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -type d -exec chmod -R 700 {} \;
 fi
 

--- a/docker-image-src/4.1/docker-entrypoint.sh
+++ b/docker-image-src/4.1/docker-entrypoint.sh
@@ -302,6 +302,9 @@ if running_as_root; then
     chmod 700 "${NEO4J_HOME}"
     find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -type d -exec chown -R ${userid}:${groupid} {} \;
     find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -type d -exec chmod -R 700 {} \;
+    # github issue #223 sometimes neo4j.conf is unreadable for no apparent reason.
+    chown "${userid}":"${groupid}" "${NEO4J_HOME}"/conf/neo4j.conf
+    chmod u+r "${NEO4J_HOME}"/conf/neo4j.conf
 fi
 
 # Only prompt for license agreement if command contains "neo4j" in it

--- a/docker-image-src/4.1/docker-entrypoint.sh
+++ b/docker-image-src/4.1/docker-entrypoint.sh
@@ -293,18 +293,11 @@ readonly groups
 readonly exec_cmd
 
 
-# Need to chown the home directory - but a user might have mounted a
-# volume here (notably a conf volume). So take care not to chown
-# volumes (stuff not owned by neo4j)
+# Need to chown the home directory
 if running_as_root; then
-    # Non-recursive chown for the base directory
-    chown "${userid}":"${groupid}" "${NEO4J_HOME}"
+    chown -R "${userid}":"${groupid}" "${NEO4J_HOME}"
     chmod 700 "${NEO4J_HOME}"
-    find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -type d -exec chown -R ${userid}:${groupid} {} \;
     find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -type d -exec chmod -R 700 {} \;
-    # github issue #223 sometimes neo4j.conf is unreadable for no apparent reason.
-    chown "${userid}":"${groupid}" "${NEO4J_HOME}"/conf/neo4j.conf
-    chmod u+r "${NEO4J_HOME}"/conf/neo4j.conf
 fi
 
 # Only prompt for license agreement if command contains "neo4j" in it

--- a/docker-image-src/4.2/docker-entrypoint.sh
+++ b/docker-image-src/4.2/docker-entrypoint.sh
@@ -293,14 +293,10 @@ readonly groups
 readonly exec_cmd
 
 
-# Need to chown the home directory - but a user might have mounted a
-# volume here (notably a conf volume). So take care not to chown
-# volumes (stuff not owned by neo4j)
+# Need to chown the home directory
 if running_as_root; then
-    # Non-recursive chown for the base directory
-    chown "${userid}":"${groupid}" "${NEO4J_HOME}"
+    chown -R "${userid}":"${groupid}" "${NEO4J_HOME}"
     chmod 700 "${NEO4J_HOME}"
-    find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -type d -exec chown -R ${userid}:${groupid} {} \;
     find "${NEO4J_HOME}" -mindepth 1 -maxdepth 1 -type d -exec chmod -R 700 {} \;
 fi
 

--- a/src/test/java/com/neo4j/docker/utils/DatabaseIO.java
+++ b/src/test/java/com/neo4j/docker/utils/DatabaseIO.java
@@ -1,6 +1,8 @@
 package com.neo4j.docker.utils;
 
 import org.junit.jupiter.api.Assertions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 
 import org.neo4j.driver.AuthToken;
@@ -15,6 +17,7 @@ import org.neo4j.driver.Result;
 public class DatabaseIO
 {
 	private static Config TEST_DRIVER_CONFIG = Config.builder().withoutEncryption().build();
+	private static final Logger log = LoggerFactory.getLogger( DatabaseIO.class );
 
 	private GenericContainer container;
 	private String boltUri;
@@ -32,6 +35,7 @@ public class DatabaseIO
 
 	public void putInitialDataIntoContainer( String user, String password )
 	{
+		log.info( "Writing data into database" );
 		Driver driver = GraphDatabase.driver( boltUri, getToken( user, password ), TEST_DRIVER_CONFIG );
 		try ( Session session = driver.session())
 		{
@@ -43,6 +47,7 @@ public class DatabaseIO
 
 	public void verifyDataInContainer( String user, String password )
 	{
+		log.info( "verifying data is present in the database" );
 		Driver driver = GraphDatabase.driver( boltUri, getToken( user, password ), TEST_DRIVER_CONFIG );
 		try ( Session session = driver.session())
 		{


### PR DESCRIPTION
This should hopefully fix a reported issue where the image fails due to permissions errors, even when nothing is mounted.