### PR TITLE
Change base image to eclipse temurin JRE not JDK

### DIFF
--- a/docker-image-src/3.5/Dockerfile
+++ b/docker-image-src/3.5/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye-slim
 ENV JAVA_HOME=/opt/java/openjdk
-COPY --from=eclipse-temurin:8 $JAVA_HOME $JAVA_HOME
+COPY --from=eclipse-temurin:8-jre $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}" \
     NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \

--- a/docker-image-src/3.5/neo4j-admin/Dockerfile
+++ b/docker-image-src/3.5/neo4j-admin/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye-slim
 ENV JAVA_HOME=/opt/java/openjdk
-COPY --from=eclipse-temurin:8 $JAVA_HOME $JAVA_HOME
+COPY --from=eclipse-temurin:8-jre $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}" \
     NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \

--- a/docker-image-src/4.3/Dockerfile
+++ b/docker-image-src/4.3/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye-slim
 ENV JAVA_HOME=/opt/java/openjdk
-COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
+COPY --from=eclipse-temurin:11-jre $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}" \
     NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \

--- a/docker-image-src/4.3/neo4j-admin/Dockerfile
+++ b/docker-image-src/4.3/neo4j-admin/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye-slim
 ENV JAVA_HOME=/opt/java/openjdk
-COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
+COPY --from=eclipse-temurin:11-jre $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}" \
     NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \

--- a/docker-image-src/4.4/Dockerfile
+++ b/docker-image-src/4.4/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye-slim
 ENV JAVA_HOME=/opt/java/openjdk
-COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
+COPY --from=eclipse-temurin:11-jre $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}" \
     NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \

--- a/docker-image-src/4.4/neo4j-admin/Dockerfile
+++ b/docker-image-src/4.4/neo4j-admin/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye-slim
 ENV JAVA_HOME=/opt/java/openjdk
-COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
+COPY --from=eclipse-temurin:11-jre $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}" \
     NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \


### PR DESCRIPTION
cl: Change base image to eclipse temurin JRE not JDK. The JDK is overkill and could introduce unnecessary security issues.