### PR TITLE
Maintain logs after execution and increase timeout

### DIFF
--- a/src/test/java/com/neo4j/docker/coredb/TestAuthentication.java
+++ b/src/test/java/com/neo4j/docker/coredb/TestAuthentication.java
@@ -59,13 +59,16 @@ public class TestAuthentication
     }
 
 	@Test
-	void testNoPassword()
-	{
+	void testNoPassword() throws IOException
+    {
 		// we test that setting NEO4J_AUTH to "none" lets the database start in TestBasic.java,
         // but that does not test that we can read/write the database
 		try(GenericContainer container = createContainer( false ))
 		{
 			container.withEnv( "NEO4J_AUTH", "none");
+            temporaryFolderManager.createFolderAndMountAsVolume( container, "/data" );
+            temporaryFolderManager.createFolderAndMountAsVolume( container, "/logs" );
+
 			container.start();
             DatabaseIO db = new DatabaseIO(container);
             db.putInitialDataIntoContainer( "neo4j", "none" );

--- a/src/test/java/com/neo4j/docker/utils/WaitStrategies.java
+++ b/src/test/java/com/neo4j/docker/utils/WaitStrategies.java
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeUnit;
 public class WaitStrategies
 {
 
-    private final static Duration STARTUP_TIMEOUT_SECONDS = Duration.ofSeconds(150);
+    private final static Duration STARTUP_TIMEOUT_SECONDS = Duration.ofSeconds(180);
 
     private WaitStrategies() {}
 


### PR DESCRIPTION
https://trello.com/c/Kb2xWAA1/1748-merge-test-failure-comneo4jdockercoredbtestauthenticationtestnopassword-is-failing-in-a-pipeline-run