### PR TITLE
Alter test to handle changes that always output exceptions

### DIFF
--- a/src/test/java/com/neo4j/docker/coredb/configurations/TestExtendedConf.java
+++ b/src/test/java/com/neo4j/docker/coredb/configurations/TestExtendedConf.java
@@ -144,7 +144,7 @@ public class TestExtendedConf
             // check that error messages from the command that failed are visible in docker logs
             Assertions.assertTrue( logs.contains( "this is an error message from inside neo4j config command expansion" ) );
             // check that the error is only encountered once (i.e. we quit the docker entrypoint the first time it was encountered)
-            Assertions.assertEquals( 1, countOccurrences( Pattern.compile( "Error evaluating value for setting" ), logs ) );
+            Assertions.assertEquals( 1, countOccurrences( Pattern.compile( "Failed to read config /var/lib/neo4j/conf/neo4j.conf: Error evaluating value for setting" ), logs ) );
         }
     }
 

--- a/src/test/java/com/neo4j/docker/coredb/configurations/TestExtendedConf.java
+++ b/src/test/java/com/neo4j/docker/coredb/configurations/TestExtendedConf.java
@@ -144,7 +144,7 @@ public class TestExtendedConf
             // check that error messages from the command that failed are visible in docker logs
             Assertions.assertTrue( logs.contains( "this is an error message from inside neo4j config command expansion" ) );
             // check that the error is only encountered once (i.e. we quit the docker entrypoint the first time it was encountered)
-            Assertions.assertEquals( 1, countOccurrences( Pattern.compile( "Failed to read config /var/lib/neo4j/conf/neo4j.conf: Error evaluating value for setting" ), logs ) );
+            Assertions.assertEquals( 1, countOccurrences( Pattern.compile( "(neo4j.conf|Error): Error evaluating value for setting" ), logs ) );
         }
     }
 

--- a/src/test/java/com/neo4j/docker/coredb/configurations/TestExtendedConf.java
+++ b/src/test/java/com/neo4j/docker/coredb/configurations/TestExtendedConf.java
@@ -144,7 +144,7 @@ public class TestExtendedConf
             // check that error messages from the command that failed are visible in docker logs
             Assertions.assertTrue( logs.contains( "this is an error message from inside neo4j config command expansion" ) );
             // check that the error is only encountered once (i.e. we quit the docker entrypoint the first time it was encountered)
-            Assertions.assertEquals( 1, countOccurrences( Pattern.compile( "(neo4j.conf|Error): Error evaluating value for setting" ), logs ) );
+            Assertions.assertEquals( 1, countOccurrences( Pattern.compile( "(neo4j\\.conf|Error): Error evaluating value for setting" ), logs ) );
         }
     }
 


### PR DESCRIPTION
To aid supporting neo4j exceptions will always be output to STDERR even if not -verbose. This requires altering the docker testInvalidExtendedConfFile_nonRootUser test to have a more specific filter to validate the container doesn't restart, since the original string is repeated within the exception stack trace.