### PR TITLE
Remove gosu from docker images

### DIFF
--- a/docker-image-src/3.5/Dockerfile
+++ b/docker-image-src/3.5/Dockerfile
@@ -11,7 +11,7 @@ RUN addgroup --system neo4j && adduser --system --no-create-home --home "${NEO4J
 COPY ./local-package/* /startup/
 
 RUN apt update \
-    && apt install -y curl wget gosu jq tini \
+    && apt install -y curl wget jq tini \
     && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && echo "${NEO4J_SHA256}  ${NEO4J_TARBALL}" | sha256sum -c --strict --quiet \
     && tar --extract --file ${NEO4J_TARBALL} --directory /var/lib \

--- a/docker-image-src/3.5/docker-entrypoint.sh
+++ b/docker-image-src/3.5/docker-entrypoint.sh
@@ -293,7 +293,7 @@ if running_as_root; then
   userid="neo4j"
   groupid="neo4j"
   groups=($(id -G neo4j))
-  exec_cmd="runuser -p -u neo4j -g neo4j --"
+  exec_cmd="exec runuser -p -u neo4j -g neo4j --"
 else
   userid="$(id -u)"
   groupid="$(id -g)"

--- a/docker-image-src/3.5/docker-entrypoint.sh
+++ b/docker-image-src/3.5/docker-entrypoint.sh
@@ -127,7 +127,7 @@ function check_mounted_folder_writable_with_chown
             echo "Warning: Folder mounted to \"${mountFolder}\" is not writable from inside container. Changing folder owner to ${userid}."
             chown -R "${userid}":"${groupid}" "${mountFolder}"
         # check permissions on files in the folder
-        elif [ $(gosu "${userid}":"${groupid}" find "${mountFolder}" -not -writable | wc -l) -gt 0 ]; then
+        elif [ $(${exec_cmd} find "${mountFolder}" -not -writable | wc -l) -gt 0 ]; then
             echo "Warning: Some files inside \"${mountFolder}\" are not writable from inside container. Changing folder owner to ${userid}."
             chown -R "${userid}":"${groupid}" "${mountFolder}"
         fi
@@ -293,7 +293,7 @@ if running_as_root; then
   userid="neo4j"
   groupid="neo4j"
   groups=($(id -G neo4j))
-  exec_cmd="exec gosu neo4j:neo4j"
+  exec_cmd="runuser -p -u neo4j -g neo4j --"
 else
   userid="$(id -u)"
   groupid="$(id -g)"
@@ -326,7 +326,7 @@ if [[ "${cmd}" == *"neo4j"* ]]; then
       echo >&2 "
 In order to use Neo4j Enterprise Edition you must accept the license agreement.
 
-(c) Neo4j Sweden AB.  2021.  All Rights Reserved.
+(c) Neo4j Sweden AB.  2022.  All Rights Reserved.
 Use of this Software without a proper commercial license with Neo4j,
 Inc. or its affiliates is prohibited.
 

--- a/docker-image-src/3.5/neo4j-admin/Dockerfile
+++ b/docker-image-src/3.5/neo4j-admin/Dockerfile
@@ -11,12 +11,13 @@ RUN addgroup --gid 7474 --system neo4j && adduser --uid 7474 --system --no-creat
 COPY ./local-package/* /startup/
 
 RUN apt update \
-    && apt install -y curl gosu procps \
+    && apt install -y curl procps \
     && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && echo "${NEO4J_SHA256}  ${NEO4J_TARBALL}" | sha256sum -c --strict --quiet \
     && tar --extract --file ${NEO4J_TARBALL} --directory /var/lib \
     && mv /var/lib/neo4j-* "${NEO4J_HOME}" \
     && rm ${NEO4J_TARBALL} \
+    && rm ${NEO4J_HOME}/bin/neo4j \
     && mv "${NEO4J_HOME}"/data /data \
     && chown -R neo4j:neo4j /data \
     && chmod -R 777 /data \

--- a/docker-image-src/3.5/neo4j-admin/docker-entrypoint.sh
+++ b/docker-image-src/3.5/neo4j-admin/docker-entrypoint.sh
@@ -7,7 +7,7 @@ function running_as_root
 
 function is_writable
 {
-    gosu "${userid}":"${groupid}" test -w "${1}"
+    ${exec_cmd} test -w "${1}"
 }
 
 function print_permissions_advice_and_fail
@@ -36,7 +36,7 @@ function check_mounted_folder_writable_with_chown
             echo "Warning: Folder mounted to \"${mountFolder}\" is not writable from inside container. Changing folder owner to ${userid}."
             chown -R "${userid}":"${groupid}" "${mountFolder}"
         # check permissions on files in the folder
-        elif [ $(gosu "${userid}":"${groupid}" find "${mountFolder}" -not -writable | wc -l) -gt 0 ]; then
+        elif [ $(${exec_cmd} find "${mountFolder}" -not -writable | wc -l) -gt 0 ]; then
             echo "Warning: Some files inside \"${mountFolder}\" are not writable from inside container. Changing folder owner to ${userid}."
             chown -R "${userid}":"${groupid}" "${mountFolder}"
         fi
@@ -53,7 +53,7 @@ if running_as_root; then
   userid="neo4j"
   groupid="neo4j"
   groups=($(id -G neo4j))
-  exec_cmd="exec gosu neo4j:neo4j"
+  exec_cmd="runuser -p -u neo4j -g neo4j --"
 else
   userid="$(id -u)"
   groupid="$(id -g)"
@@ -69,7 +69,7 @@ if [ "${NEO4J_EDITION}" == "enterprise" ]; then
       echo >&2 "
 In order to use Neo4j Enterprise Edition you must accept the license agreement.
 
-(c) Neo4j Sweden AB. 2021.  All Rights Reserved.
+(c) Neo4j Sweden AB. 2022.  All Rights Reserved.
 Use of this Software without a proper commercial license with Neo4j,
 Inc. or its affiliates is prohibited.
 
@@ -105,8 +105,6 @@ if [ -d /backups ]; then
 fi
 
 # ==== MAKE SURE NEO4J CANNOT BE RUN FROM THIS CONTAINER ====
-
-rm ${NEO4J_HOME}/bin/neo4j
 
 if [[ "${1}" == "neo4j" ]]; then
     correct_image="neo4j:"$(neo4j-admin --version)"-${NEO4J_EDITION}"

--- a/docker-image-src/4.3/Dockerfile
+++ b/docker-image-src/4.3/Dockerfile
@@ -11,7 +11,7 @@ RUN addgroup --gid 7474 --system neo4j && adduser --uid 7474 --system --no-creat
 COPY ./local-package/* /startup/
 
 RUN apt update \
-    && apt install -y curl wget gosu jq tini \
+    && apt install -y curl wget jq tini \
     && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && echo "${NEO4J_SHA256}  ${NEO4J_TARBALL}" | sha256sum -c --strict --quiet \
     && tar --extract --file ${NEO4J_TARBALL} --directory /var/lib \

--- a/docker-image-src/4.3/docker-entrypoint.sh
+++ b/docker-image-src/4.3/docker-entrypoint.sh
@@ -299,7 +299,7 @@ if running_as_root; then
   userid="neo4j"
   groupid="neo4j"
   groups=($(id -G neo4j))
-  exec_cmd="runuser -p -u neo4j -g neo4j --"
+  exec_cmd="exec runuser -p -u neo4j -g neo4j --"
   neo4j_admin_cmd="runuser -p -u neo4j -g neo4j -- neo4j-admin"
 else
   userid="$(id -u)"

--- a/docker-image-src/4.3/docker-entrypoint.sh
+++ b/docker-image-src/4.3/docker-entrypoint.sh
@@ -133,7 +133,7 @@ function check_mounted_folder_writable_with_chown
             echo "Warning: Folder mounted to \"${mountFolder}\" is not writable from inside container. Changing folder owner to ${userid}."
             chown -R "${userid}":"${groupid}" "${mountFolder}"
         # check permissions on files in the folder
-        elif [ $(gosu "${userid}":"${groupid}" find "${mountFolder}" -not -writable | wc -l) -gt 0 ]; then
+        elif [ $(${exec_cmd} find "${mountFolder}" -not -writable | wc -l) -gt 0 ]; then
             echo "Warning: Some files inside \"${mountFolder}\" are not writable from inside container. Changing folder owner to ${userid}."
             chown -R "${userid}":"${groupid}" "${mountFolder}"
         fi
@@ -299,8 +299,8 @@ if running_as_root; then
   userid="neo4j"
   groupid="neo4j"
   groups=($(id -G neo4j))
-  exec_cmd="exec gosu neo4j:neo4j"
-  neo4j_admin_cmd="gosu neo4j:neo4j neo4j-admin"
+  exec_cmd="runuser -p -u neo4j -g neo4j --"
+  neo4j_admin_cmd="runuser -p -u neo4j -g neo4j -- neo4j-admin"
 else
   userid="$(id -u)"
   groupid="$(id -g)"
@@ -332,7 +332,7 @@ if [[ "${cmd}" == *"neo4j"* ]]; then
       echo >&2 "
 In order to use Neo4j Enterprise Edition you must accept the license agreement.
 
-(c) Neo4j Sweden AB. 2021.  All Rights Reserved.
+(c) Neo4j Sweden AB. 2022.  All Rights Reserved.
 Use of this Software without a proper commercial license with Neo4j,
 Inc. or its affiliates is prohibited.
 
@@ -528,7 +528,7 @@ function get_neo4j_run_cmd {
     fi
 
     if running_as_root; then
-        gosu neo4j:neo4j neo4j console --dry-run "${extraArgs[@]}"
+        ${exec_cmd} neo4j console --dry-run "${extraArgs[@]}"
     else
         neo4j console --dry-run "${extraArgs[@]}"
     fi

--- a/docker-image-src/4.3/neo4j-admin/Dockerfile
+++ b/docker-image-src/4.3/neo4j-admin/Dockerfile
@@ -11,12 +11,13 @@ RUN addgroup --gid 7474 --system neo4j && adduser --uid 7474 --system --no-creat
 COPY ./local-package/* /startup/
 
 RUN apt update \
-    && apt install -y curl gosu procps \
+    && apt install -y curl procps \
     && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && echo "${NEO4J_SHA256}  ${NEO4J_TARBALL}" | sha256sum -c --strict --quiet \
     && tar --extract --file ${NEO4J_TARBALL} --directory /var/lib \
     && mv /var/lib/neo4j-* "${NEO4J_HOME}" \
     && rm ${NEO4J_TARBALL} \
+    && rm ${NEO4J_HOME}/bin/neo4j \
     && mv "${NEO4J_HOME}"/data /data \
     && chown -R neo4j:neo4j /data \
     && chmod -R 777 /data \

--- a/docker-image-src/4.3/neo4j-admin/docker-entrypoint.sh
+++ b/docker-image-src/4.3/neo4j-admin/docker-entrypoint.sh
@@ -7,7 +7,7 @@ function running_as_root
 
 function is_writable
 {
-    gosu "${userid}":"${groupid}" test -w "${1}"
+    ${exec_cmd} test -w "${1}"
 }
 
 function print_permissions_advice_and_fail
@@ -36,7 +36,7 @@ function check_mounted_folder_writable_with_chown
             echo "Warning: Folder mounted to \"${mountFolder}\" is not writable from inside container. Changing folder owner to ${userid}."
             chown -R "${userid}":"${groupid}" "${mountFolder}"
         # check permissions on files in the folder
-        elif [ $(gosu "${userid}":"${groupid}" find "${mountFolder}" -not -writable | wc -l) -gt 0 ]; then
+        elif [ $(${exec_cmd} find "${mountFolder}" -not -writable | wc -l) -gt 0 ]; then
             echo "Warning: Some files inside \"${mountFolder}\" are not writable from inside container. Changing folder owner to ${userid}."
             chown -R "${userid}":"${groupid}" "${mountFolder}"
         fi
@@ -53,7 +53,7 @@ if running_as_root; then
   userid="neo4j"
   groupid="neo4j"
   groups=($(id -G neo4j))
-  exec_cmd="exec gosu neo4j:neo4j"
+  exec_cmd="runuser -p -u neo4j -g neo4j --"
 else
   userid="$(id -u)"
   groupid="$(id -g)"
@@ -69,7 +69,7 @@ if [ "${NEO4J_EDITION}" == "enterprise" ]; then
       echo >&2 "
 In order to use Neo4j Enterprise Edition you must accept the license agreement.
 
-(c) Neo4j Sweden AB. 2021.  All Rights Reserved.
+(c) Neo4j Sweden AB. 2022.  All Rights Reserved.
 Use of this Software without a proper commercial license with Neo4j,
 Inc. or its affiliates is prohibited.
 
@@ -108,8 +108,6 @@ if [ -d /backups ]; then
 fi
 
 # ==== MAKE SURE NEO4J CANNOT BE RUN FROM THIS CONTAINER ====
-
-rm ${NEO4J_HOME}/bin/neo4j
 
 if [[ "${1}" == "neo4j" ]]; then
     correct_image="neo4j:"$(neo4j-admin --version)"-${NEO4J_EDITION}"

--- a/docker-image-src/4.4/Dockerfile
+++ b/docker-image-src/4.4/Dockerfile
@@ -11,7 +11,7 @@ RUN addgroup --gid 7474 --system neo4j && adduser --uid 7474 --system --no-creat
 COPY ./local-package/* /startup/
 
 RUN apt update \
-    && apt install -y curl wget gosu jq tini \
+    && apt install -y curl wget jq tini \
     && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && echo "${NEO4J_SHA256}  ${NEO4J_TARBALL}" | sha256sum -c --strict --quiet \
     && tar --extract --file ${NEO4J_TARBALL} --directory /var/lib \

--- a/docker-image-src/4.4/docker-entrypoint.sh
+++ b/docker-image-src/4.4/docker-entrypoint.sh
@@ -133,7 +133,7 @@ function check_mounted_folder_writable_with_chown
             echo "Warning: Folder mounted to \"${mountFolder}\" is not writable from inside container. Changing folder owner to ${userid}."
             chown -R "${userid}":"${groupid}" "${mountFolder}"
         # check permissions on files in the folder
-        elif [ $(gosu "${userid}":"${groupid}" find "${mountFolder}" -not -writable | wc -l) -gt 0 ]; then
+        elif [ $(${exec_cmd} find "${mountFolder}" -not -writable | wc -l) -gt 0 ]; then
             echo "Warning: Some files inside \"${mountFolder}\" are not writable from inside container. Changing folder owner to ${userid}."
             chown -R "${userid}":"${groupid}" "${mountFolder}"
         fi
@@ -329,8 +329,8 @@ if running_as_root; then
   userid="neo4j"
   groupid="neo4j"
   groups=($(id -G neo4j))
-  exec_cmd="exec gosu neo4j:neo4j"
-  neo4j_admin_cmd="gosu neo4j:neo4j neo4j-admin"
+  exec_cmd="runuser -p -u neo4j -g neo4j --"
+  neo4j_admin_cmd="runuser -p -u neo4j -g neo4j -- neo4j-admin"
 else
   userid="$(id -u)"
   groupid="$(id -g)"
@@ -557,11 +557,11 @@ function get_neo4j_run_cmd {
         extraArgs+=("--expand-commands")
     fi
 
-    if running_as_root; then
-        gosu neo4j:neo4j neo4j console --dry-run "${extraArgs[@]}"
-    else
-        neo4j console --dry-run "${extraArgs[@]}"
-    fi
+#    if running_as_root; then
+        ${exec_cmd} neo4j console --dry-run "${extraArgs[@]}"
+#    else
+#        neo4j console --dry-run "${extraArgs[@]}"
+#    fi
 }
 
 # Use su-exec to drop privileges to neo4j user

--- a/docker-image-src/4.4/docker-entrypoint.sh
+++ b/docker-image-src/4.4/docker-entrypoint.sh
@@ -284,7 +284,6 @@ function set_initial_password
     if [ "${cmd}" == "neo4j" ]; then
         if [ "${_neo4j_auth:-}" == "none" ]; then
             add_env_setting_to_conf "dbms.security.auth_enabled" "false" "${NEO4J_HOME}"
-            # NEO4J_dbms_security_auth__enabled=false
         elif [[ "${_neo4j_auth:-}" =~ ^([^/]+)\/([^/]+)/?([tT][rR][uU][eE])?$ ]]; then
             admin_user="${BASH_REMATCH[1]}"
             password="${BASH_REMATCH[2]}"
@@ -329,7 +328,7 @@ if running_as_root; then
   userid="neo4j"
   groupid="neo4j"
   groups=($(id -G neo4j))
-  exec_cmd="runuser -p -u neo4j -g neo4j --"
+  exec_cmd="exec runuser -p -u neo4j -g neo4j --"
   neo4j_admin_cmd="runuser -p -u neo4j -g neo4j -- neo4j-admin"
 else
   userid="$(id -u)"

--- a/docker-image-src/4.4/docker-entrypoint.sh
+++ b/docker-image-src/4.4/docker-entrypoint.sh
@@ -362,7 +362,7 @@ if [[ "${cmd}" == *"neo4j"* ]]; then
       echo >&2 "
 In order to use Neo4j Enterprise Edition you must accept the license agreement.
 
-(c) Neo4j Sweden AB. 2021.  All Rights Reserved.
+(c) Neo4j Sweden AB. 2022.  All Rights Reserved.
 Use of this Software without a proper commercial license with Neo4j,
 Inc. or its affiliates is prohibited.
 

--- a/docker-image-src/4.4/docker-entrypoint.sh
+++ b/docker-image-src/4.4/docker-entrypoint.sh
@@ -557,11 +557,11 @@ function get_neo4j_run_cmd {
         extraArgs+=("--expand-commands")
     fi
 
-#    if running_as_root; then
+    if running_as_root; then
         ${exec_cmd} neo4j console --dry-run "${extraArgs[@]}"
-#    else
-#        neo4j console --dry-run "${extraArgs[@]}"
-#    fi
+    else
+        neo4j console --dry-run "${extraArgs[@]}"
+    fi
 }
 
 # Use su-exec to drop privileges to neo4j user

--- a/docker-image-src/4.4/neo4j-admin/Dockerfile
+++ b/docker-image-src/4.4/neo4j-admin/Dockerfile
@@ -11,12 +11,13 @@ RUN addgroup --gid 7474 --system neo4j && adduser --uid 7474 --system --no-creat
 COPY ./local-package/* /startup/
 
 RUN apt update \
-    && apt install -y curl gosu procps \
+    && apt install -y curl procps \
     && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && echo "${NEO4J_SHA256}  ${NEO4J_TARBALL}" | sha256sum -c --strict --quiet \
     && tar --extract --file ${NEO4J_TARBALL} --directory /var/lib \
     && mv /var/lib/neo4j-* "${NEO4J_HOME}" \
     && rm ${NEO4J_TARBALL} \
+    && rm ${NEO4J_HOME}/bin/neo4j \
     && mv "${NEO4J_HOME}"/data /data \
     && chown -R neo4j:neo4j /data \
     && chmod -R 777 /data \

--- a/docker-image-src/4.4/neo4j-admin/docker-entrypoint.sh
+++ b/docker-image-src/4.4/neo4j-admin/docker-entrypoint.sh
@@ -7,7 +7,7 @@ function running_as_root
 
 function is_writable
 {
-    gosu "${userid}":"${groupid}" test -w "${1}"
+    ${exec_cmd} test -w "${1}"
 }
 
 function print_permissions_advice_and_fail
@@ -36,7 +36,7 @@ function check_mounted_folder_writable_with_chown
             echo "Warning: Folder mounted to \"${mountFolder}\" is not writable from inside container. Changing folder owner to ${userid}."
             chown -R "${userid}":"${groupid}" "${mountFolder}"
         # check permissions on files in the folder
-        elif [ $(gosu "${userid}":"${groupid}" find "${mountFolder}" -not -writable | wc -l) -gt 0 ]; then
+        elif [ $(${exec_cmd} find "${mountFolder}" -not -writable | wc -l) -gt 0 ]; then
             echo "Warning: Some files inside \"${mountFolder}\" are not writable from inside container. Changing folder owner to ${userid}."
             chown -R "${userid}":"${groupid}" "${mountFolder}"
         fi
@@ -53,7 +53,7 @@ if running_as_root; then
   userid="neo4j"
   groupid="neo4j"
   groups=($(id -G neo4j))
-  exec_cmd="exec gosu neo4j:neo4j"
+  exec_cmd="runuser -p -u neo4j -g neo4j --"
 else
   userid="$(id -u)"
   groupid="$(id -g)"
@@ -69,7 +69,7 @@ if [ "${NEO4J_EDITION}" == "enterprise" ]; then
       echo >&2 "
 In order to use Neo4j Enterprise Edition you must accept the license agreement.
 
-(c) Neo4j Sweden AB. 2021.  All Rights Reserved.
+(c) Neo4j Sweden AB. 2022.  All Rights Reserved.
 Use of this Software without a proper commercial license with Neo4j,
 Inc. or its affiliates is prohibited.
 
@@ -108,8 +108,6 @@ if [ -d /backups ]; then
 fi
 
 # ==== MAKE SURE NEO4J CANNOT BE RUN FROM THIS CONTAINER ====
-
-rm ${NEO4J_HOME}/bin/neo4j
 
 if [[ "${1}" == "neo4j" ]]; then
     correct_image="neo4j:"$(neo4j-admin --version)"-${NEO4J_EDITION}"

--- a/docker-image-src/5.0/Dockerfile
+++ b/docker-image-src/5.0/Dockerfile
@@ -11,7 +11,7 @@ RUN addgroup --gid 7474 --system neo4j && adduser --uid 7474 --system --no-creat
 COPY ./local-package/* /startup/
 
 RUN apt update \
-    && apt install -y curl wget gosu jq tini \
+    && apt install -y curl wget jq tini \
     && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && echo "${NEO4J_SHA256}  ${NEO4J_TARBALL}" | sha256sum -c --strict --quiet \
     && tar --extract --file ${NEO4J_TARBALL} --directory /var/lib \

--- a/docker-image-src/5.0/docker-entrypoint.sh
+++ b/docker-image-src/5.0/docker-entrypoint.sh
@@ -133,7 +133,7 @@ function check_mounted_folder_writable_with_chown
             echo "Warning: Folder mounted to \"${mountFolder}\" is not writable from inside container. Changing folder owner to ${userid}."
             chown -R "${userid}":"${groupid}" "${mountFolder}"
         # check permissions on files in the folder
-        elif [ $(gosu "${userid}":"${groupid}" find "${mountFolder}" -not -writable | wc -l) -gt 0 ]; then
+        elif [ $(${exec_cmd} find "${mountFolder}" -not -writable | wc -l) -gt 0 ]; then
             echo "Warning: Some files inside \"${mountFolder}\" are not writable from inside container. Changing folder owner to ${userid}."
             chown -R "${userid}":"${groupid}" "${mountFolder}"
         fi
@@ -328,8 +328,8 @@ if running_as_root; then
   userid="neo4j"
   groupid="neo4j"
   groups=($(id -G neo4j))
-  exec_cmd="exec gosu neo4j:neo4j"
-  neo4j_admin_cmd="gosu neo4j:neo4j neo4j-admin"
+  exec_cmd="runuser -p -u neo4j -g neo4j --"
+  neo4j_admin_cmd="runuser -p -u neo4j -g neo4j -- neo4j-admin"
 else
   userid="$(id -u)"
   groupid="$(id -g)"
@@ -361,7 +361,7 @@ if [[ "${cmd}" == *"neo4j"* ]]; then
       echo >&2 "
 In order to use Neo4j Enterprise Edition you must accept the license agreement.
 
-(c) Neo4j Sweden AB. 2021.  All Rights Reserved.
+(c) Neo4j Sweden AB. 2022.  All Rights Reserved.
 Use of this Software without a proper commercial license with Neo4j,
 Inc. or its affiliates is prohibited.
 
@@ -550,7 +550,7 @@ function get_neo4j_run_cmd {
     fi
 
     if running_as_root; then
-        gosu neo4j:neo4j neo4j console --dry-run "${extraArgs[@]}"
+        ${exec_cmd} neo4j console --dry-run "${extraArgs[@]}"
     else
         neo4j console --dry-run "${extraArgs[@]}"
     fi

--- a/docker-image-src/5.0/docker-entrypoint.sh
+++ b/docker-image-src/5.0/docker-entrypoint.sh
@@ -328,7 +328,7 @@ if running_as_root; then
   userid="neo4j"
   groupid="neo4j"
   groups=($(id -G neo4j))
-  exec_cmd="runuser -p -u neo4j -g neo4j --"
+  exec_cmd="exec runuser -p -u neo4j -g neo4j --"
   neo4j_admin_cmd="runuser -p -u neo4j -g neo4j -- neo4j-admin"
 else
   userid="$(id -u)"

--- a/docker-image-src/5.0/neo4j-admin/Dockerfile
+++ b/docker-image-src/5.0/neo4j-admin/Dockerfile
@@ -11,12 +11,13 @@ RUN addgroup --gid 7474 --system neo4j && adduser --uid 7474 --system --no-creat
 COPY ./local-package/* /startup/
 
 RUN apt update \
-    && apt install -y curl gosu procps \
+    && apt install -y curl procps \
     && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && echo "${NEO4J_SHA256}  ${NEO4J_TARBALL}" | sha256sum -c --strict --quiet \
     && tar --extract --file ${NEO4J_TARBALL} --directory /var/lib \
     && mv /var/lib/neo4j-* "${NEO4J_HOME}" \
     && rm ${NEO4J_TARBALL} \
+    && rm ${NEO4J_HOME}/bin/neo4j \
     && mv "${NEO4J_HOME}"/data /data \
     && chown -R neo4j:neo4j /data \
     && chmod -R 777 /data \

--- a/docker-image-src/5.0/neo4j-admin/docker-entrypoint.sh
+++ b/docker-image-src/5.0/neo4j-admin/docker-entrypoint.sh
@@ -7,7 +7,7 @@ function running_as_root
 
 function is_writable
 {
-    gosu "${userid}":"${groupid}" test -w "${1}"
+    ${exec_cmd} test -w "${1}"
 }
 
 function print_permissions_advice_and_fail
@@ -36,7 +36,7 @@ function check_mounted_folder_writable_with_chown
             echo "Warning: Folder mounted to \"${mountFolder}\" is not writable from inside container. Changing folder owner to ${userid}."
             chown -R "${userid}":"${groupid}" "${mountFolder}"
         # check permissions on files in the folder
-        elif [ $(gosu "${userid}":"${groupid}" find "${mountFolder}" -not -writable | wc -l) -gt 0 ]; then
+        elif [ $(${exec_cmd} find "${mountFolder}" -not -writable | wc -l) -gt 0 ]; then
             echo "Warning: Some files inside \"${mountFolder}\" are not writable from inside container. Changing folder owner to ${userid}."
             chown -R "${userid}":"${groupid}" "${mountFolder}"
         fi
@@ -53,7 +53,7 @@ if running_as_root; then
   userid="neo4j"
   groupid="neo4j"
   groups=($(id -G neo4j))
-  exec_cmd="exec gosu neo4j:neo4j"
+  exec_cmd="runuser -p -u neo4j -g neo4j --"
 else
   userid="$(id -u)"
   groupid="$(id -g)"
@@ -69,7 +69,7 @@ if [ "${NEO4J_EDITION}" == "enterprise" ]; then
       echo >&2 "
 In order to use Neo4j Enterprise Edition you must accept the license agreement.
 
-(c) Neo4j Sweden AB. 2021.  All Rights Reserved.
+(c) Neo4j Sweden AB. 2022.  All Rights Reserved.
 Use of this Software without a proper commercial license with Neo4j,
 Inc. or its affiliates is prohibited.
 
@@ -108,8 +108,6 @@ if [ -d /backups ]; then
 fi
 
 # ==== MAKE SURE NEO4J CANNOT BE RUN FROM THIS CONTAINER ====
-
-rm ${NEO4J_HOME}/bin/neo4j
 
 if [[ "${1}" == "neo4j" ]]; then
     correct_image="neo4j:"$(neo4j-admin --version)"-${NEO4J_EDITION}"

--- a/src/test/java/com/neo4j/docker/neo4jadmin/TestDumpLoad44.java
+++ b/src/test/java/com/neo4j/docker/neo4jadmin/TestDumpLoad44.java
@@ -108,7 +108,9 @@ public class TestDumpLoad44
     // This runs the actual stop command. Which we set up in createDBContainer to send SIGTERM
     private void stopContainer(GenericContainer container)
     {
+        log.info( "issuing container stop command" );
         container.getDockerClient().stopContainerCmd( container.getContainerId() ).exec();
+        log.info( "Container stopped" );
     }
 
     private void shouldCreateDumpAndLoadDump( boolean asDefaultUser, String password ) throws Exception

--- a/src/test/java/com/neo4j/docker/neo4jserver/configurations/Configuration.java
+++ b/src/test/java/com/neo4j/docker/neo4jserver/configurations/Configuration.java
@@ -25,7 +25,7 @@ enum Setting{
     TXLOG_RETENTION_POLICY
     }
 
-class Configuration
+public class Configuration
 {
     private static Map<Setting,Configuration> CONFIGURATIONS_5X = new EnumMap<Setting,Configuration>( Setting.class ) {{
         put( Setting.CLUSTER_DISCOVERY_ADDRESS, new Configuration("server.discovery.advertised_address"));

--- a/src/test/java/com/neo4j/docker/neo4jserver/configurations/TestExtendedConf.java
+++ b/src/test/java/com/neo4j/docker/neo4jserver/configurations/TestExtendedConf.java
@@ -105,7 +105,7 @@ public class TestExtendedConf
 		// copy configuration file and set permissions
 		Path confFile = testConfsFolder.resolve( "ExtendedConf.conf" );
 		Files.copy( confFile, confFolder.resolve( "neo4j.conf" ) );
-		setFileOwnerToNeo4j( confFolder.resolve( "neo4j.conf" ) );
+		HostFileSystemOperations.setFileOwnerToNeo4j( confFolder.resolve( "neo4j.conf" ) );
 		chmodConfFilePermissions( confFolder.resolve( "neo4j.conf" ) );
 
 		// start  container
@@ -221,23 +221,5 @@ public class TestExtendedConf
 			permissions.add( PosixFilePermission.GROUP_READ );
 		}
 		Files.setPosixFilePermissions( file, permissions );
-	}
-
-	private void setFileOwnerToNeo4j(Path file) throws Exception
-	{
-		ProcessBuilder pb = new ProcessBuilder( "chown", "7474:7474", file.toAbsolutePath().toString() ).redirectErrorStream( true );
-		Process proc = pb.start();
-		proc.waitFor();
-		if(proc.exitValue() != 0)
-		{
-			String errorMsg = new BufferedReader( new InputStreamReader( proc.getInputStream() ) )
-					.lines()
-					.collect( Collectors.joining() );
-			// if we cannot set up test conditions properly, abort test but don't register a test failure.
-			Assumptions.assumeTrue( false,
-									"Could not change owner of test file to 7474. User needs to be in sudoers list. Error:\n" +
-									errorMsg );
-		}
-		return;
 	}
 }


### PR DESCRIPTION
changelog: Replaced usages of `gosu` with `runuser` to avoid vulnerabilities associated with Go.