### PR TITLE
Add ai.* namespace to genai plugin

### DIFF
--- a/docker-image-src/calver/coredb/neo4j-plugins.json
+++ b/docker-image-src/calver/coredb/neo4j-plugins.json
@@ -31,7 +31,7 @@
   "genai": {
     "location": "/var/lib/neo4j/products/neo4j-genai-plugin-*.jar",
     "properties": {
-      "dbms.security.procedures.unrestricted": "genai.*"
+      "dbms.security.procedures.unrestricted": "genai.*,ai.*"
     }
   },
   "fleet-management": {


### PR DESCRIPTION
Last year we added new procedures and functions to the genai plugin in the ai.* namespace. These are only available in calver (Cypher 25).