### PR TITLE
apoc configurations location changed in 5.x

### DIFF
--- a/src/test/java/com/neo4j/docker/neo4jserver/configurations/Configuration.java
+++ b/src/test/java/com/neo4j/docker/neo4jserver/configurations/Configuration.java
@@ -12,6 +12,7 @@ import java.util.Map;
 public class Configuration
 {
     private static Map<Setting,Configuration> CONFIGURATIONS_5X = new EnumMap<Setting,Configuration>( Setting.class ) {{
+        put( Setting.APOC_EXPORT_FILE_ENABLED, new Configuration( "apoc.export.file.enabled"));
         put( Setting.BACKUP_ENABLED, new Configuration("server.backup.enabled"));
         put( Setting.BACKUP_LISTEN_ADDRESS, new Configuration("server.backup.listen_address"));
         put( Setting.CLUSTER_DISCOVERY_ADDRESS, new Configuration("server.discovery.advertised_address"));
@@ -31,6 +32,7 @@ public class Configuration
     }};
 
     private static Map<Setting,Configuration> CONFIGURATIONS_4X = new EnumMap<Setting,Configuration>( Setting.class ) {{
+        put( Setting.APOC_EXPORT_FILE_ENABLED, new Configuration( "apoc.export.file.enabled"));
         put( Setting.BACKUP_ENABLED, new Configuration("dbms.backup.enabled"));
         put( Setting.BACKUP_LISTEN_ADDRESS, new Configuration("dbms.backup.listen_address"));
         put( Setting.CLUSTER_DISCOVERY_ADDRESS, new Configuration("causal_clustering.discovery_advertised_address"));

--- a/src/test/java/com/neo4j/docker/neo4jserver/configurations/Setting.java
+++ b/src/test/java/com/neo4j/docker/neo4jserver/configurations/Setting.java
@@ -2,6 +2,7 @@ package com.neo4j.docker.neo4jserver.configurations;
 
 public enum Setting
 {
+    APOC_EXPORT_FILE_ENABLED,
     BACKUP_ENABLED,
     BACKUP_LISTEN_ADDRESS,
     CLUSTER_DISCOVERY_ADDRESS,


### PR DESCRIPTION
Since 5.0.0, APOC configuration settings have gone in apoc.conf instead of neo4j.conf. Adding APOC confs to the end of neo4j.conf causes neo4j to fail on startup because of strict checking.
This change means that apoc configurations set by environment variable are now written to apoc.conf instead of neo4j.conf.