### PR TITLE
made /docker-entrypoint.sh link to newer /startup/docker-entrypoint.sh

### DIFF
--- a/docker-image-src/3.5/Dockerfile
+++ b/docker-image-src/3.5/Dockerfile
@@ -27,6 +27,7 @@ RUN apt update \
     && chmod -R 777 "${NEO4J_HOME}" \
     && ln -s /data "${NEO4J_HOME}"/data \
     && ln -s /logs "${NEO4J_HOME}"/logs \
+    && ln -s /startup/docker-entrypoint.sh /docker-entrypoint.sh \
     && apt-get -y purge --auto-remove curl \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker-image-src/4.1/Dockerfile
+++ b/docker-image-src/4.1/Dockerfile
@@ -27,6 +27,7 @@ RUN apt update \
     && chmod -R 777 "${NEO4J_HOME}" \
     && ln -s /data "${NEO4J_HOME}"/data \
     && ln -s /logs "${NEO4J_HOME}"/logs \
+    && ln -s /startup/docker-entrypoint.sh /docker-entrypoint.sh \
     && apt-get -y purge --auto-remove curl \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker-image-src/4.2/Dockerfile
+++ b/docker-image-src/4.2/Dockerfile
@@ -27,6 +27,7 @@ RUN apt update \
     && chmod -R 777 "${NEO4J_HOME}" \
     && ln -s /data "${NEO4J_HOME}"/data \
     && ln -s /logs "${NEO4J_HOME}"/logs \
+    && ln -s /startup/docker-entrypoint.sh /docker-entrypoint.sh \
     && apt-get -y purge --auto-remove curl \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker-image-src/4.3/Dockerfile
+++ b/docker-image-src/4.3/Dockerfile
@@ -27,6 +27,7 @@ RUN apt update \
     && chmod -R 777 "${NEO4J_HOME}" \
     && ln -s /data "${NEO4J_HOME}"/data \
     && ln -s /logs "${NEO4J_HOME}"/logs \
+    && ln -s /startup/docker-entrypoint.sh /docker-entrypoint.sh \
     && apt-get -y purge --auto-remove curl \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker-image-src/4.4/Dockerfile
+++ b/docker-image-src/4.4/Dockerfile
@@ -27,6 +27,7 @@ RUN apt update \
     && chmod -R 777 "${NEO4J_HOME}" \
     && ln -s /data "${NEO4J_HOME}"/data \
     && ln -s /logs "${NEO4J_HOME}"/logs \
+    && ln -s /startup/docker-entrypoint.sh /docker-entrypoint.sh \
     && apt-get -y purge --auto-remove curl \
     && rm -rf /var/lib/apt/lists/*
 

--- a/src/test/java/com/neo4j/docker/utils/Neo4jVersion.java
+++ b/src/test/java/com/neo4j/docker/utils/Neo4jVersion.java
@@ -6,10 +6,8 @@ import java.util.regex.Pattern;
 
 public class Neo4jVersion
 {
-    //public static final Neo4jVersion EXPECTED_NEO4J_VERSION = Neo4jVersion.fromVersionString( System.getenv( "NEO4J_VERSION" ) );
-    //public static final Neo4jVersion LATEST_2X_VERSION = new Neo4jVersion(2,3,12);
-    //public static final Neo4jVersion LATEST_32_VERSION = new Neo4jVersion(3,2,14);
     public static final Neo4jVersion NEO4J_VERSION_400 = new Neo4jVersion(4,0,0);
+    public static final Neo4jVersion NEO4J_VERSION_500 = new Neo4jVersion(5,0,0);
 
     public final int major;
     public final int minor;


### PR DESCRIPTION
This is so downstream dependents don't break, as it has been reported that the new entrypoint location broke the neo4j-labs helm charts.