### PR TITLE
feature to allow NEO4J_AUTH through file rather than environment

### DIFF
--- a/docker-image-src/5/coredb/docker-entrypoint.sh
+++ b/docker-image-src/5/coredb/docker-entrypoint.sh
@@ -349,6 +349,26 @@ If Neo4j fails to start, you can:
     fi
 }
 
+
+function set_initial_password_from_path
+{
+    # this has an inbuilt assumption that any configuration settings from the environment have already been applied to neo4j.conf
+    # This is for the logic to test whether password length is too short.
+    local _neo4j_auth_path="${1}"
+
+    # set the neo4j initial password only if you run the database server
+    if [ "${cmd}" == "neo4j" ]; then
+
+        # Validate the existance of the password file
+        if [ ! -f "${_neo4j_auth_path}" ]; then
+            echo >&2 "The password file '${_neo4j_auth_path}' does not exist!"
+            exit 1
+        fi
+
+        set_initial_password "$(cat "${_neo4j_auth_path}")"
+    fi
+}
+
 # ==== CODE STARTS ====
 debug_msg "DEBUGGING ENABLED"
 
@@ -572,7 +592,11 @@ done
 
 # ==== SET PASSWORD ====
 
-set_initial_password "${NEO4J_AUTH:-}"
+if [[ -n "${NEO4J_AUTH_PATH}" ]]; then
+    set_initial_password_from_path "${NEO4J_AUTH_PATH}"
+else
+    set_initial_password "${NEO4J_AUTH:-}"
+fi
 
 # ==== INVOKE NEO4J STARTUP ====
 

--- a/src/test/java/com/neo4j/docker/coredb/TestAdminReport.java
+++ b/src/test/java/com/neo4j/docker/coredb/TestAdminReport.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Container;
+import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
@@ -141,7 +142,16 @@ public class TestAdminReport
         {
             container.withCommand( "neo4j-admin-report", "--help" );
             StartupDetector.makeContainerWaitUntilFinished( container, Duration.ofSeconds( 20 ) );
-            container.start();
+            try
+            {
+                container.start();
+            }
+            catch ( ContainerLaunchException e )
+            {
+                // consume any failed to start exceptions
+                log.warn( "Running 'neo4j-admin-report --help' caused the container to fail rather than " +
+                          "successfully complete. This is allowable, so the test is not going to fail." );
+            }
             verifyHelpText( container.getLogs(OutputFrame.OutputType.STDOUT),
                             container.getLogs(OutputFrame.OutputType.STDERR) );
         }

--- a/src/test/java/com/neo4j/docker/coredb/TestAuthentication.java
+++ b/src/test/java/com/neo4j/docker/coredb/TestAuthentication.java
@@ -18,19 +18,23 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.output.WaitingConsumer;
 import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
-public class TestPasswords
+public class TestAuthentication
 {
-    private static Logger log = LoggerFactory.getLogger( TestPasswords.class);
+    private static Logger log = LoggerFactory.getLogger(TestAuthentication.class);
+    private static final String NEO4J_AUTH_FILE_ENV = "NEO4J_AUTH_PATH";
+
     @RegisterExtension
     public static TemporaryFolderManager temporaryFolderManager = new TemporaryFolderManager();
 
@@ -51,10 +55,19 @@ public class TestPasswords
         return container;
     }
 
+    private Path setInitialPasswordWithSecretsFile(GenericContainer container, String password) throws IOException
+    {
+        Path secretsFolder = temporaryFolderManager.createFolderAndMountAsVolume( container, "/secrets" );
+        Files.writeString( secretsFolder.resolve( "passwordfile" ), "neo4j/"+password );
+        container.withEnv( NEO4J_AUTH_FILE_ENV, "/secrets/passwordfile" );
+        return secretsFolder;
+    }
+
 	@Test
 	void testNoPassword()
 	{
-		// we test that setting NEO4J_AUTH to none lets the database start in TestBasic.java but not that we can read/write the database
+		// we test that setting NEO4J_AUTH to "none" lets the database start in TestBasic.java,
+        // but that does not test that we can read/write the database
 		try(GenericContainer container = createContainer( false ))
 		{
 			container.withEnv( "NEO4J_AUTH", "none");
@@ -98,7 +111,7 @@ public class TestPasswords
             DatabaseIO db = new DatabaseIO(container);
             // try with no password, this should fail because the default password should be applied with no NEO4J_AUTH env variable
 			Assertions.assertThrows( org.neo4j.driver.exceptions.AuthenticationException.class,
-									 () -> db.putInitialDataIntoContainer( "neo4j", "" ),
+									 () -> db.putInitialDataIntoContainer( "neo4j", "none" ),
 									 "Able to access database with no password, even though NEO4J_AUTH=none was not specified!");
 			Assertions.assertThrows( org.neo4j.driver.exceptions.ClientException.class,
 									 () -> db.putInitialDataIntoContainer( "neo4j", "neo4j" ),
@@ -138,6 +151,64 @@ public class TestPasswords
             secondContainer.start();
             DatabaseIO db = new DatabaseIO(secondContainer);
             db.verifyInitialDataInContainer( "neo4j", password );
+        }
+    }
+
+    @ParameterizedTest(name = "as_current_user_{0}")
+    @ValueSource(booleans = {true, false})
+    void testCanSetPasswordFromSecretsFile( boolean asCurrentUser ) throws Exception
+    {
+        String password = "some_valid_password";
+
+        try(GenericContainer container = createContainer( asCurrentUser ))
+		{
+			setInitialPasswordWithSecretsFile( container, password );
+            StartupDetector.makeContainerWaitForNeo4jReady(container, password);
+			log.info( String.format( "Starting first container as %s user and setting password",
+									 asCurrentUser? "current" : "default" ) );
+            container.start();
+            DatabaseIO db = new DatabaseIO(container);
+            db.putInitialDataIntoContainer( "neo4j", password );
+            db.verifyInitialDataInContainer( "neo4j", password );
+        }
+    }
+
+    @Test
+    void testSecretsFileTakesPriorityOverEnvAuthentication() throws Exception
+    {
+        String password = "some_valid_password";
+        String wrongPassword = "not_the_password";
+
+        try(GenericContainer container = createContainer(false ))
+		{
+            container.withEnv( "NEO4J_AUTH", "neo4j/" + wrongPassword );
+			setInitialPasswordWithSecretsFile( container, password );
+            StartupDetector.makeContainerWaitForNeo4jReady(container, password);
+            container.start();
+            DatabaseIO db = new DatabaseIO(container);
+			Assertions.assertThrows( org.neo4j.driver.exceptions.AuthenticationException.class,
+									 () -> db.putInitialDataIntoContainer("neo4j", wrongPassword),
+									 "Able to access database with password set in the environment rather than secrets");
+
+            db.putInitialDataIntoContainer( "neo4j", password );
+            db.verifyInitialDataInContainer( "neo4j", password );
+        }
+    }
+
+    @Test
+    void testFailsIfSecretsFileSetButMissing()
+    {
+        try(GenericContainer failContainer = createContainer( false ))
+		{
+            StartupDetector.makeContainerWaitUntilFinished( failContainer, Duration.ofSeconds( 30 ) )
+                           .withEnv( NEO4J_AUTH_FILE_ENV, "/secrets/doesnotexist.secret" );
+
+            Assertions.assertThrows( ContainerLaunchException.class, () -> failContainer.start(),
+                                     "Neo4j started even though the password file does not exist" );
+            // an error message should be printed to stderr
+            String errors = failContainer.getLogs( OutputFrame.OutputType.STDERR);
+            Assertions.assertTrue( errors.contains( "The password file '/secrets/doesnotexist.secret' does not exist" ),
+                                   "Did not error about missing password file. Actual error was: "+errors);
         }
     }
 
@@ -219,16 +290,25 @@ public class TestPasswords
         }
     }
 
-    @Test
-    void testWarnAndFailIfPasswordLessThan8Chars() throws Exception
+    @ParameterizedTest(name = "use_secrets_file_{0}")
+    @ValueSource(booleans = {true, false})
+    void testWarnAndFailIfPasswordLessThan8Chars(boolean usePasswordFile) throws Exception
     {
         Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 5,2,0 ) ),
                                 "Minimum password length introduced in 5.2.0");
+        String shortPassword = "123";
         try(GenericContainer failContainer = createContainer( false ))
         {
-            failContainer.withEnv( "NEO4J_AUTH", "neo4j/123" )
-                         .withStartupCheckStrategy( new OneShotStartupCheckStrategy() );
-            Assertions.assertThrows( ContainerLaunchException.class, () -> failContainer.start(),
+            if(usePasswordFile)
+            {
+                setInitialPasswordWithSecretsFile( failContainer, shortPassword );
+            }
+            else
+            {
+                failContainer.withEnv( "NEO4J_AUTH", "neo4j/"+shortPassword );
+            }
+            StartupDetector.makeContainerWaitUntilFinished( failContainer, Duration.ofSeconds( 30 ) );
+            Assertions.assertThrows( ContainerLaunchException.class, failContainer::start,
                                      "Neo4j started even though initial password was too short" );
             String logsOut = failContainer.getLogs();
             Assertions.assertTrue( logsOut.contains( "Invalid value for password" ),
@@ -238,17 +318,27 @@ public class TestPasswords
         }
     }
 
-    @Test
-    void testWarnAndFailIfPasswordLessThanOverride() throws Exception
+    @ParameterizedTest(name = "use_secrets_file_{0}")
+    @ValueSource(booleans = {true, false})
+    void testWarnAndFailIfPasswordLessThanOverride(boolean usePasswordFile) throws Exception
     {
         Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 5,2,0 ) ),
                                 "Minimum password length introduced in 5.2.0");
+        String shortPassword = "123";
         try(GenericContainer failContainer = createContainer( false ))
         {
-            failContainer.withEnv( "NEO4J_AUTH", "neo4j/123" )
-                         .withEnv(Configuration.getConfigurationNameMap().get( Setting.MINIMUM_PASSWORD_LENGTH ).envName, "20")
-                         .withStartupCheckStrategy( new OneShotStartupCheckStrategy() );
-            Assertions.assertThrows( ContainerLaunchException.class, () -> failContainer.start(),
+            if(usePasswordFile)
+            {
+                setInitialPasswordWithSecretsFile( failContainer, shortPassword );
+            }
+            else
+            {
+                failContainer.withEnv( "NEO4J_AUTH", "neo4j/"+shortPassword );
+            }
+
+            StartupDetector.makeContainerWaitUntilFinished( failContainer, Duration.ofSeconds( 30 ) )
+                           .withEnv(Configuration.getConfigurationNameMap().get( Setting.MINIMUM_PASSWORD_LENGTH ).envName, "20");
+            Assertions.assertThrows( ContainerLaunchException.class, failContainer::start,
                                      "Neo4j started even though initial password was too short" );
             String logsOut = failContainer.getLogs();
             Assertions.assertTrue( logsOut.contains( "Invalid value for password" ),
@@ -258,42 +348,60 @@ public class TestPasswords
         }
     }
 
-    @Test
-    void shouldNotWarnAboutMinimumPasswordLengthIfSettingOverridden_env() throws Exception
+    @ParameterizedTest(name = "use_secrets_file_{0}")
+    @ValueSource(booleans = {true, false})
+    void shouldNotWarnAboutMinimumPasswordLengthIfSettingOverridden_env(boolean usePasswordFile) throws Exception
     {
         Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 5,2,0 ) ),
                                 "Minimum password length introduced in 5.2.0");
+        String shortPassword = "123";
         try(GenericContainer container = createContainer( false ))
         {
-            container.withEnv( "NEO4J_AUTH", "neo4j/123" )
-                     .withEnv(Configuration.getConfigurationNameMap().get( Setting.MINIMUM_PASSWORD_LENGTH ).envName, "2");
-            container.start();
-            String logs = container.getLogs();
-            Assertions.assertFalse( logs.contains( "Invalid value for password. The minimum password length is 8 characters." ),
-                                    "Should not error about minimum password length if overridden.");
-            DatabaseIO db = new DatabaseIO( container );
-            db.putInitialDataIntoContainer( "neo4j", "123" );
+            if(usePasswordFile)
+            {
+                setInitialPasswordWithSecretsFile( container, shortPassword );
+            }
+            else
+            {
+                container.withEnv( "NEO4J_AUTH", "neo4j/"+shortPassword );
+            }
+            container.withEnv(Configuration.getConfigurationNameMap().get( Setting.MINIMUM_PASSWORD_LENGTH ).envName, "2");
+            verifyDoesNotWarnAboutMinimumPasswordLengthIfSettingOverridden( container, shortPassword );
         }
     }
 
-    @Test
-    void shouldNotWarnAboutMinimumPasswordLengthIfSettingOverridden_conf() throws Exception
+    @ParameterizedTest(name = "use_secrets_file_{0}")
+    @ValueSource(booleans = {true, false})
+    void shouldNotWarnAboutMinimumPasswordLengthIfSettingOverridden_conf(boolean usePasswordFile) throws Exception
     {
         Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 5,2,0 ) ),
                                 "Minimum password length introduced in 5.2.0");
+        String shortPassword = "123";
         try(GenericContainer container = createContainer( false ))
         {
+            if(usePasswordFile)
+            {
+                setInitialPasswordWithSecretsFile( container, shortPassword );
+            }
+            else
+            {
+                container.withEnv( "NEO4J_AUTH", "neo4j/"+shortPassword );
+            }
             Path confMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/conf");
             Files.writeString(confMount.resolve( "neo4j.conf" ),
                               Configuration.getConfigurationNameMap().get( Setting.MINIMUM_PASSWORD_LENGTH ).name+"=2");
+            verifyDoesNotWarnAboutMinimumPasswordLengthIfSettingOverridden( container, shortPassword );
+        }
+    }
 
-            container.withEnv( "NEO4J_AUTH", "neo4j/123" );
+    private void verifyDoesNotWarnAboutMinimumPasswordLengthIfSettingOverridden(GenericContainer container, String password) throws Exception
+    {
             container.start();
             String logs = container.getLogs();
             Assertions.assertFalse( logs.contains( "Invalid value for password. The minimum password length is 8 characters." ),
                                     "Should not error about minimum password length if overridden.");
             DatabaseIO db = new DatabaseIO( container );
-            db.putInitialDataIntoContainer( "neo4j", "123" );
-        }
+            db.putInitialDataIntoContainer( "neo4j", password );
+            db.verifyInitialDataInContainer( "neo4j", password );
     }
 }

--- a/src/test/java/com/neo4j/docker/coredb/TestAuthentication.java
+++ b/src/test/java/com/neo4j/docker/coredb/TestAuthentication.java
@@ -203,7 +203,7 @@ public class TestAuthentication
             StartupDetector.makeContainerWaitUntilFinished( failContainer, Duration.ofSeconds( 30 ) )
                            .withEnv( NEO4J_AUTH_FILE_ENV, "/secrets/doesnotexist.secret" );
 
-            Assertions.assertThrows( ContainerLaunchException.class, () -> failContainer.start(),
+            Assertions.assertThrows( ContainerLaunchException.class, failContainer::start,
                                      "Neo4j started even though the password file does not exist" );
             // an error message should be printed to stderr
             String errors = failContainer.getLogs( OutputFrame.OutputType.STDERR);

--- a/src/test/java/com/neo4j/docker/coredb/TestMounting.java
+++ b/src/test/java/com/neo4j/docker/coredb/TestMounting.java
@@ -234,7 +234,7 @@ public class TestMounting
             // currently Neo4j will try to start and fail. It should be fixed to throw an error and not try starting
             container.setWaitStrategy( Wait.forLogMessage( "[fF]older /data is not accessible for user", 1 )
                                            .withStartupTimeout( Duration.ofSeconds( 20 ) ) );
-            Assertions.assertThrows( org.testcontainers.containers.ContainerLaunchException.class,
+            Assertions.assertThrows( ContainerLaunchException.class,
                                      () -> container.start(),
                                      "Neo4j should not start in secure mode if data folder is unwritable" );
         }
@@ -253,7 +253,7 @@ public class TestMounting
             // currently Neo4j will try to start and fail. It should be fixed to throw an error and not try starting
             container.setWaitStrategy( Wait.forLogMessage( "[fF]older /logs is not accessible for user", 1 )
                                            .withStartupTimeout( Duration.ofSeconds( 20 ) ) );
-            Assertions.assertThrows( org.testcontainers.containers.ContainerLaunchException.class,
+            Assertions.assertThrows( ContainerLaunchException.class,
                                      () -> container.start(),
                                      "Neo4j should not start in secure mode if logs folder is unwritable" );
         }

--- a/src/test/java/com/neo4j/docker/coredb/plugins/TestPluginInstallation.java
+++ b/src/test/java/com/neo4j/docker/coredb/plugins/TestPluginInstallation.java
@@ -248,9 +248,8 @@ public class TestPluginInstallation
             // if we try to set a plugin that doesn't exist
             container.withEnv( Neo4jPluginEnv.get(), "[\"notarealplugin\"]" )
                      .withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
-                     .withStartupCheckStrategy( new OneShotStartupCheckStrategy()
-                                                        .withTimeout( Duration.ofSeconds( 30 ) ) )
                      .withLogConsumer( new Slf4jLogConsumer( log ) );
+            StartupDetector.makeContainerWaitUntilFinished( container, Duration.ofSeconds(30) );
             Assertions.assertThrows( ContainerLaunchException.class, container::start );
             // the container should output a helpful message and quit
             String stdout = container.getLogs();
@@ -268,9 +267,8 @@ public class TestPluginInstallation
             // if we try to set a plugin that doesn't exist
             container.withEnv( Neo4jPluginEnv.get(), "[\"apoc\", \"notarealplugin\"]" )
                      .withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
-                     .withStartupCheckStrategy( new OneShotStartupCheckStrategy()
-                                                        .withTimeout( Duration.ofSeconds( 30 ) ) )
                      .withLogConsumer( new Slf4jLogConsumer( log ) );
+            StartupDetector.makeContainerWaitUntilFinished(container, Duration.ofSeconds(30));
             Assertions.assertThrows( ContainerLaunchException.class, container::start );
             // the container should output a helpful message and quit
             String stdout = container.getLogs();

--- a/src/test/java/com/neo4j/docker/neo4jadmin/TestAdminBasic.java
+++ b/src/test/java/com/neo4j/docker/neo4jadmin/TestAdminBasic.java
@@ -30,7 +30,7 @@ public class TestAdminBasic
              .waitingFor( new HttpWaitStrategy().forPort( 7474 ).forStatusCode( 200 ) )
              .withCommand( "neo4j", "console" );
 
-        Assertions.assertThrows( ContainerLaunchException.class, () -> admin.start() );
+        Assertions.assertThrows( ContainerLaunchException.class, admin::start );
         admin.stop();
     }
     @Test

--- a/src/test/java/com/neo4j/docker/neo4jadmin/TestReport.java
+++ b/src/test/java/com/neo4j/docker/neo4jadmin/TestReport.java
@@ -21,8 +21,7 @@ public class TestReport
         GenericContainer container = new GenericContainer( TestSettings.ADMIN_IMAGE_ID )
                 .withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" ).withEnv( "NEO4J_DEBUG", "yes" )
                 .withCommand( "neo4j-admin", "server", "report" )
-                .withLogConsumer( new Slf4jLogConsumer( log ) )
-                .withStartupCheckStrategy( new OneShotStartupCheckStrategy().withTimeout( Duration.ofSeconds( 20 ) ) );
+                .withLogConsumer( new Slf4jLogConsumer( log ) );
         StartupDetector.makeContainerWaitUntilFinished( container, Duration.ofSeconds( 20 ) );
         return container;
     }

--- a/src/test/java/com/neo4j/docker/utils/StartupDetector.java
+++ b/src/test/java/com/neo4j/docker/utils/StartupDetector.java
@@ -7,6 +7,7 @@ import java.util.concurrent.TimeUnit;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import org.rnorth.ducttape.unreliables.Unreliables;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
 import org.testcontainers.containers.wait.strategy.AbstractWaitStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerStatus;
@@ -41,9 +42,16 @@ public class StartupDetector {
         return makeContainerWaitForDatabaseReady(container, "neo4j", password, "neo4j", timeout);
     }
 
+    /**For containers that will just run a command and exit automatically.
+     * With this wait strategy, starting a container will block until the container has closed itself.
+     * The container could have succeeded or failed, we just wait for it to close.
+     * @param container the container to set the wait strategy on
+     * @param timeout how long to wait
+     * @return container in the modified state.
+     * */
     public static GenericContainer makeContainerWaitUntilFinished(GenericContainer container, Duration timeout)
     {
-
+        container.setStartupCheckStrategy( new OneShotStartupCheckStrategy().withTimeout( timeout ) );
         container.setWaitStrategy( new AbstractWaitStrategy()
         {
             @Override


### PR DESCRIPTION
This feature is intended for kubernetes (and possibly other cloud environments) where passwords are provided to the container as a secrets mount.