### PR TITLE
Fix CVE-2020-14803

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 include make-common.mk
 
-NEO4J_BASE_IMAGE?="openjdk:11-jdk-slim"
+NEO4J_BASE_IMAGE?="openjdk:11.0.11-jdk-slim"
 
 # Use make test TESTS='<pattern>' to run specific tests
 # e.g. `make test TESTS='TestCausalCluster'` or `make test TESTS='*Cluster*'`


### PR DESCRIPTION
Hello,

This PR fixes CVE-2020-14803 by upgrading OpenJDK to 11.0.11

More details here:
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-14803

Another solution would be to rebuild all Neo4J images on DockerHub, so the latest _openjdk:11-jdk-slim_ image would be used.

Thank you.