### PR TITLE
changed jvm additional test to not use a real jvm parameter

### DIFF
--- a/src/test/java/com/neo4j/docker/coredb/configurations/TestJVMAdditionalConfig.java
+++ b/src/test/java/com/neo4j/docker/coredb/configurations/TestJVMAdditionalConfig.java
@@ -111,12 +111,12 @@ public class TestJVMAdditionalConfig
     void testSpecialCharInJvmAdditional_dollar_conf() throws Exception
     {
         testJvmAdditionalSpecialCharacters_conf("dollar",
-                                                "-Djavax.net.ssl.trustStorePassword=\"beepbeep$boop1boop2\"" );
+                                                "-Dnot.a.real.parameter=\"beepbeep$boop1boop2\"" );
     }
 
     @Test
     void testSpecialCharInJvmAdditional_dollar_env() throws Exception {
-        testJvmAdditionalSpecialCharacters_env( "-Djavax.net.ssl.trustStorePassword=\"bleepblorp$bleep1blorp4\"");
+        testJvmAdditionalSpecialCharacters_env( "-Dnot.a.real.parameter=\"bleepblorp$bleep1blorp4\"");
     }
 
     void testJvmAdditionalSpecialCharacters_conf(String charName, String expectedJvmAdditional) throws Exception


### PR DESCRIPTION
The test was supplying an invalid value for the parameter it was testing (ssl trust store password), so when something in neo4j changed to actually require a correct value, this test started (correctly) failing.