### PR TITLE
Container stop with SIGINT and SIGTERM were not actually testing with SIGINT and SIGTERM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <junit.version>5.10.0</junit.version>
         <neo4j.driver.version>4.4.11</neo4j.driver.version>
         <surefire.version>3.1.2</surefire.version>
-        <testcontainers.version>1.18.0</testcontainers.version>
+        <testcontainers.version>1.19.8</testcontainers.version>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <junit.version>5.10.0</junit.version>
         <neo4j.driver.version>4.4.11</neo4j.driver.version>
         <surefire.version>3.1.2</surefire.version>
-        <testcontainers.version>1.19.8</testcontainers.version>
+        <testcontainers.version>1.18.0</testcontainers.version>
     </properties>
 
     <profiles>


### PR DESCRIPTION
TestContainers ignores stop signals added to the CreateContainerCmd, so the tests have to manually make kill and stop commands.