### PR TITLE
Extended container startup timeouts from 60 and 90 to 150 seconds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,10 +11,10 @@
 
 	<properties>
         <java.version>17</java.version>
-        <junit.version>5.10.0</junit.version>
-        <neo4j.driver.version>4.4.11</neo4j.driver.version>
+        <junit.version>5.11.0</junit.version>
+        <neo4j.driver.version>5.24.0</neo4j.driver.version>
         <surefire.version>3.1.2</surefire.version>
-        <testcontainers.version>1.18.0</testcontainers.version>
+        <testcontainers.version>1.20.1</testcontainers.version>
     </properties>
 
     <profiles>

--- a/src/test/java/com/neo4j/docker/TestDeprecationWarning.java
+++ b/src/test/java/com/neo4j/docker/TestDeprecationWarning.java
@@ -31,7 +31,7 @@ public class TestDeprecationWarning
             container.withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
                      .withExposedPorts( 7474, 7687 )
                      .withLogConsumer( new Slf4jLogConsumer( log ))
-                     .waitingFor( WaitStrategies.waitForBoltReady( Duration.ofSeconds( 90 ) ) );
+                     .waitingFor( WaitStrategies.waitForBoltReady() );
             container.start();
             // container should successfully start
             String logs = container.getLogs( OutputFrame.OutputType.STDERR );
@@ -92,7 +92,7 @@ public class TestDeprecationWarning
                      .withEnv( DEPRECATION_WARN_SUPPRESS_FLAG, "suppress" )
                      .withExposedPorts( 7474, 7687 )
                      .withLogConsumer( new Slf4jLogConsumer( log ))
-                     .waitingFor( WaitStrategies.waitForBoltReady( Duration.ofSeconds( 90 ) ) );
+                     .waitingFor( WaitStrategies.waitForBoltReady() );
             container.start();
             // container should successfully start
             String logs = container.getLogs( OutputFrame.OutputType.STDERR );

--- a/src/test/java/com/neo4j/docker/TestDockerComposeSecrets.java
+++ b/src/test/java/com/neo4j/docker/TestDockerComposeSecrets.java
@@ -52,7 +52,7 @@ public class TestDockerComposeSecrets
                  .withExposedService( serviceName, DEFAULT_HTTP_PORT )
                  .withEnv( "NEO4J_IMAGE", TestSettings.IMAGE_ID.asCanonicalNameString() )
                  .withEnv( "HOST_ROOT", containerRootDir.toAbsolutePath().toString() )
-                 .waitingFor( serviceName, waitForBoltReady( Duration.ofSeconds( 90 ) ) )
+                 .waitingFor( serviceName, waitForBoltReady() )
                  .withLogConsumer( serviceName, new Slf4jLogConsumer( log ) );
 
         return container;

--- a/src/test/java/com/neo4j/docker/coredb/TestAuthentication.java
+++ b/src/test/java/com/neo4j/docker/coredb/TestAuthentication.java
@@ -42,7 +42,7 @@ public class TestAuthentication
         container.withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
                  .withExposedPorts( 7474, 7687 )
                  .withLogConsumer( new Slf4jLogConsumer( log ) )
-                 .waitingFor(WaitStrategies.waitForBoltReady( Duration.ofSeconds( 90) ));
+                 .waitingFor(WaitStrategies.waitForBoltReady());
         if(asCurrentUser)
         {
             SetContainerUser.nonRootUser( container );
@@ -100,9 +100,7 @@ public class TestAuthentication
 		try(GenericContainer container = createContainer( true ))
         {
             log.info( "Starting first container as current user and not specifying NEO4J_AUTH" );
-            container.waitingFor( WaitStrategies.waitForNeo4jReady( "neo4j",
-                                                                    "neo4j",
-                                                                    Duration.ofSeconds( 90)) );
+            container.waitingFor( WaitStrategies.waitForNeo4jReady( "neo4j" ) );
             container.start();
             DatabaseIO db = new DatabaseIO(container);
             // try with no password, this should fail because the default password should be applied with no NEO4J_AUTH env variable
@@ -272,7 +270,7 @@ public class TestAuthentication
             String intialPass = "apassword";
             String resetPass = "new_password";
             container.withEnv("NEO4J_AUTH", user+"/"+intialPass+"/true" )
-                     .waitingFor(   WaitStrategies.waitForNeo4jReady( user, intialPass, Duration.ofSeconds(60)) );
+                     .waitingFor(   WaitStrategies.waitForNeo4jReady( intialPass ) );
             container.start();
             DatabaseIO db = new DatabaseIO(container);
             Assertions.assertThrows( org.neo4j.driver.exceptions.ClientException.class,

--- a/src/test/java/com/neo4j/docker/coredb/TestBasic.java
+++ b/src/test/java/com/neo4j/docker/coredb/TestBasic.java
@@ -243,7 +243,7 @@ public class TestBasic
             int boltHostPort = getUniqueHostPort();
             int browserHostPort = getUniqueHostPort();
 
-            container.waitingFor( waitForBoltReady( Duration.ofSeconds( 90 ) ) );
+            container.waitingFor( waitForBoltReady() );
             container.withEnv( "NEO4J_AUTH", "none" );
 
             // Ensuring host ports are constant with container restarts
@@ -262,7 +262,7 @@ public class TestBasic
             container.getDockerClient().startContainerCmd( container.getContainerId() ).exec();
 
             // Applying the Waiting strategy to ensure container is correctly running, because DockerClient does not check
-            waitForBoltReady( Duration.ofSeconds( 90 ) ).waitUntilReady( container );
+            waitForBoltReady().waitUntilReady( container );
         }
     }
 
@@ -276,7 +276,7 @@ public class TestBasic
         try ( GenericContainer container = createBasicContainer() )
         {
             temporaryFolderManager.mountHostFolderAsVolume(container, scriptFolder, "/extension");
-            container.waitingFor(waitForBoltReady(Duration.ofSeconds(60)))
+            container.waitingFor(waitForBoltReady())
                     .withEnv("EXTENSION_SCRIPT", "/extension/startscript.sh");
             container.start();
             String logs = container.getLogs(OutputFrame.OutputType.STDOUT);

--- a/src/test/java/com/neo4j/docker/coredb/TestSSL.java
+++ b/src/test/java/com/neo4j/docker/coredb/TestSSL.java
@@ -61,7 +61,7 @@ public class TestSSL
                 .withEnv("NEO4J_DEBUG", "yes")
                 .withExposedPorts(7474, 7687)
                 .withLogConsumer(new Slf4jLogConsumer(log))
-                .waitingFor(WaitStrategies.waitForNeo4jReady(PASSWORD, Duration.ofSeconds(60)));
+                .waitingFor(WaitStrategies.waitForNeo4jReady(PASSWORD ));
         return container;
     }
 

--- a/src/test/java/com/neo4j/docker/coredb/configurations/TestConfSettings.java
+++ b/src/test/java/com/neo4j/docker/coredb/configurations/TestConfSettings.java
@@ -125,7 +125,7 @@ public class TestConfSettings
         try(GenericContainer container = createContainer())
         {
             container.withEnv( "NEO4J_1a", "1" )
-                     .waitingFor( WaitStrategies.waitForBoltReady( Duration.ofSeconds( 90 ) ) );
+                     .waitingFor( WaitStrategies.waitForBoltReady() );
             container.start();
             Assertions.assertTrue( container.isRunning() );
             String errorLogs = container.getLogs( OutputFrame.OutputType.STDERR);

--- a/src/test/java/com/neo4j/docker/coredb/configurations/TestExtendedConf.java
+++ b/src/test/java/com/neo4j/docker/coredb/configurations/TestExtendedConf.java
@@ -62,7 +62,7 @@ public class TestExtendedConf
                 .withEnv( "EXTENDED_CONF", "true" )
                 .withExposedPorts( 7474, 7687 )
                 .withLogConsumer( new Slf4jLogConsumer( log ) )
-                .waitingFor( WaitStrategies.waitForBoltReady( Duration.ofSeconds(90)));
+                .waitingFor( WaitStrategies.waitForBoltReady());
        return container;
     }
 

--- a/src/test/java/com/neo4j/docker/coredb/plugins/TestBundledPluginInstallation.java
+++ b/src/test/java/com/neo4j/docker/coredb/plugins/TestBundledPluginInstallation.java
@@ -99,7 +99,7 @@ public class TestBundledPluginInstallation
                  .withEnv("NEO4J_DEBUG", "yes")
                  .withExposedPorts( 7474, 7687 )
                  .withLogConsumer( new Slf4jLogConsumer( log ) )
-                 .waitingFor( WaitStrategies.waitForBoltReady(Duration.ofSeconds(60)) );
+                 .waitingFor( WaitStrategies.waitForBoltReady() );
         return container;
     }
 

--- a/src/test/java/com/neo4j/docker/coredb/plugins/TestPluginInstallation.java
+++ b/src/test/java/com/neo4j/docker/coredb/plugins/TestPluginInstallation.java
@@ -88,7 +88,7 @@ public class TestPluginInstallation
                  .withEnv( Neo4jPluginEnv.get(), "[\"_testing\"]" )
                  .withExposedPorts( 7474, 7687 )
                  .withLogConsumer( new Slf4jLogConsumer( log ) )
-                 .waitingFor( WaitStrategies.waitForNeo4jReady( DB_USER, DB_PASSWORD, Duration.ofSeconds( 60 )));
+                 .waitingFor( WaitStrategies.waitForNeo4jReady( DB_PASSWORD));
         SetContainerUser.nonRootUser( container );
         return container;
     }

--- a/src/test/java/com/neo4j/docker/neo4jadmin/TestBackupRestore.java
+++ b/src/test/java/com/neo4j/docker/neo4jadmin/TestBackupRestore.java
@@ -59,7 +59,7 @@ public class TestBackupRestore
                  .withEnv( confNames.get( Setting.BACKUP_LISTEN_ADDRESS ).envName, "0.0.0.0:6362" )
                  .withExposedPorts( 7474, 7687, 6362 )
                  .withLogConsumer( new Slf4jLogConsumer( log ) )
-                 .waitingFor(WaitStrategies.waitForNeo4jReady( password, Duration.ofSeconds( 90 )));
+                 .waitingFor(WaitStrategies.waitForNeo4jReady( password ));
         if(!asDefaultUser)
         {
             SetContainerUser.nonRootUser( container );

--- a/src/test/java/com/neo4j/docker/neo4jadmin/TestBackupRestore44.java
+++ b/src/test/java/com/neo4j/docker/neo4jadmin/TestBackupRestore44.java
@@ -57,7 +57,7 @@ public class TestBackupRestore44
                  .withEnv( confNames.get( Setting.BACKUP_LISTEN_ADDRESS ).envName, "0.0.0.0:6362" )
                  .withExposedPorts( 7474, 7687, 6362 )
                  .withLogConsumer( new Slf4jLogConsumer( log ) )
-                 .waitingFor(WaitStrategies.waitForNeo4jReady( password, Duration.ofSeconds( 90 )));
+                 .waitingFor(WaitStrategies.waitForNeo4jReady( password ));
         if(!asDefaultUser)
         {
             SetContainerUser.nonRootUser( container );

--- a/src/test/java/com/neo4j/docker/neo4jadmin/TestDumpLoad.java
+++ b/src/test/java/com/neo4j/docker/neo4jadmin/TestDumpLoad.java
@@ -47,7 +47,7 @@ public class TestDumpLoad
                  .withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
                  .withExposedPorts( 7474, 7687 )
                  .withLogConsumer( new Slf4jLogConsumer( log ) )
-                 .waitingFor( WaitStrategies.waitForNeo4jReady( password, Duration.ofSeconds( 90 )) );
+                 .waitingFor( WaitStrategies.waitForNeo4jReady( password) );
         if(!asDefaultUser)
         {
             SetContainerUser.nonRootUser( container );

--- a/src/test/java/com/neo4j/docker/neo4jadmin/TestDumpLoad44.java
+++ b/src/test/java/com/neo4j/docker/neo4jadmin/TestDumpLoad44.java
@@ -51,7 +51,7 @@ public class TestDumpLoad44
                  .withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
                  .withExposedPorts( 7474, 7687 )
                  .withLogConsumer( new Slf4jLogConsumer( log ) )
-                 .waitingFor( WaitStrategies.waitForNeo4jReady( password, Duration.ofSeconds( 90 )) )
+                 .waitingFor( WaitStrategies.waitForNeo4jReady( password ) )
                  // the default testcontainer framework behaviour is to just stop the process entirely,
                  // preventing clean shutdown. This means we can run the stop command and
                  // it'll send a SIGTERM to initiate neo4j shutdown. See also stopContainer method.

--- a/src/test/java/com/neo4j/docker/utils/WaitStrategies.java
+++ b/src/test/java/com/neo4j/docker/utils/WaitStrategies.java
@@ -15,6 +15,9 @@ import org.testcontainers.utility.DockerStatus;
 
 public class WaitStrategies
 {
+
+    private final static Duration STARTUP_TIMEOUT_SECONDS = Duration.ofSeconds(150);
+
     private WaitStrategies() {}
 
     public static WaitStrategy waitForNeo4jReady( String username, String password, String database, Duration timeout )
@@ -28,28 +31,20 @@ public class WaitStrategies
                        .withStartupTimeout(timeout);
         } else
         {
-            return waitForBoltReady( timeout );
+            return waitForBoltReady();
         }
     }
 
     public static WaitStrategy waitForNeo4jReady( String password ) {
-        return waitForNeo4jReady( "neo4j", password, "neo4j", Duration.ofSeconds(60));
+        return waitForNeo4jReady( "neo4j", password, "neo4j", STARTUP_TIMEOUT_SECONDS);
     }
 
-    public static WaitStrategy waitForNeo4jReady( String password, Duration timeout ) {
-        return waitForNeo4jReady( "neo4j", password, "neo4j", timeout);
-    }
-
-    public static WaitStrategy waitForNeo4jReady( String user, String password, Duration timeout ) {
-        return waitForNeo4jReady( user, password, "neo4j", timeout);
-    }
-
-    public static WaitStrategy waitForBoltReady( Duration timeout )
+    public static WaitStrategy waitForBoltReady()
     {
         return Wait.forHttp("/")
                    .forPort(7687)
                    .forStatusCode(200)
-                   .withStartupTimeout(timeout);
+                   .withStartupTimeout(STARTUP_TIMEOUT_SECONDS);
     }
 
     /**For containers that will just run a command and exit automatically.


### PR DESCRIPTION
Also refactored WaitStrategies to read timeout value from one place, to facilitate easy tweaking of this value. There is, I think, little value of having different timeouts for different tests.