### PR TITLE
using jdk 11 latest for 4.4 base

### DIFF
--- a/docker-image-src/4.4/Dockerfile
+++ b/docker-image-src/4.4/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye-slim
 ENV JAVA_HOME=/opt/java/openjdk
-COPY --from=eclipse-temurin:11.0.15_10-jdk-jammy $JAVA_HOME $JAVA_HOME
+COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}" \
     NEO4J_SHA256=%%NEO4J_SHA%% \
     NEO4J_TARBALL=%%NEO4J_TARBALL%% \


### PR DESCRIPTION
we previously specified 11.0.15_8 because it didn't have a bug, but that bug might now be fixed in the latest jdk version and we need to check.