### PR TITLE
stop clearing NEO4J_ACCEPT_LICENSE_AGREEMENT

### DIFF
--- a/docker-image-src/5.0/docker-entrypoint.sh
+++ b/docker-image-src/5.0/docker-entrypoint.sh
@@ -516,6 +516,7 @@ for i in $( set | grep ^NEO4J_ | awk -F'=' '{print $1}' | sort -rn ); do
 done
 export NEO4J_HOME="${temp_neo4j_home}"
 export NEO4J_PLUGINS="${temp_neo4j_plugins}"
+export NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
 unset temp_neo4j_home temp_neo4j_plugins
 
 # ==== SET PASSWORD AND PLUGINS ====

--- a/src/test/java/com/neo4j/docker/neo4jserver/TestBasic.java
+++ b/src/test/java/com/neo4j/docker/neo4jserver/TestBasic.java
@@ -104,6 +104,26 @@ public class TestBasic
     }
 
     @Test
+    void testLicenseAcceptanceAvoidsWarning() throws Exception
+    {
+        Assumptions.assumeTrue( TestSettings.EDITION == TestSettings.Edition.ENTERPRISE,
+                                "No license checks for community edition");
+        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 5,0,0 ) ),
+                                "No unified license acceptance method before 5.0.0");
+        try(GenericContainer container = createBasicContainer())
+        {
+            StartupDetector.makeContainerWaitForNeo4jReady( container, "none" );
+            container.start();
+            Assertions.assertTrue( container.isRunning() );
+
+            String stdout = container.getLogs(OutputFrame.OutputType.STDOUT);
+            Assertions.assertTrue( stdout.contains( "The license agreement was accepted with environment variable " +
+                                                    "NEO4J_ACCEPT_LICENSE_AGREEMENT=yes when the Software was started." ),
+            "Neo4j did not register that the license was agreed to.");
+        }
+    }
+
+    @Test
     void testCypherShellOnPath() throws Exception
     {
         String expectedCypherShellPath = "/var/lib/neo4j/bin/cypher-shell";


### PR DESCRIPTION
so that neo4j knows license was accepted and doesn't print a warning on startup