### PR TITLE
quick fix to stop the upgrade tests from failing in 5.27 and calver

### DIFF
--- a/src/test/java/com/neo4j/docker/utils/Neo4jVersion.java
+++ b/src/test/java/com/neo4j/docker/utils/Neo4jVersion.java
@@ -8,6 +8,7 @@ public class Neo4jVersion
     public static final Neo4jVersion NEO4J_VERSION_400 = new Neo4jVersion( 4, 0, 0 );
     public static final Neo4jVersion NEO4J_VERSION_440 = new Neo4jVersion( 4, 4, 0 );
     public static final Neo4jVersion NEO4J_VERSION_500 = new Neo4jVersion( 5, 0, 0 );
+    public static final Neo4jVersion NEO4J_VERSION_527 = new Neo4jVersion( 5, 27, 0 );
 
     public final int major;
     public final int minor;


### PR DESCRIPTION
I think the Neo4jVersion class should have some idea of the version branch and that would make it possible to clean up a lot of the assumptions.

This is a quick fix to unblock another team.