### PR TITLE
Change to URLs for the GDS distribution

### DIFF
--- a/docker-image-src/common/neo4jlabs-plugins.json
+++ b/docker-image-src/common/neo4jlabs-plugins.json
@@ -37,7 +37,7 @@
     }
   },
   "graph-data-science": {
-    "versions": "https://s3-eu-west-1.amazonaws.com/com.neo4j.graphalgorithms.dist/graph-data-science/versions.json",
+    "versions": "https://graphdatascience.ninja/versions.json",
     "properties": {
       "dbms.security.procedures.unrestricted": "gds.*"
     }


### PR DESCRIPTION
In order to comply with the sanctions against Russia,
we are moving the GDS artifacts to a new bucket and URL
where we can apply the appropriate rules.