### PR TITLE
Removed `streams` from `NEO4J_PLUGINS` in 5.x

### DIFF
--- a/docker-image-src/5/coredb/neo4j-plugins.json
+++ b/docker-image-src/5/coredb/neo4j-plugins.json
@@ -21,10 +21,6 @@
       "dbms.bloom.license_file": "/licenses/bloom.license"
     }
   },
-  "streams": {
-    "versions": "https://neo4j-contrib.github.io/neo4j-streams/versions.json",
-    "properties": {}
-  },
   "graphql": {
     "versions": "https://neo4j-graphql.github.io/neo4j-graphql/versions.json",
     "properties": {


### PR DESCRIPTION
changelog: The `streams` plugin was erroneously listed as being a supported plugin in 5.x versions. This has been removed from 5.x docker source (the plugin integration remains in 4.4 and earlier images).