### PR TITLE
Update Debian package manager usage

### DIFF
--- a/docker-image-src/4.4/coredb/Dockerfile-debian
+++ b/docker-image-src/4.4/coredb/Dockerfile-debian
@@ -13,8 +13,8 @@ RUN addgroup --gid 7474 --system neo4j && adduser --uid 7474 --system --no-creat
 
 COPY ./local-package/* /startup/
 
-RUN apt update \
-    && apt-get install -y curl gcc git jq make procps tini wget \
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y curl ca-certificates gcc libc-dev git jq make procps tini wget \
     && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && echo "${NEO4J_SHA256}  ${NEO4J_TARBALL}" | sha256sum -c --strict --quiet \
     && tar --extract --file ${NEO4J_TARBALL} --directory /var/lib \
@@ -40,7 +40,7 @@ RUN apt update \
     && echo 2a87af245eb125aca9305a0b1025525ac80825590800f047419dc57bba36b334 Makefile | sha256sum -c \
     && make \
     && mv /su-exec/su-exec /usr/bin/su-exec \
-    && apt-get -y purge --auto-remove curl gcc git make \
+    && apt-get -y purge --auto-remove curl gcc git make libc-dev \
     && rm -rf /var/lib/apt/lists/* /su-exec
 
 

--- a/docker-image-src/4.4/neo4j-admin/Dockerfile-debian
+++ b/docker-image-src/4.4/neo4j-admin/Dockerfile-debian
@@ -13,8 +13,8 @@ RUN addgroup --gid 7474 --system neo4j && adduser --uid 7474 --system --no-creat
 
 COPY ./local-package/* /startup/
 
-RUN apt update \
-    && apt install -y curl procps \
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y curl ca-certificates procps \
     && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && echo "${NEO4J_SHA256}  ${NEO4J_TARBALL}" | sha256sum -c --strict --quiet \
     && tar --extract --file ${NEO4J_TARBALL} --directory /var/lib \

--- a/docker-image-src/5/coredb/Dockerfile-debian
+++ b/docker-image-src/5/coredb/Dockerfile-debian
@@ -13,8 +13,8 @@ RUN addgroup --gid 7474 --system neo4j && adduser --uid 7474 --system --no-creat
 
 COPY ./local-package/* /startup/
 
-RUN apt update \
-    && apt-get install -y curl gcc git jq make procps tini wget \
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y curl ca-certificates gcc libc-dev git jq make procps tini wget \
     && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && echo "${NEO4J_SHA256}  ${NEO4J_TARBALL}" | sha256sum -c --strict --quiet \
     && tar --extract --file ${NEO4J_TARBALL} --directory /var/lib \
@@ -40,7 +40,7 @@ RUN apt update \
     && echo 2a87af245eb125aca9305a0b1025525ac80825590800f047419dc57bba36b334 Makefile | sha256sum -c \
     && make \
     && mv /su-exec/su-exec /usr/bin/su-exec \
-    && apt-get -y purge --auto-remove curl gcc git make \
+    && apt-get -y purge --auto-remove curl gcc git make libc-dev \
     && rm -rf /var/lib/apt/lists/* /su-exec
 
 

--- a/docker-image-src/5/neo4j-admin/Dockerfile-debian
+++ b/docker-image-src/5/neo4j-admin/Dockerfile-debian
@@ -13,8 +13,8 @@ RUN addgroup --gid 7474 --system neo4j && adduser --uid 7474 --system --no-creat
 
 COPY ./local-package/* /startup/
 
-RUN apt update \
-    && apt install -y curl procps \
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y curl ca-certificates procps \
     && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && echo "${NEO4J_SHA256}  ${NEO4J_TARBALL}" | sha256sum -c --strict --quiet \
     && tar --extract --file ${NEO4J_TARBALL} --directory /var/lib \

--- a/docker-image-src/calver/coredb/Dockerfile-debian
+++ b/docker-image-src/calver/coredb/Dockerfile-debian
@@ -13,8 +13,8 @@ RUN addgroup --gid 7474 --system neo4j && adduser --uid 7474 --system --no-creat
 
 COPY ./local-package/* /startup/
 
-RUN apt update \
-    && apt-get install -y curl gcc git jq make procps tini wget \
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y curl ca-certificates gcc libc-dev git jq make procps tini wget \
     && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && echo "${NEO4J_SHA256}  ${NEO4J_TARBALL}" | sha256sum -c --strict --quiet \
     && tar --extract --file ${NEO4J_TARBALL} --directory /var/lib \
@@ -40,7 +40,7 @@ RUN apt update \
     && echo 2a87af245eb125aca9305a0b1025525ac80825590800f047419dc57bba36b334 Makefile | sha256sum -c \
     && make \
     && mv /su-exec/su-exec /usr/bin/su-exec \
-    && apt-get -y purge --auto-remove curl gcc git make \
+    && apt-get -y purge --auto-remove curl gcc git make libc-dev \
     && rm -rf /var/lib/apt/lists/* /su-exec
 
 

--- a/docker-image-src/calver/neo4j-admin/Dockerfile-debian
+++ b/docker-image-src/calver/neo4j-admin/Dockerfile-debian
@@ -13,8 +13,8 @@ RUN addgroup --gid 7474 --system neo4j && adduser --uid 7474 --system --no-creat
 
 COPY ./local-package/* /startup/
 
-RUN apt update \
-    && apt install -y curl procps \
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y curl ca-certificates procps \
     && curl --fail --silent --show-error --location --remote-name ${NEO4J_URI} \
     && echo "${NEO4J_SHA256}  ${NEO4J_TARBALL}" | sha256sum -c --strict --quiet \
     && tar --extract --file ${NEO4J_TARBALL} --directory /var/lib \


### PR DESCRIPTION
The man pages of Debian quite clearly states that `apt` is for human usage, and scripts should rely on `apt-get` for stability.

Also, packages should be installed with `--no-install-recommends` to avoid pulling in unnecessary dependencies (e.g.  `gcc` pulls in `libtiff5` without us really needing it), meaning less network traffic when building. 

After no longer installing the recommended packages we have to complement our packages with `ca-certificates` for common TLS certificates, and `libc-dev` to build `su-exec`..