### PR TITLE
ROPS-93 add deprecation warnings to bullseye and ubi9 based images

### DIFF
--- a/build-scripts/build-utils-common-functions.sh
+++ b/build-scripts/build-utils-common-functions.sh
@@ -95,7 +95,7 @@ fi
 case "$(get_branch_from_version ${NEO4JVERSION})" in
   calver )
     SUPPORTED_IMAGE_OS=("bullseye" "trixie" "ubi9" "ubi10")
-    DEPRECATED_IMAGE_OS=("ubi8")
+    DEPRECATED_IMAGE_OS=("bullseye" "ubi8" "ubi9")
     ;;
   5 )
     SUPPORTED_IMAGE_OS=("bullseye" "trixie" "ubi9" "ubi10")

--- a/src/test/java/com/neo4j/docker/utils/BaseOS.java
+++ b/src/test/java/com/neo4j/docker/utils/BaseOS.java
@@ -6,10 +6,10 @@ import org.junit.jupiter.api.Assertions;
 public enum BaseOS {
     // debian
     TRIXIE("trixie", null, null),
-    BULLSEYE("bullseye", null, new Neo4jVersion(5, 26, 21)),
+    BULLSEYE("bullseye", new Neo4jVersion(2026, 3, 0), new Neo4jVersion(5, 26, 21)),
     // redhat
     UBI10("ubi10", null, null),
-    UBI9("ubi9", null, new Neo4jVersion(5, 26, 21)),
+    UBI9("ubi9", new Neo4jVersion(2026, 3, 0), new Neo4jVersion(5, 26, 21)),
     UBI8("ubi8", new Neo4jVersion(2024, 1, 0), new Neo4jVersion(5, 20, 0)),
     ;
 

--- a/src/test/java/com/neo4j/docker/utils/BaseOSTest.java
+++ b/src/test/java/com/neo4j/docker/utils/BaseOSTest.java
@@ -18,7 +18,7 @@ class BaseOSTest {
 
     @ParameterizedTest(name = "{0}, {1}.{2}.{3}")
     @CsvSource({"ubi8,5,19,0", "ubi9,5,26,20", "bullseye,5,26,20",
-                "ubi8,2023,12,0" //, "ubi9,2026,2,0", "bullseye,2026,2,0"
+                "ubi8,2023,12,0", "ubi9,2026,2,0", "bullseye,2026,2,0"
     })
     void testHasDeprecationWarning_before(String name, int major, int minor, int patch) {
         BaseOS os = BaseOS.fromString(name);
@@ -31,7 +31,7 @@ class BaseOSTest {
 
     @ParameterizedTest(name = "{0}, {1}.{2}.{3}")
     @CsvSource({"ubi8,5,20,0", "ubi9,5,26,21", "bullseye,5,26,21",
-                "ubi8,2024,1,0"//, "ubi9,2026,3,0","bullseye,2026,3,0"
+                "ubi8,2024,1,0", "ubi9,2026,3,0","bullseye,2026,3,0"
     })
     void testHasDeprecationWarning_equal(String name, int major, int minor, int patch) {
         BaseOS os = BaseOS.fromString(name);
@@ -44,7 +44,7 @@ class BaseOSTest {
 
     @ParameterizedTest(name = "{0}, {1}.{2}.{3}")
     @CsvSource({"ubi8,5,26,0", "ubi9,5,26,50", "bullseye,5,26,50",
-            "ubi8,2027,1,0"//, "ubi9,2026,4,0", "bullseye,2026,4,0"
+            "ubi8,2027,1,0", "ubi9,2026,4,0", "bullseye,2026,4,0"
     })
     void testHasDeprecationWarning_after(String name, int major, int minor, int patch) {
         BaseOS os = BaseOS.fromString(name);


### PR DESCRIPTION
changelog: New docker images based on Debian Trixie and RedHat UBI10 are now available in dockerhub and will be the default.