### PR TITLE
Solves apoc-core flag not being added until 4.3

### DIFF
--- a/src/test/java/com/neo4j/docker/neo4jserver/plugins/TestBundledPluginInstallation.java
+++ b/src/test/java/com/neo4j/docker/neo4jserver/plugins/TestBundledPluginInstallation.java
@@ -33,7 +33,7 @@ public class TestBundledPluginInstallation
     static Stream<Arguments> bundledPluginsArgs() {
         return Stream.of(
                 // plugin name key, version it's bundled since, is enterprise only
-               Arguments.arguments("apoc-core", new Neo4jVersion(4, 1, 0), false),
+               Arguments.arguments("apoc-core", new Neo4jVersion(4, 3, 15), false),
                Arguments.arguments( "graph-data-science", new Neo4jVersion( 4,4,0 ), true ),
                Arguments.arguments( "bloom", new Neo4jVersion( 4,4,0 ), true )
         );


### PR DESCRIPTION
`apoc-core` flag wasn't added until 4.3.15, so these commands would fail

```
docker run --restart always --publish=7474:7474 --publish=7687:7687 --env=NEO4J_ACCEPT_LICENSE_AGREEMENT=yes --env NEO4JLABS_PLUGINS='["apoc-core"]' neo4j:4.2-enterprise

docker run --restart always --publish=7474:7474 --publish=7687:7687 --env=NEO4J_ACCEPT_LICENSE_AGREEMENT=yes --env NEO4JLABS_PLUGINS='["apoc-core"]' neo4j:4.1-enterprise
```

