### PR TITLE
updating test containers and re-enabling plugin test for arm

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <neo4j.version>${env.NEO4JVERSION}</neo4j.version>
         <!-- set java.version to either 1.8, 11 or 17 but don't commit with it set to 11 or 17 -->
         <java.version>1.8</java.version>
-        <testcontainers.version>1.17.1</testcontainers.version>
+        <testcontainers.version>1.17.5</testcontainers.version>
 	</properties>
 
 	<build>

--- a/src/test/java/com/neo4j/docker/neo4jserver/plugins/TestPluginInstallation.java
+++ b/src/test/java/com/neo4j/docker/neo4jserver/plugins/TestPluginInstallation.java
@@ -45,18 +45,18 @@ public class TestPluginInstallation
     @Rule
     public HttpServerRule httpServer = new HttpServerRule();
 
-    @BeforeAll
-    public static void ensureNotARMArchitecture()
-    {
-        // These tests make use of a TestContainers feature that means that if you serve something locally on the
-        // host machine, it is accessible from a container at the address http://host.testcontainers.internal
-        // This feature does not seem to work on ARM64 machines. I've created a bug report here 27/01/2022:
-        // https://github.com/testcontainers/testcontainers-java/issues/4956
-        //
-        // For now, we skip these tests on ARM until there is a fix or workaround.
-        Assumptions.assumeTrue( System.getProperty("os.arch").equals( "amd64" ),
-                                "Plugin tests can only run on amd64 machines at the moment" );
-    }
+//    @BeforeAll
+//    public static void ensureNotARMArchitecture()
+//    {
+//        // These tests make use of a TestContainers feature that means that if you serve something locally on the
+//        // host machine, it is accessible from a container at the address http://host.testcontainers.internal
+//        // This feature does not seem to work on ARM64 machines. I've created a bug report here 27/01/2022:
+//        // https://github.com/testcontainers/testcontainers-java/issues/4956
+//        //
+//        // For now, we skip these tests on ARM until there is a fix or workaround.
+//        Assumptions.assumeTrue( System.getProperty("os.arch").equals( "amd64" ),
+//                                "Plugin tests can only run on amd64 machines at the moment" );
+//    }
 
     private GenericContainer createContainerWithTestingPlugin()
     {


### PR DESCRIPTION
TestContainers may have fixed the http://host.testcontainers.internal feature