### PR TITLE
print an error message if neo4j is already running

### DIFF
--- a/docker-image-src/4.4/docker-entrypoint.sh
+++ b/docker-image-src/4.4/docker-entrypoint.sh
@@ -567,6 +567,11 @@ function get_neo4j_run_cmd {
 # Note that su-exec, despite its name, does not replicate the
 # functionality of exec, so we need to use both
 if [ "${cmd}" == "neo4j" ]; then
+    if [ -f "${NEO4J_HOME}/run/neo4j.pid" ]; then
+        echo >&2 "Error: It looks like neo4j is already running. If you are sure that neo4j is not running, delete ${NEO4J_HOME}/run/neo4j.pid. This could be caused by not shutting down neo4j gracefully. Consider increasing --time/-t for docker stop."
+        exit 1
+    fi
+
     # separate declaration and use of get_neo4j_run_cmd so that error codes are correctly surfaced
     neo4j_console_cmd="$(get_neo4j_run_cmd)"
     ${exec_cmd} ${neo4j_console_cmd?:No Neo4j command was generated}


### PR DESCRIPTION
Bug: neo4j container sometimes fails to start without outputting any message, after being forced to stop.

This happens if the `--time` / `stop_grace_period` of `docker stop` or `docker compose stop` is not long enough, for example the default value 10 seconds. The output of https://github.com/neo4j/docker-neo4j/blob/0c091859a7d1d487452b7fd7abe70599d48fed4d/docker-image-src/4.4/docker-entrypoint.sh#L560

will become `Neo4j is already running (pid:1)`, but the entry point script will not show any error message.

It will be really helpful for users to debug if the entry point script could point out why `neo4j console --dry-run` fails, or at least print an error message if the problem is that the pid file already exists and provide some solutions (what I did in this PR).

- **Steps to reproduce**. 
```bash
docker create --name neo4j neo4j:4.4-community
docker start neo4j
# wait after neo4j is started
docker stop neo4j -t 10 # default is 10 seconds, lower the value if not able to reproduce
docker start -ai neo4j
```

- Expected behaviour: neo4j starts, or shows a message about why it fails to start
- Actual behaviour: containers exits with code 1, without any output.
- Neo4j image tag being used: `neo4j:4.4-community`. I assume this also applies to other tags.
- The output of the `docker version` command

```
Server: Docker Engine - Community
 Engine:
  Version:          20.10.16
  API version:      1.41 (minimum version 1.12)
  Go version:       go1.17.10
  Git commit:       f756502
  Built:            Thu May 12 09:15:28 2022
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.6.4
  GitCommit:        212e8b6fa2f44b9c21b2798135fc6fb7c53efc16
 runc:
  Version:          1.1.1
  GitCommit:        v1.1.1-0-g52de29d
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```