### PR TITLE
updated java base image to eclipse-temurin because openjdk is no longer supported

### DIFF
--- a/docker-image-src/3.5/Dockerfile
+++ b/docker-image-src/3.5/Dockerfile
@@ -1,6 +1,8 @@
-FROM openjdk:8-jre-slim
-
-ENV NEO4J_SHA256=%%NEO4J_SHA%% \
+FROM debian:bullseye-slim
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:8 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}" \
+    NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \
     NEO4J_EDITION=%%NEO4J_EDITION%% \
     NEO4J_HOME="/var/lib/neo4j"

--- a/docker-image-src/3.5/neo4j-admin/Dockerfile
+++ b/docker-image-src/3.5/neo4j-admin/Dockerfile
@@ -1,6 +1,8 @@
-FROM openjdk:8-jre-slim
-
-ENV NEO4J_SHA256=%%NEO4J_SHA%% \
+FROM debian:bullseye-slim
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:8 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}" \
+    NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \
     NEO4J_EDITION=%%NEO4J_EDITION%% \
     NEO4J_HOME="/var/lib/neo4j"

--- a/docker-image-src/4.3/Dockerfile
+++ b/docker-image-src/4.3/Dockerfile
@@ -1,6 +1,8 @@
-FROM %%NEO4J_BASE_IMAGE%%
-
-ENV NEO4J_SHA256=%%NEO4J_SHA%% \
+FROM debian:bullseye-slim
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}" \
+    NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \
     NEO4J_EDITION=%%NEO4J_EDITION%% \
     NEO4J_HOME="/var/lib/neo4j"

--- a/docker-image-src/4.3/neo4j-admin/Dockerfile
+++ b/docker-image-src/4.3/neo4j-admin/Dockerfile
@@ -1,6 +1,8 @@
-FROM %%NEO4J_BASE_IMAGE%%
-
-ENV NEO4J_SHA256=%%NEO4J_SHA%% \
+FROM debian:bullseye-slim
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}" \
+    NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \
     NEO4J_EDITION=%%NEO4J_EDITION%% \
     NEO4J_HOME="/var/lib/neo4j"

--- a/docker-image-src/4.4/Dockerfile
+++ b/docker-image-src/4.4/Dockerfile
@@ -1,6 +1,8 @@
-FROM openjdk:11-jdk-slim
-
-ENV NEO4J_SHA256=%%NEO4J_SHA%% \
+FROM debian:bullseye-slim
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}" \
+    NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \
     NEO4J_EDITION=%%NEO4J_EDITION%% \
     NEO4J_HOME="/var/lib/neo4j"

--- a/docker-image-src/4.4/neo4j-admin/Dockerfile
+++ b/docker-image-src/4.4/neo4j-admin/Dockerfile
@@ -1,6 +1,8 @@
-FROM openjdk:11-jdk-slim
-
-ENV NEO4J_SHA256=%%NEO4J_SHA%% \
+FROM debian:bullseye-slim
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}" \
+    NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \
     NEO4J_EDITION=%%NEO4J_EDITION%% \
     NEO4J_HOME="/var/lib/neo4j"

--- a/docker-image-src/5.0/Dockerfile
+++ b/docker-image-src/5.0/Dockerfile
@@ -1,6 +1,8 @@
-FROM openjdk:17-jdk-slim
-
-ENV NEO4J_SHA256=%%NEO4J_SHA%% \
+FROM debian:bullseye-slim
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:17 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}" \
+    NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \
     NEO4J_EDITION=%%NEO4J_EDITION%% \
     NEO4J_HOME="/var/lib/neo4j"

--- a/docker-image-src/5.0/neo4j-admin/Dockerfile
+++ b/docker-image-src/5.0/neo4j-admin/Dockerfile
@@ -1,6 +1,8 @@
-FROM openjdk:17-jdk-slim
-
-ENV NEO4J_SHA256=%%NEO4J_SHA%% \
+FROM debian:bullseye-slim
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:17 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}" \
+    NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \
     NEO4J_EDITION=%%NEO4J_EDITION%% \
     NEO4J_HOME="/var/lib/neo4j"


### PR DESCRIPTION
changelog: Redhat are no longer supporting or updating the `openjdk` docker images that we use as base images. This means there will no longer be security updates to `openjdk` images after July 2022. 
- https://github.com/docker-library/openjdk/issues/505
- https://github.com/docker-library/docs/pull/2162
Switching Docker base image to [eclipse-temurin AdoptOpenJDK java](https://hub.docker.com/_/eclipse-temurin) built on top of `debian:bullseye-slim`.