### PR TITLE
Refine startup criteria for 5.0-Enterprise containers

### DIFF
--- a/src/test/java/com/neo4j/docker/neo4jadmin/TestBackupRestore.java
+++ b/src/test/java/com/neo4j/docker/neo4jadmin/TestBackupRestore.java
@@ -4,6 +4,7 @@ import com.neo4j.docker.utils.DatabaseIO;
 import com.neo4j.docker.utils.HostFileSystemOperations;
 import com.neo4j.docker.utils.Neo4jVersion;
 import com.neo4j.docker.utils.SetContainerUser;
+import com.neo4j.docker.utils.StartupDetector;
 import com.neo4j.docker.utils.TestSettings;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
@@ -49,11 +50,8 @@ public class TestBackupRestore
                  .withEnv( "NEO4J_dbms_backup_enabled", "true" )
                  .withEnv( "NEO4J_dbms_backup_listen__address", "0.0.0.0:6362" )
                  .withExposedPorts( 7474, 7687, 6362 )
-                 .withLogConsumer( new Slf4jLogConsumer( log ) )
-                 .waitingFor( Wait.forHttp( "/" )
-                                  .forPort( 7474 )
-                                  .forStatusCode( 200 )
-                                  .withStartupTimeout( Duration.ofSeconds( 90 ) ) );
+                 .withLogConsumer( new Slf4jLogConsumer( log ) );
+        StartupDetector.makeContainerWaitForNeo4jReady(container, password, Duration.ofSeconds( 90 ));
         if(!asDefaultUser)
         {
             SetContainerUser.nonRootUser( container );

--- a/src/test/java/com/neo4j/docker/neo4jadmin/TestDumpLoad.java
+++ b/src/test/java/com/neo4j/docker/neo4jadmin/TestDumpLoad.java
@@ -5,6 +5,7 @@ import com.neo4j.docker.utils.DatabaseIO;
 import com.neo4j.docker.utils.HostFileSystemOperations;
 import com.neo4j.docker.utils.Neo4jVersion;
 import com.neo4j.docker.utils.SetContainerUser;
+import com.neo4j.docker.utils.StartupDetector;
 import com.neo4j.docker.utils.TestSettings;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
@@ -46,15 +47,12 @@ public class TestDumpLoad
                  .withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
                  .withExposedPorts( 7474, 7687 )
                  .withLogConsumer( new Slf4jLogConsumer( log ) )
-                 .waitingFor( Wait.forHttp( "/" )
-                                  .forPort( 7474 )
-                                  .forStatusCode( 200 )
-                                  .withStartupTimeout( Duration.ofSeconds( 90 ) ) )
                  // the default testcontainer framework behaviour is to just stop the process entirely,
                  // preventing clean shutdown. This means we can run the stop command and
                  // it'll send a SIGTERM to initiate neo4j shutdown. See also stopContainer method.
                  .withCreateContainerCmdModifier(
                          (Consumer<CreateContainerCmd>) cmd -> cmd.withStopSignal( "SIGTERM" ).withStopTimeout( 20 ));
+        StartupDetector.makeContainerWaitForNeo4jReady(container, password, Duration.ofSeconds( 90 ));
         if(!asDefaultUser)
         {
             SetContainerUser.nonRootUser( container );

--- a/src/test/java/com/neo4j/docker/neo4jserver/TestBasic.java
+++ b/src/test/java/com/neo4j/docker/neo4jserver/TestBasic.java
@@ -3,6 +3,7 @@ package com.neo4j.docker.neo4jserver;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.neo4j.docker.utils.DatabaseIO;
 import com.neo4j.docker.utils.Neo4jVersion;
+import com.neo4j.docker.utils.StartupDetector;
 import com.neo4j.docker.utils.TestSettings;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
@@ -151,7 +152,7 @@ public class TestBasic
     {
         try(GenericContainer container = createBasicContainer())
         {
-            setContainerWaitForNeo4jUp( container );
+            StartupDetector.makeContainerWaitForNeo4jReady(container, "none");
             // sets sigterm as the stop container signal
             container.withCreateContainerCmdModifier((Consumer<CreateContainerCmd>) cmd ->
                     cmd.withStopSignal( signal )

--- a/src/test/java/com/neo4j/docker/neo4jserver/TestMounting.java
+++ b/src/test/java/com/neo4j/docker/neo4jserver/TestMounting.java
@@ -1,10 +1,22 @@
 package com.neo4j.docker.neo4jserver;
 
+import static com.neo4j.docker.utils.StartupDetector.makeContainerWaitForNeo4jReady;
+
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.model.Bind;
-import com.neo4j.docker.neo4jserver.configurations.Configuration;
 import com.neo4j.docker.utils.DatabaseIO;
 import com.neo4j.docker.utils.HostFileSystemOperations;
+import com.neo4j.docker.utils.Neo4jVersion;
+import com.neo4j.docker.utils.SetContainerUser;
+import com.neo4j.docker.utils.TestSettings;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Random;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
@@ -18,25 +30,8 @@ import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
-import com.neo4j.docker.utils.SetContainerUser;
-import com.neo4j.docker.utils.Neo4jVersion;
-import com.neo4j.docker.utils.TestSettings;
 import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.LinkOption;
-import java.nio.file.OpenOption;
-import java.nio.file.Path;
-import java.nio.file.attribute.PosixFilePermission;
-import java.nio.file.attribute.UserPrincipal;
-import java.time.Duration;
-import java.util.Random;
-import java.util.Set;
-import java.util.function.Consumer;
-import java.util.stream.Stream;
 
 
 public class TestMounting
@@ -66,6 +61,7 @@ public class TestMounting
 				 .withLogConsumer( new Slf4jLogConsumer( log ) )
 				 .withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
 				 .withEnv( "NEO4J_AUTH", "none" );
+		makeContainerWaitForNeo4jReady( container, "none" );
 		if(asCurrentUser)
 		{
 			SetContainerUser.nonRootUser( container );

--- a/src/test/java/com/neo4j/docker/neo4jserver/plugins/TestPluginInstallation.java
+++ b/src/test/java/com/neo4j/docker/neo4jserver/plugins/TestPluginInstallation.java
@@ -3,6 +3,7 @@ package com.neo4j.docker.neo4jserver.plugins;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.google.gson.Gson;
 import com.neo4j.docker.utils.*;
+import java.time.Duration;
 import org.junit.Rule;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
@@ -66,11 +67,9 @@ public class TestPluginInstallation
                 .withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
                 .withEnv( Neo4jPluginEnv.get(), "[\"_testing\"]" )
                 .withExposedPorts( 7474, 7687 )
-                .withLogConsumer( new Slf4jLogConsumer( log ) )
-                .waitingFor( Wait.forHttp( "/" )
-                                 .forPort( 7474 )
-                                 .forStatusCode( 200 ) );
-
+                .withLogConsumer( new Slf4jLogConsumer( log ) );
+        StartupDetector.makeContainerWaitForDatabaseReady(container, DB_USER, DB_PASSWORD, "neo4j",
+                Duration.ofSeconds(60));
         SetContainerUser.nonRootUser( container );
         return container;
     }

--- a/src/test/java/com/neo4j/docker/utils/StartupDetector.java
+++ b/src/test/java/com/neo4j/docker/utils/StartupDetector.java
@@ -1,0 +1,38 @@
+package com.neo4j.docker.utils;
+
+import java.time.Duration;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+public class StartupDetector {
+    private StartupDetector() {}
+
+    public static GenericContainer makeContainerWaitForDatabaseReady(
+            GenericContainer container, String username,
+            String password, String database, Duration timeout) {
+        if (TestSettings.EDITION == TestSettings.Edition.ENTERPRISE &&
+                TestSettings.NEO4J_VERSION.isAtLeastVersion(Neo4jVersion.NEO4J_VERSION_500)) {
+            container.setWaitStrategy(Wait.forHttp("/db/" + database + "/cluster/available")
+                    .withBasicCredentials(username, password)
+                    .forPort(7474)
+                    .forStatusCode(200)
+                    .withStartupTimeout(timeout));
+        } else {
+            container.setWaitStrategy(Wait.forHttp("/")
+                    .forPort(7474)
+                    .forStatusCode(200)
+                    .withStartupTimeout(timeout));
+        }
+        return container;
+    }
+
+    public static GenericContainer makeContainerWaitForNeo4jReady(GenericContainer container, String password) {
+        return makeContainerWaitForDatabaseReady(container, "neo4j", password, "neo4j", Duration.ofSeconds(60));
+    }
+
+    public static GenericContainer makeContainerWaitForNeo4jReady(
+            GenericContainer container, String password,
+            Duration timeout) {
+        return makeContainerWaitForDatabaseReady(container, "neo4j", password, "neo4j", timeout);
+    }
+}


### PR DESCRIPTION
In *5.0 Enterprise* edition all user databases are started asynchronously. Meaning when the start is
complete ("Started" is printed in the user log) and the http endpoint responds with 200 that does not
mean that the user databases and so the default database "neo4j" is available.
All tests which assume that, are likely to fail. This change modifies the readiness criteria (only
for enterprise && >=5.0) that instead of waiting for 200 on the generic http endpoint it waits for
200 for the database's availability endpoint: /db/<dbname>/cluster/available (for this the caller
needs to authenticate).