### PR TITLE
publish neo4j admin scripts need updating to name images after real base os not just 'debian'

### DIFF
--- a/build-docker-image.sh
+++ b/build-docker-image.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 set -eu -o pipefail
 
-SUPPORTED_IMAGE_OS=("bullseye" "ubi9")
-EDITIONS=("community" "enterprise")
-
-DISTRIBUTION_SITE="https://dist.neo4j.org"
 ROOT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source "$ROOT_DIR/build-utils-common-functions.sh"
 BUILD_DIR=${ROOT_DIR}/build
@@ -76,7 +72,7 @@ fetch_tarball "${NEO4JVERSION}" "${NEO4JEDITION}"
 ## construct local build context. These are all the files required to build the
 ## neo4j image locally.
 
-echo "Building local context for docker build"
+echo "Building local context for docker build ${NEO4JEDITION}-${NEO4JVERSION}-${IMAGE_OS}"
 COREDB_LOCALCXT_DIR=${BUILD_DIR}/${IMAGE_OS}/coredb/${NEO4JEDITION}
 ADMIN_LOCALCXT_DIR=${BUILD_DIR}/${IMAGE_OS}/neo4j-admin/${NEO4JEDITION}
 mkdir -p ${COREDB_LOCALCXT_DIR}

--- a/build-utils-common-functions.sh
+++ b/build-utils-common-functions.sh
@@ -1,5 +1,9 @@
 # Common functions used by build-docker-image.sh and publish-neo4j-admin-image.sh
 
+SUPPORTED_IMAGE_OS=("bullseye" "ubi9")
+EDITIONS=("community" "enterprise")
+DISTRIBUTION_SITE="https://dist.neo4j.org"
+
 function contains_element
 {
   local e match="$1"
@@ -40,7 +44,6 @@ function get_compatible_dockerfile_for_os_or_error
 
     case ${branch} in
         calver | 5 | 4.4 )
-            local SUPPORTED_IMAGE_OS=("bullseye" "ubi9")
             if contains_element "${requested_os}" "${SUPPORTED_IMAGE_OS[@]}"; then
                 echo  "Dockerfile-${requested_os}"
                 return 0
@@ -51,12 +54,11 @@ function get_compatible_dockerfile_for_os_or_error
             if contains_element "${requested_os}" "${SUPPORTED_IMAGE_OS[@]}"; then
                 echo  "Dockerfile"
                 return 0
-            else
-                echo >&2 "${requested_os} is not a supported operating system for ${branch}."
-                return 1
             fi
             ;;
     esac
+    echo >&2 "${requested_os} is not a supported operating system for ${branch}."
+    return 1
 }
 
 function tarball_name

--- a/publish-neo4j-admin-image.sh
+++ b/publish-neo4j-admin-image.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -eu -o pipefail
 
-EDITIONS=("community" "enterprise")
-
 ROOT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source "$ROOT_DIR/build-utils-common-functions.sh"
 BUILD_DIR=${ROOT_DIR}/build
@@ -14,12 +12,12 @@ function usage
 {
     echo >&2 "USAGE: $0 <version> <edition> <operating system> <repository>
     For example:
-        $0 4.4.10 community debian neo/neo4j-admin
-        $0 5.10.0 enterprise ubi9 neo/neo4j-admin
+        $0 4.4.10 community bullseye neo4j/neo4j-admin
+        $0 5.10.0 enterprise ubi9 neo4j/neo4j-admin
     Version and operating system can also be set in the environment.
     For example:
-        NEO4JVERSION=4.4.10 NEO4JEDITION=community IMAGE_OS=debian REPOSITORY=neo/neo4j-admin $0
-        NEO4JVERSION=5.10.0 NEO4JEDITION=enterprise IMAGE_OS=ubi9 REPOSITORY=neo/neo4j-admin $0
+        NEO4JVERSION=4.4.10 NEO4JEDITION=community IMAGE_OS=bullseye REPOSITORY=neo4j/neo4j-admin $0
+        NEO4JVERSION=5.10.0 NEO4JEDITION=enterprise IMAGE_OS=ubi9 REPOSITORY=neo4j/neo4j-admin $0
     "
     exit 1
 }
@@ -55,11 +53,16 @@ if [[ ! "${NEO4JVERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+.*$  ]]; then
     echo "\"${NEO4JVERSION}\" is not a valid version number."
     usage
 fi
+# verify base OS
+if ! contains_element "${IMAGE_OS}" "${SUPPORTED_IMAGE_OS[@]}"; then
+    echo >&2 "${IMAGE_OS} is not a supported base image."
+    usage
+fi
 # get source files
 BRANCH=$(get_branch_from_version ${NEO4JVERSION})
 DOCKERFILE_NAME=$(get_compatible_dockerfile_for_os_or_error "${BRANCH}" "${IMAGE_OS}")
 
-echo "Building local context for docker build"
+echo "Building local context for docker build ${NEO4JEDITION}-${NEO4JVERSION}-${IMAGE_OS}"
 ADMIN_LOCALCXT_DIR=${BUILD_DIR}/${IMAGE_OS}/neo4j-admin/${NEO4JEDITION}
 mkdir -p ${ADMIN_LOCALCXT_DIR}
 

--- a/publish-neo4j-admin-images.sh
+++ b/publish-neo4j-admin-images.sh
@@ -22,8 +22,8 @@ docker buildx imagetools create "${REPOSITORY}":5-community \
 echo "Publishing ${REPOSITORY}:${NEO4JVERSION}"
 "${ROOT_DIR}/publish-neo4j-admin-image.sh" "${NEO4JVERSION}" "enterprise" "ubi9" "${REPOSITORY}"
 "${ROOT_DIR}/publish-neo4j-admin-image.sh" "${NEO4JVERSION}" "community" "ubi9" "${REPOSITORY}"
-"${ROOT_DIR}/publish-neo4j-admin-image.sh" "${NEO4JVERSION}" "enterprise" "debian" "${REPOSITORY}"
-"${ROOT_DIR}/publish-neo4j-admin-image.sh" "${NEO4JVERSION}" "community" "debian" "${REPOSITORY}"
+"${ROOT_DIR}/publish-neo4j-admin-image.sh" "${NEO4JVERSION}" "enterprise" "bullseye" "${REPOSITORY}"
+"${ROOT_DIR}/publish-neo4j-admin-image.sh" "${NEO4JVERSION}" "community" "bullseye" "${REPOSITORY}"
 
 echo "Adding extra tags..."
 
@@ -31,32 +31,50 @@ MAJOR=$(get_major_from_version "${NEO4JVERSION}")
 
 if [[ "$MAJOR" == "5" ]]; then
     echo "Tagging ${MAJOR}..."
-    docker buildx imagetools create "${REPOSITORY}:${NEO4JVERSION}-community-debian" \
-    --tag "${REPOSITORY}:5-community" \
-    --tag "${REPOSITORY}:5"
+    docker buildx imagetools create "${REPOSITORY}:${NEO4JVERSION}-community-bullseye" \
+    --tag "${REPOSITORY}:${MAJOR}-community-bullseye" \
+    --tag "${REPOSITORY}:${MAJOR}-community-debian" \
+    --tag "${REPOSITORY}:${MAJOR}-community" \
+    --tag "${REPOSITORY}:${MAJOR}"
 
-    docker buildx imagetools create "${REPOSITORY}:${NEO4JVERSION}-enterprise-debian" \
-    --tag "${REPOSITORY}:5-enterprise"
+    docker buildx imagetools create "${REPOSITORY}:${NEO4JVERSION}-enterprise-bullseye" \
+    --tag "${REPOSITORY}:${MAJOR}-enterprise-bullseye" \
+    --tag "${REPOSITORY}:${MAJOR}-enterprise-debian" \
+    --tag "${REPOSITORY}:${MAJOR}-enterprise"
 
 elif [[ "$MAJOR" -gt 2024 ]]; then
     echo "Tagging calver ${MAJOR}..."
-    docker buildx imagetools create "${REPOSITORY}:${NEO4JVERSION}-community-debian" \
-    --tag "${REPOSITORY}:${MAJOR}" \
+    docker buildx imagetools create "${REPOSITORY}:${NEO4JVERSION}-community-bullseye" \
+    --tag "${REPOSITORY}:${MAJOR}-community-bullseye" \
+    --tag "${REPOSITORY}:${MAJOR}-community-debian" \
     --tag "${REPOSITORY}:${MAJOR}-community" \
+    --tag "${REPOSITORY}:${MAJOR}" \
+    --tag "${REPOSITORY}:community-bullseye" \
     --tag "${REPOSITORY}:community-debian" \
     --tag "${REPOSITORY}:community" \
+    --tag "${REPOSITORY}:bullseye" \
     --tag "${REPOSITORY}:debian" \
     --tag "${REPOSITORY}:latest"
 
     docker buildx imagetools create "${REPOSITORY}:${NEO4JVERSION}-community-ubi9" \
+    --tag "${REPOSITORY}:${MAJOR}-community-ubi9" \
+    --tag "${REPOSITORY}:${MAJOR}-community-redhat" \
     --tag "${REPOSITORY}:community-ubi9" \
+    --tag "${REPOSITORY}:community-redhat" \
     --tag "${REPOSITORY}:ubi9" \
+    --tag "${REPOSITORY}:redhat"
 
-    docker buildx imagetools create "${REPOSITORY}:${NEO4JVERSION}-enterprise-debian" \
+    docker buildx imagetools create "${REPOSITORY}:${NEO4JVERSION}-enterprise-bullseye" \
+    --tag "${REPOSITORY}:${MAJOR}-enterprise-bullseye" \
+    --tag "${REPOSITORY}:${MAJOR}-enterprise-debian" \
     --tag "${REPOSITORY}:${MAJOR}-enterprise" \
+    --tag "${REPOSITORY}:enterprise-bullseye" \
     --tag "${REPOSITORY}:enterprise-debian" \
     --tag "${REPOSITORY}:enterprise"
 
     docker buildx imagetools create "${REPOSITORY}:${NEO4JVERSION}-enterprise-ubi9" \
-    --tag "${REPOSITORY}:enterprise-ubi9"
+    --tag "${REPOSITORY}:${MAJOR}-enterprise-ubi9" \
+    --tag "${REPOSITORY}:${MAJOR}-enterprise-redhat" \
+    --tag "${REPOSITORY}:enterprise-ubi9" \
+    --tag "${REPOSITORY}:enterprise-redhat"
 fi


### PR DESCRIPTION
When updating image build scripts to take the base OS as "bullseye" instead of "debian", I accidentally missed the publish neo4j-admin scripts. PR: https://github.com/neo4j/docker-neo4j/pull/562

I have updated the publish scripts to use "bullseye" as the base image name, and to tag all admin images with additional `-debian` or `-redhat` tags.