### PR TITLE
Add Bloom Plugin

### DIFF
--- a/docker-image-src/4.2/docker-entrypoint.sh
+++ b/docker-image-src/4.2/docker-entrypoint.sh
@@ -419,6 +419,11 @@ if [ -d /data ]; then
     fi
 fi
 
+if [ -d /licenses ]; then
+    check_mounted_folder_readable "/licenses"
+    : ${NEO4J_dbms_directories_licenses:="/licenses"}
+fi
+
 declare -A COMMUNITY
 declare -A ENTERPRISE
 

--- a/docker-image-src/4.3/docker-entrypoint.sh
+++ b/docker-image-src/4.3/docker-entrypoint.sh
@@ -419,6 +419,11 @@ if [ -d /data ]; then
     fi
 fi
 
+if [ -d /licenses ]; then
+    check_mounted_folder_readable "/licenses"
+    : ${NEO4J_dbms_directories_licenses:="/licenses"}
+fi
+
 declare -A COMMUNITY
 declare -A ENTERPRISE
 

--- a/neo4jlabs-plugins.json
+++ b/neo4jlabs-plugins.json
@@ -9,7 +9,8 @@
     "versions": "https://bloom-plugins.s3.eu-west-2.amazonaws.com/versions.json",
     "properties": {
       "dbms.unmanaged_extension_classes": "com.neo4j.bloom.server=/browser/bloom",
-      "dbms.security.procedures.unrestricted": "bloom.*"
+      "dbms.security.procedures.unrestricted": "bloom.*",
+      "neo4j.bloom.license_file": "/licenses/bloom.license"
     }
   },  
   "streams": {

--- a/neo4jlabs-plugins.json
+++ b/neo4jlabs-plugins.json
@@ -5,6 +5,13 @@
       "dbms.security.procedures.unrestricted": "apoc.*"
     }
   },
+  "bloom": {
+    "versions": "https://bloom-plugins.s3.eu-west-2.amazonaws.com/versions.json",
+    "properties": {
+      "dbms.unmanaged_extension_classes": "com.neo4j.bloom.server=/browser/bloom",
+      "dbms.security.procedures.unrestricted": "bloom.*"
+    }
+  },  
   "streams": {
     "versions": "https://neo4j-contrib.github.io/neo4j-streams/versions.json",
     "properties": {}


### PR DESCRIPTION
Allow Bloom to be installed using the "NEO4JLABS_PLUGINS".  
Bloom plugin requires a license file ( https://neo4j.com/docs/bloom-user-guide/current/bloom-installation/ ), in order to get the plugin running the user needs to share a volume like in the following example:
```
docker run -it --rm \
  --publish=7474:7474 --publish=7687:7687 \
  -v $HOME/bloom.license:/licenses/bloom.license \
  --env NEO4J_AUTH=neo4j/test \
  --env=NEO4J_ACCEPT_LICENSE_AGREEMENT=yes \
  --env NEO4JLABS_PLUGINS='["bloom"]' \
  test/19971
```
The default location (inside the docker container) for the plugin license is `${NEO4J_HOME}/licenses/`