### PR TITLE
Add Fleet management plugin to supported plugins

### DIFF
--- a/docker-image-src/4.4/coredb/neo4j-plugins.json
+++ b/docker-image-src/4.4/coredb/neo4j-plugins.json
@@ -51,6 +51,13 @@
       "dbms.security.procedures.unrestricted":"semantics.*"
     }
   },
+  "fleet-management": {
+    "location": "/var/lib/neo4j/labs/neo4j-fleet-management-*.jar",
+    "properties": {
+      "dbms.security.procedures.unrestricted": "fleetManagement.*",
+      "dbms.security.procedures.allowlist": "fleetManagement.*"
+    }
+  },
   "_testing": {
     "versions": "http://host.testcontainers.internal:3000/versions.json",
     "properties": {

--- a/docker-image-src/5/coredb/neo4j-plugins.json
+++ b/docker-image-src/5/coredb/neo4j-plugins.json
@@ -40,6 +40,13 @@
       "dbms.security.procedures.unrestricted": "genai.*"
     }
   },
+  "fleet-management": {
+    "location": "/var/lib/neo4j/labs/neo4j-fleet-management-*.jar",
+    "properties": {
+      "dbms.security.procedures.unrestricted": "fleetManagement.*",
+      "dbms.security.procedures.allowlist": "fleetManagement.*"
+    }
+  },
   "_testing": {
     "versions": "http://host.testcontainers.internal:3000/versions.json",
     "properties": {

--- a/docker-image-src/calver/coredb/neo4j-plugins.json
+++ b/docker-image-src/calver/coredb/neo4j-plugins.json
@@ -34,6 +34,13 @@
       "dbms.security.procedures.unrestricted": "genai.*"
     }
   },
+  "fleet-management": {
+    "location": "/var/lib/neo4j/labs/neo4j-fleet-management-*.jar",
+    "properties": {
+      "dbms.security.procedures.unrestricted": "fleetManagement.*",
+      "dbms.security.procedures.allowlist": "fleetManagement.*"
+    }
+  },
   "_testing": {
     "versions": "http://host.testcontainers.internal:3000/versions.json",
     "properties": {


### PR DESCRIPTION
Fleet management plugin is part of Fleet management feature to be introduced in Aura to monitor on-prem Neo4j deployments with an Aura account. It is already bundled in latest(calver), 5.26-LTS & 4.4-LTS Neo4j packages to facilitate the installation and configuration of the plugin and related procedures to enable the monitoring. For more info:

- [Trello](https://trello.com/c/hBXmkJJ2/2842-update-docker-packaging-to-allow-efm-plugin-to-be-installed-if-specified-similar-to-bloom-and-gds-plugins)
- [FAQs](https://docs.google.com/document/d/1zdMJSMHZ8xGU_4XHRajeacz8lPFkRgegYLhO2ROcA1A)
- [Quick start guide](https://docs.google.com/presentation/d/1WZWt_YNdYfCP_bN6qQfMPG_qHLYUZxxHjMnSHk83uLQ/edit?usp=drive_link)