### PR TITLE
Changed regex in test to match output from updated logger and old output

### DIFF
--- a/src/test/java/com/neo4j/docker/neo4jadmin/TestDumpLoad.java
+++ b/src/test/java/com/neo4j/docker/neo4jadmin/TestDumpLoad.java
@@ -61,7 +61,7 @@ public class TestDumpLoad
         container.withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
                  .withExposedPorts( 7474, 7687 )
                  .withLogConsumer( new Slf4jLogConsumer( log ) )
-                 .waitingFor( new LogMessageWaitStrategy().withRegEx( "^Done: \\d+ files, [\\d\\.,]+[KMGi]+B processed\\..*" ) )
+                 .waitingFor( new LogMessageWaitStrategy().withRegEx( "^Done: \\d+ files, [\\d\\.,]+[KMGi]*B processed.*" ) )
 //                 .waitingFor( new LogMessageWaitStrategy().withRegEx( "^Done: .*" ) )
                  .withStartupCheckStrategy( new OneShotStartupCheckStrategy().withTimeout( Duration.ofSeconds( 90 ) ) );
         if(!asDefaultUser)

--- a/src/test/java/com/neo4j/docker/neo4jadmin/TestDumpLoad44.java
+++ b/src/test/java/com/neo4j/docker/neo4jadmin/TestDumpLoad44.java
@@ -70,7 +70,7 @@ public class TestDumpLoad44
         container.withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
                  .withExposedPorts( 7474, 7687 )
                  .withLogConsumer( new Slf4jLogConsumer( log ) )
-                 .waitingFor( new LogMessageWaitStrategy().withRegEx( "^Done: \\d+ files, [\\d\\.,]+[KMGi]+B processed\\..*" ) )
+                 .waitingFor( new LogMessageWaitStrategy().withRegEx( "^Done: \\d+ files, [\\d\\.,]+[KMGi]*B processed.*" ) )
                  .withStartupCheckStrategy( new OneShotStartupCheckStrategy().withTimeout( Duration.ofSeconds( 90 ) ) );
         if(!asDefaultUser)
         {


### PR DESCRIPTION
Changed a logger in neo4j, see the PR [here](https://github.com/neo-technology/neo4j/pull/27138 )
Need to change the regex in some tests here to match both the new output and the old one.