### PR TITLE
fixed tini install in versions 4.3 and earlier

### DIFF
--- a/docker-image-src/3.5/Dockerfile
+++ b/docker-image-src/3.5/Dockerfile
@@ -4,8 +4,6 @@ ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \
     NEO4J_EDITION=%%NEO4J_EDITION%% \
     NEO4J_HOME="/var/lib/neo4j" \
-    TINI_VERSION="v0.18.0" \
-    TINI_SHA256="12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855"
 ARG NEO4J_URI=%%NEO4J_DIST_SITE%%/%%NEO4J_TARBALL%%
 
 RUN addgroup --system neo4j && adduser --system --no-create-home --home "${NEO4J_HOME}" --ingroup neo4j neo4j
@@ -13,10 +11,7 @@ RUN addgroup --system neo4j && adduser --system --no-create-home --home "${NEO4J
 COPY ./local-package/* /tmp/
 
 RUN apt update \
-     && apt install -y curl wget gosu jq \
-     && curl -L --fail --silent --show-error "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini" > /sbin/tini \
-     && echo "${TINI_SHA256}  /sbin/tini" | sha256sum -c --strict --quiet \
-     && chmod +x /sbin/tini \
+     && apt install -y curl wget gosu jq tini \
      && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
      && echo "${NEO4J_SHA256}  ${NEO4J_TARBALL}" | sha256sum -c --strict --quiet \
      && tar --extract --file ${NEO4J_TARBALL} --directory /var/lib \
@@ -47,5 +42,5 @@ COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 EXPOSE 7474 7473 7687
 
-ENTRYPOINT ["/sbin/tini", "-g", "--", "/docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "-g", "--", "/docker-entrypoint.sh"]
 CMD ["neo4j"]

--- a/docker-image-src/3.5/Dockerfile
+++ b/docker-image-src/3.5/Dockerfile
@@ -3,7 +3,7 @@ FROM openjdk:8-jre-slim
 ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \
     NEO4J_EDITION=%%NEO4J_EDITION%% \
-    NEO4J_HOME="/var/lib/neo4j" \
+    NEO4J_HOME="/var/lib/neo4j"
 ARG NEO4J_URI=%%NEO4J_DIST_SITE%%/%%NEO4J_TARBALL%%
 
 RUN addgroup --system neo4j && adduser --system --no-create-home --home "${NEO4J_HOME}" --ingroup neo4j neo4j

--- a/docker-image-src/4.0/Dockerfile
+++ b/docker-image-src/4.0/Dockerfile
@@ -5,18 +5,13 @@ ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_EDITION=%%NEO4J_EDITION%% \
     NEO4J_HOME="/var/lib/neo4j"
 ARG NEO4J_URI=%%NEO4J_DIST_SITE%%/%%NEO4J_TARBALL%%
-ARG TINI_SHA256="12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855"
-ARG TINI_URI="https://github.com/krallin/tini/releases/download/v0.18.0/tini"
 
 RUN addgroup --gid 7474 --system neo4j && adduser --uid 7474 --system --no-create-home --home "${NEO4J_HOME}" --ingroup neo4j neo4j
 
 COPY ./local-package/* /tmp/
 
 RUN apt update \
-    && apt install -y curl wget gosu jq \
-    && curl -L --fail --silent --show-error ${TINI_URI} > /sbin/tini \
-    && echo "${TINI_SHA256}  /sbin/tini" | sha256sum -c --strict --quiet \
-    && chmod +x /sbin/tini \
+    && apt install -y curl wget gosu jq tini \
     && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && echo "${NEO4J_SHA256}  ${NEO4J_TARBALL}" | sha256sum -c --strict --quiet \
     && tar --extract --file ${NEO4J_TARBALL} --directory /var/lib \
@@ -47,5 +42,5 @@ COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 EXPOSE 7474 7473 7687
 
-ENTRYPOINT ["/sbin/tini", "-g", "--", "/docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "-g", "--", "/docker-entrypoint.sh"]
 CMD ["neo4j"]

--- a/docker-image-src/4.1/Dockerfile
+++ b/docker-image-src/4.1/Dockerfile
@@ -5,18 +5,13 @@ ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_EDITION=%%NEO4J_EDITION%% \
     NEO4J_HOME="/var/lib/neo4j"
 ARG NEO4J_URI=%%NEO4J_DIST_SITE%%/%%NEO4J_TARBALL%%
-ARG TINI_SHA256="12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855"
-ARG TINI_URI="https://github.com/krallin/tini/releases/download/v0.18.0/tini"
 
 RUN addgroup --gid 7474 --system neo4j && adduser --uid 7474 --system --no-create-home --home "${NEO4J_HOME}" --ingroup neo4j neo4j
 
 COPY ./local-package/* /tmp/
 
 RUN apt update \
-    && apt install -y curl wget gosu jq \
-    && curl -L --fail --silent --show-error ${TINI_URI} > /sbin/tini \
-    && echo "${TINI_SHA256}  /sbin/tini" | sha256sum -c --strict --quiet \
-    && chmod +x /sbin/tini \
+    && apt install -y curl wget gosu jq tini \
     && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && echo "${NEO4J_SHA256}  ${NEO4J_TARBALL}" | sha256sum -c --strict --quiet \
     && tar --extract --file ${NEO4J_TARBALL} --directory /var/lib \
@@ -47,5 +42,5 @@ COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 EXPOSE 7474 7473 7687
 
-ENTRYPOINT ["/sbin/tini", "-g", "--", "/docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "-g", "--", "/docker-entrypoint.sh"]
 CMD ["neo4j"]

--- a/docker-image-src/4.2/Dockerfile
+++ b/docker-image-src/4.2/Dockerfile
@@ -5,18 +5,13 @@ ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_EDITION=%%NEO4J_EDITION%% \
     NEO4J_HOME="/var/lib/neo4j"
 ARG NEO4J_URI=%%NEO4J_DIST_SITE%%/%%NEO4J_TARBALL%%
-ARG TINI_SHA256="12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855"
-ARG TINI_URI="https://github.com/krallin/tini/releases/download/v0.18.0/tini"
 
 RUN addgroup --gid 7474 --system neo4j && adduser --uid 7474 --system --no-create-home --home "${NEO4J_HOME}" --ingroup neo4j neo4j
 
 COPY ./local-package/* /tmp/
 
 RUN apt update \
-    && apt install -y curl wget gosu jq \
-    && curl -L --fail --silent --show-error ${TINI_URI} > /sbin/tini \
-    && echo "${TINI_SHA256}  /sbin/tini" | sha256sum -c --strict --quiet \
-    && chmod +x /sbin/tini \
+    && apt install -y curl wget gosu jq tini \
     && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && echo "${NEO4J_SHA256}  ${NEO4J_TARBALL}" | sha256sum -c --strict --quiet \
     && tar --extract --file ${NEO4J_TARBALL} --directory /var/lib \
@@ -47,5 +42,5 @@ COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 EXPOSE 7474 7473 7687
 
-ENTRYPOINT ["/sbin/tini", "-g", "--", "/docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "-g", "--", "/docker-entrypoint.sh"]
 CMD ["neo4j"]

--- a/docker-image-src/4.3/Dockerfile
+++ b/docker-image-src/4.3/Dockerfile
@@ -5,18 +5,13 @@ ENV NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_EDITION=%%NEO4J_EDITION%% \
     NEO4J_HOME="/var/lib/neo4j"
 ARG NEO4J_URI=%%NEO4J_DIST_SITE%%/%%NEO4J_TARBALL%%
-ARG TINI_SHA256="12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855"
-ARG TINI_URI="https://github.com/krallin/tini/releases/download/v0.18.0/tini"
 
 RUN addgroup --gid 7474 --system neo4j && adduser --uid 7474 --system --no-create-home --home "${NEO4J_HOME}" --ingroup neo4j neo4j
 
 COPY ./local-package/* /tmp/
 
 RUN apt update \
-    && apt install -y curl wget gosu jq \
-    && curl -L --fail --silent --show-error ${TINI_URI} > /sbin/tini \
-    && echo "${TINI_SHA256}  /sbin/tini" | sha256sum -c --strict --quiet \
-    && chmod +x /sbin/tini \
+    && apt install -y curl wget gosu jq tini \
     && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && echo "${NEO4J_SHA256}  ${NEO4J_TARBALL}" | sha256sum -c --strict --quiet \
     && tar --extract --file ${NEO4J_TARBALL} --directory /var/lib \
@@ -47,5 +42,5 @@ COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 EXPOSE 7474 7473 7687
 
-ENTRYPOINT ["/sbin/tini", "-g", "--", "/docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "-g", "--", "/docker-entrypoint.sh"]
 CMD ["neo4j"]


### PR DESCRIPTION
changes to the makefile for building 4.4 ARM images broke ARM image building in earlier Neo4j versions. Removing the ARM specific build steps meant that ARM architectures were building the images using tini built for amd64.

I fixed the Dockerfiles so that tini is installed through apt in all active versions of Neo4j.