### PR TITLE
added --nodocs flag to ubi9 Dockerfiles

### DIFF
--- a/docker-image-src/5/coredb/Dockerfile-ubi9
+++ b/docker-image-src/5/coredb/Dockerfile-ubi9
@@ -15,7 +15,7 @@ RUN set -eux; \
             ;; \
         *) echo >&2 "Neo4j does not currently have a docker image for architecture $arch"; exit 1 ;; \
     esac; \
-    microdnf install -y \
+    microdnf install -y --nodocs \
         findutils \
         gcc \
         git \

--- a/docker-image-src/5/neo4j-admin/Dockerfile-ubi9
+++ b/docker-image-src/5/neo4j-admin/Dockerfile-ubi9
@@ -2,7 +2,7 @@ FROM redhat/ubi9-minimal:latest
 ENV JAVA_HOME=/usr
 
 # gather pre-requisite packages
-RUN microdnf install -y gzip java-17 procps shadow-utils tar util-linux && \
+RUN microdnf install -y --nodocs gzip java-17 procps shadow-utils tar util-linux && \
     microdnf clean all
 
 ENV PATH="${JAVA_HOME}/bin:${PATH}" \


### PR DESCRIPTION
make the image a little smaller and stops ssl documentation from triggering security scan false positives.