### PR TITLE
add debugging option

### DIFF
--- a/src/test/java/com/neo4j/docker/neo4jserver/TestBasic.java
+++ b/src/test/java/com/neo4j/docker/neo4jserver/TestBasic.java
@@ -29,8 +29,7 @@ public class TestBasic
     private GenericContainer createBasicContainer()
     {
         GenericContainer container = new GenericContainer( TestSettings.IMAGE_ID );
-        container.withEnv( "NEO4J_AUTH", "none" )
-                 .withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
+        container.withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
                  .withExposedPorts( 7474, 7687 )
                  .withLogConsumer( new Slf4jLogConsumer( log ) );
         return container;
@@ -41,9 +40,12 @@ public class TestBasic
     {
         try(GenericContainer container = createBasicContainer())
         {
-            StartupDetector.makeContainerWaitForNeo4jReady( container, "none" );
+            StartupDetector.makeContainerWaitForNeo4jReady( container, "neo4j" );
             container.start();
             Assertions.assertTrue( container.isRunning() );
+            String stdout = container.getLogs();
+            Assertions.assertFalse( stdout.contains( "DEBUGGING ENABLED" ),
+                                    "Debugging was enabled even though we did not set debugging" );
         }
     }
 
@@ -52,7 +54,7 @@ public class TestBasic
     {
         try(GenericContainer container = createBasicContainer())
         {
-            StartupDetector.makeContainerWaitForNeo4jReady( container, "none" );
+            StartupDetector.makeContainerWaitForNeo4jReady( container, "neo4j" );
             container.start();
             Assertions.assertTrue( container.isRunning() );
 
@@ -112,7 +114,7 @@ public class TestBasic
                                 "No unified license acceptance method before 5.0.0");
         try(GenericContainer container = createBasicContainer())
         {
-            StartupDetector.makeContainerWaitForNeo4jReady( container, "none" );
+            StartupDetector.makeContainerWaitForNeo4jReady( container, "neo4j" );
             container.start();
             Assertions.assertTrue( container.isRunning() );
 
@@ -129,7 +131,7 @@ public class TestBasic
         String expectedCypherShellPath = "/var/lib/neo4j/bin/cypher-shell";
         try(GenericContainer container = createBasicContainer())
         {
-            StartupDetector.makeContainerWaitForNeo4jReady( container, "none" );
+            StartupDetector.makeContainerWaitForNeo4jReady( container, "neo4j" );
             container.start();
 
             Container.ExecResult whichResult = container.execInContainer( "which", "cypher-shell" );
@@ -143,7 +145,7 @@ public class TestBasic
     {
         try(GenericContainer container = createBasicContainer())
         {
-            StartupDetector.makeContainerWaitForNeo4jReady( container, "none" );
+            StartupDetector.makeContainerWaitForNeo4jReady( container, "neo4j" );
             container.setWorkingDirectory( "/tmp" );
             Assertions.assertDoesNotThrow( () -> container.start(),
                                            "Could not start neo4j from workdir other than NEO4J_HOME" );
@@ -156,6 +158,7 @@ public class TestBasic
     {
         try(GenericContainer container = createBasicContainer())
         {
+            container.withEnv( "NEO4J_AUTH", "none" );
             StartupDetector.makeContainerWaitForNeo4jReady(container, "none");
             // sets sigterm as the stop container signal
             container.withCreateContainerCmdModifier((Consumer<CreateContainerCmd>) cmd ->
@@ -174,14 +177,14 @@ public class TestBasic
         }
     }
 
-//    @Test
-//    void testStartsWhenDebuggingEnabled()
-//    {
-//        try(GenericContainer container = createBasicContainer())
-//        {
-//            container.withEnv( "NEO4J_DEBUG", "true" );
-//            container.start();
-//            Assertions.assertTrue( container.isRunning() );
-//        }
-//    }
+    @Test
+    void testStartsWhenDebuggingEnabled()
+    {
+        try(GenericContainer container = createBasicContainer())
+        {
+            container.withEnv( "NEO4J_DEBUG", "true" );
+            container.start();
+            Assertions.assertTrue( container.isRunning() );
+        }
+    }
 }

--- a/src/test/java/com/neo4j/docker/neo4jserver/TestBasic.java
+++ b/src/test/java/com/neo4j/docker/neo4jserver/TestBasic.java
@@ -152,7 +152,7 @@ public class TestBasic
 
     @ParameterizedTest(name = "ShutsDownCorrectly_{0}")
     @ValueSource(strings = {"SIGTERM", "SIGINT"})
-    void verifyShutsDownCleanly(String signal) throws Exception
+    void testShutsDownCleanly(String signal) throws Exception
     {
         try(GenericContainer container = createBasicContainer())
         {
@@ -173,4 +173,15 @@ public class TestBasic
                                    "clean shutdown not initiated by " + signal );
         }
     }
+
+//    @Test
+//    void testStartsWhenDebuggingEnabled()
+//    {
+//        try(GenericContainer container = createBasicContainer())
+//        {
+//            container.withEnv( "NEO4J_DEBUG", "true" );
+//            container.start();
+//            Assertions.assertTrue( container.isRunning() );
+//        }
+//    }
 }

--- a/src/test/java/com/neo4j/docker/neo4jserver/TestPasswords.java
+++ b/src/test/java/com/neo4j/docker/neo4jserver/TestPasswords.java
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 
 public class TestPasswords
 {
-    public static final String AUTH = "none";
     private static Logger log = LoggerFactory.getLogger( TestPasswords.class);
 
     private GenericContainer createContainer( boolean asCurrentUser )
@@ -50,8 +49,8 @@ public class TestPasswords
 		// we test that setting NEO4J_AUTH to none lets the database start in TestBasic.java but not that we can read/write the database
 		try(GenericContainer container = createContainer( false ))
 		{
-			container.withEnv( "NEO4J_AUTH", AUTH);
-            StartupDetector.makeContainerWaitForNeo4jReady(container, AUTH, Duration.ofSeconds( 90 ));
+			container.withEnv( "NEO4J_AUTH", "none");
+            StartupDetector.makeContainerWaitForNeo4jReady(container, "none", Duration.ofSeconds( 90 ));
 			container.start();
             DatabaseIO db = new DatabaseIO(container);
             db.putInitialDataIntoContainer( "neo4j", "none" );
@@ -137,6 +136,22 @@ public class TestPasswords
         }
     }
 
+    @Test
+    void testCanSetPasswordWithDebugging() throws Exception
+    {
+        String password = "some_valid_password";
+
+        try ( GenericContainer container = createContainer( false  ) )
+        {
+            container.withEnv( "NEO4J_AUTH", "neo4j/" + password )
+                     .withEnv( "NEO4J_DEBUG", "yes" );
+            StartupDetector.makeContainerWaitForNeo4jReady( container, password );
+            // create a database with stuff in
+            container.start();
+            DatabaseIO db = new DatabaseIO( container );
+            db.putInitialDataIntoContainer( "neo4j", password );
+        }
+    }
 
     @ParameterizedTest(name = "as current user={0}")
     @ValueSource(booleans = {true, false})


### PR DESCRIPTION
cl: Added debugging output to docker-entrypoint.sh which can be enabled by setting environment variable `NEO4J_DEBUG` to any value.