### PR TITLE
replaced gosu with su-exec in 5.x for better security tracability

### DIFF
--- a/docker-image-src/5/coredb/Dockerfile-debian
+++ b/docker-image-src/5/coredb/Dockerfile-debian
@@ -1,5 +1,15 @@
+FROM debian:bullseye-slim as suexec-builder
+RUN apt update \
+    && apt install -y gcc git make \
+    && git clone https://github.com/ncopa/su-exec.git \
+    && cd su-exec \
+    && make \
+    && rm -rf /var/lib/apt/lists/*
+
+
 FROM debian:bullseye-slim
 ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=suexec-builder /su-exec/su-exec /usr/bin/su-exec
 COPY --from=eclipse-temurin:17 $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}" \
     NEO4J_SHA256=%%NEO4J_SHA%% \
@@ -13,7 +23,7 @@ RUN addgroup --gid 7474 --system neo4j && adduser --uid 7474 --system --no-creat
 COPY ./local-package/* /startup/
 
 RUN apt update \
-    && apt install -y curl gosu jq procps tini wget \
+    && apt install -y curl jq procps tini wget \
     && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && echo "${NEO4J_SHA256}  ${NEO4J_TARBALL}" | sha256sum -c --strict --quiet \
     && tar --extract --file ${NEO4J_TARBALL} --directory /var/lib \

--- a/docker-image-src/5/coredb/Dockerfile-ubi8
+++ b/docker-image-src/5/coredb/Dockerfile-ubi8
@@ -1,6 +1,15 @@
+FROM redhat/ubi8-minimal:latest as suexec-builder
+RUN microdnf install -y gcc git make \
+    && git clone https://github.com/ncopa/su-exec.git \
+    && cd su-exec \
+    && make \
+    && microdnf clean all
+
+
 FROM redhat/ubi8-minimal:latest
 ENV JAVA_HOME=/opt/java/openjdk
 COPY --from=eclipse-temurin:17 $JAVA_HOME $JAVA_HOME
+COPY --from=suexec-builder /su-exec/su-exec /usr/bin/su-exec
 
 # gather pre-requisite packages
 RUN set -eux; \
@@ -9,14 +18,10 @@ RUN set -eux; \
         'x86_64') \
             tiniurl="https://github.com/krallin/tini/releases/download/v0.19.0/tini"; \
             tinisha="93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c"; \
-            gosuurl="https://github.com/tianon/gosu/releases/download/1.16/gosu-amd64"; \
-            gosusha="3a4e1fc7430f9e7dd7b0cbbe0bfde26bf4a250702e84cf48a1eb2b631c64cf13"; \
             ;; \
         'aarch64') \
             tiniurl="https://github.com/krallin/tini/releases/download/v0.19.0/tini-arm64"; \
             tinisha="07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81"; \
-            gosuurl="https://github.com/tianon/gosu/releases/download/1.16/gosu-arm64"; \
-            gosusha="23fa49907d5246d2e257de3bf883f57fba47fe1f559f7e732ff16c0f23d2b6a6"; \
             ;; \
         *) echo >&2 "Neo4j does not currently have a docker image for architecture $arch"; exit 1 ;; \
     esac; \
@@ -33,19 +38,14 @@ RUN set -eux; \
     wget -q ${tiniurl} -O /usr/bin/tini; \
     wget -q ${tiniurl}.asc -O tini.asc; \
     echo "${tinisha}"  /usr/bin/tini | sha256sum -c --strict --quiet; \
-    wget -q ${gosuurl} -O /usr/sbin/gosu; \
-    wget -q  ${gosuurl}.asc -O gosu.asc; \
-    echo "${gosusha}" /usr/sbin/gosu | sha256sum -c --strict --quiet; \
     chmod a+x /usr/bin/tini; \
-    chmod a+x /usr/sbin/gosu; \
     export GNUPGHOME="$(mktemp -d)"; \
     gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys \
         595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
         B42F6819007F00F88E364FD4036A9C25BF357DD4; \
     gpg --batch --verify tini.asc /usr/bin/tini; \
-    gpg --batch --verify gosu.asc /usr/sbin/gosu; \
     gpgconf --kill all; \
-    rm -rf "$GNUPGHOME" tini.asc gosu.asc; \
+    rm -rf "$GNUPGHOME" tini.asc; \
     microdnf clean all
 
 ENV PATH="${JAVA_HOME}/bin:${PATH}" \

--- a/docker-image-src/5/coredb/docker-entrypoint.sh
+++ b/docker-image-src/5/coredb/docker-entrypoint.sh
@@ -98,7 +98,7 @@ function check_mounted_folder_writable_with_chown
             echo "Warning: Folder mounted to \"${mountFolder}\" is not writable from inside container. Changing folder owner to ${userid}."
             chown -R "${userid}":"${groupid}" "${mountFolder}"
         # check permissions on files in the folder
-        elif [ $(gosu "${userid}":"${groupid}" find "${mountFolder}" -not -writable | wc -l) -gt 0 ]; then
+        elif [ $(su-exec "${userid}":"${groupid}" find "${mountFolder}" -not -writable | wc -l) -gt 0 ]; then
             echo "Warning: Some files inside \"${mountFolder}\" are not writable from inside container. Changing folder owner to ${userid}."
             chown -R "${userid}":"${groupid}" "${mountFolder}"
         fi
@@ -360,8 +360,8 @@ if running_as_root; then
   userid="neo4j"
   groupid="neo4j"
   groups=($(id -G neo4j))
-  exec_cmd="exec gosu neo4j:neo4j"
-  neo4j_admin_cmd="gosu neo4j:neo4j neo4j-admin"
+  exec_cmd="exec su-exec neo4j:neo4j"
+  neo4j_admin_cmd="su-exec neo4j:neo4j neo4j-admin"
   debug_msg "Running as root user inside neo4j image"
 else
   userid="$(id -u)"
@@ -615,7 +615,7 @@ function get_neo4j_run_cmd {
     fi
 
     if running_as_root; then
-        gosu neo4j:neo4j neo4j console --dry-run "${extra_args[@]}"
+        su-exec neo4j:neo4j neo4j console --dry-run "${extra_args[@]}"
     else
         neo4j console --dry-run "${extra_args[@]}"
     fi

--- a/docker-image-src/5/coredb/neo4j-admin-report.sh
+++ b/docker-image-src/5/coredb/neo4j-admin-report.sh
@@ -41,12 +41,12 @@ debug_msg "report_destination will be ${report_destination}"
 debug_msg "Determining which user to run neo4j-admin as."
 if running_as_root; then
     debug_msg "running neo4j-admin report as root"
-    if [[ ! $(gosu neo4j:neo4j test -w "${report_destination}") ]]; then
+    if [[ ! $(su-exec neo4j:neo4j test -w "${report_destination}") ]]; then
         debug_msg "reowning ${report_destination} to neo4j:neo4j"
         chown neo4j:neo4j "${report_destination}"
     fi
-    debug_msg gosu neo4j:neo4j "${report_cmd[@]}" "$@"
-    gosu neo4j:neo4j "${report_cmd[@]}" "$@"
+    debug_msg su-exec neo4j:neo4j "${report_cmd[@]}" "$@"
+    su-exec neo4j:neo4j "${report_cmd[@]}" "$@"
 else
     debug_msg "running neo4j-admin report as user defined by --user flag"
     if [[ ! -w "${report_destination}" ]]; then


### PR DESCRIPTION
Using the `gosu` tool results in too many complaints about vulnerabilities, because we also have to include `go` in the image.
By replacing `gosu` with `su-exec` we don't need to include `go`, and so theoretically it should not have those CVEs.

Since `su-exec` isn't provided as a pre-built binary anywhere reliable, I had to update the Dockerfiles to be multi-stage builds. I don't know if this violates the rules of docker official images. I couldn't see anything mentioning multi-stage builds specifically, but it does risk forcing us to revert this change later.