### PR TITLE
fix dump-config so it works as documented

### DIFF
--- a/docker-image-src/4.1/docker-entrypoint.sh
+++ b/docker-image-src/4.1/docker-entrypoint.sh
@@ -488,9 +488,11 @@ fi
 [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
 
 if [ "${cmd}" == "dump-config" ]; then
-    if ! is_writable "/conf"; then
-        print_permissions_advice_and_fail "/conf"
+    if [ ! -d "/conf" ]; then
+        echo >&2 "You must mount a folder to /conf so that the configuration file(s) can be dumped to there."
+        exit 1
     fi
+    check_mounted_folder_writable_with_chown "/conf"
     cp --recursive "${NEO4J_HOME}"/conf/* /conf
     echo "Config Dumped"
     exit 0

--- a/docker-image-src/4.2/docker-entrypoint.sh
+++ b/docker-image-src/4.2/docker-entrypoint.sh
@@ -504,9 +504,11 @@ fi
 [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
 
 if [ "${cmd}" == "dump-config" ]; then
-    if ! is_writable "/conf"; then
-        print_permissions_advice_and_fail "/conf"
+    if [ ! -d "/conf" ]; then
+        echo >&2 "You must mount a folder to /conf so that the configuration file(s) can be dumped to there."
+        exit 1
     fi
+    check_mounted_folder_writable_with_chown "/conf"
     cp --recursive "${NEO4J_HOME}"/conf/* /conf
     echo "Config Dumped"
     exit 0

--- a/docker-image-src/4.3/docker-entrypoint.sh
+++ b/docker-image-src/4.3/docker-entrypoint.sh
@@ -504,9 +504,11 @@ fi
 [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
 
 if [ "${cmd}" == "dump-config" ]; then
-    if ! is_writable "/conf"; then
-        print_permissions_advice_and_fail "/conf"
+    if [ ! -d "/conf" ]; then
+        echo >&2 "You must mount a folder to /conf so that the configuration file(s) can be dumped to there."
+        exit 1
     fi
+    check_mounted_folder_writable_with_chown "/conf"
     cp --recursive "${NEO4J_HOME}"/conf/* /conf
     echo "Config Dumped"
     exit 0

--- a/docker-image-src/4.4/docker-entrypoint.sh
+++ b/docker-image-src/4.4/docker-entrypoint.sh
@@ -534,9 +534,11 @@ fi
 [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
 
 if [ "${cmd}" == "dump-config" ]; then
-    if ! is_writable "/conf"; then
-        print_permissions_advice_and_fail "/conf"
+    if [ ! -d "/conf" ]; then
+        echo >&2 "You must mount a folder to /conf so that the configuration file(s) can be dumped to there."
+        exit 1
     fi
+    check_mounted_folder_writable_with_chown "/conf"
     cp --recursive "${NEO4J_HOME}"/conf/* /conf
     echo "Config Dumped"
     exit 0

--- a/docker-image-src/5.0/docker-entrypoint.sh
+++ b/docker-image-src/5.0/docker-entrypoint.sh
@@ -534,9 +534,11 @@ fi
 [ -f "${EXTENSION_SCRIPT:-}" ] && . ${EXTENSION_SCRIPT}
 
 if [ "${cmd}" == "dump-config" ]; then
-    if ! is_writable "/conf"; then
-        print_permissions_advice_and_fail "/conf"
+    if [ ! -d "/conf" ]; then
+        echo >&2 "You must mount a folder to /conf so that the configuration file(s) can be dumped to there."
+        exit 1
     fi
+    check_mounted_folder_writable_with_chown "/conf"
     cp --recursive "${NEO4J_HOME}"/conf/* /conf
     echo "Config Dumped"
     exit 0


### PR DESCRIPTION
dump-config was failing if run according to documentation:
https://neo4j.com/docs/operations-manual/current/docker/configuration/#docker-conf-volume

This was because docker did not have file permissions to write to the conf folder when running as the default user.
The fix is that our docker image will now `chown` the mounted `/conf` folder if (and only if) `dump-config` is requested and no `--user` argument is given. 
In normal neo4j usage, the conf folder does not need to be writable, so the permissions are not changed.