### PR TITLE
Add spotless code format checking

### DIFF
--- a/.github/workflows/spotless.yml
+++ b/.github/workflows/spotless.yml
@@ -1,0 +1,18 @@
+name: Spotless
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  spotless:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+      - name: Spotless check
+        run: mvn spotless:check || echo >&2 "enable pre-commit checks by running \"pre-commit install\""

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: spotless-check
+        name: maven spotless check
+        entry: mvn --batch-mode --no-transfer-progress spotless:apply
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,10 @@
 		<java.version>17</java.version>
 		<junit.version>5.11.0</junit.version>
 		<neo4j.driver.version>5.26.0</neo4j.driver.version>
+		<spotless.version>3.4.0</spotless.version>
 		<surefire.version>3.1.2</surefire.version>
 		<testcontainers.version>1.20.1</testcontainers.version>
+		<slf4j.version>2.0.17</slf4j.version>
 	</properties>
 
 	<profiles>
@@ -63,6 +65,26 @@
 					<excludedGroups>${profile.exclude}</excludedGroups>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>com.diffplug.spotless</groupId>
+				<artifactId>spotless-maven-plugin</artifactId>
+				<version>${spotless.version}</version>
+				<configuration>
+					<java>
+						<removeUnusedImports/>
+						<forbidWildcardImports/>
+						<palantirJavaFormat/>
+					</java>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>check</goal>
+						</goals>
+						<phase>verify</phase>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 
@@ -71,12 +93,12 @@
 			<!-- logging library -->
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.32</version>
+			<version>${slf4j.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.7.32</version>
+			<artifactId>slf4j-reload4j</artifactId>
+			<version>${slf4j.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/src/test/java/com/neo4j/docker/TestDeprecationWarning.java
+++ b/src/test/java/com/neo4j/docker/TestDeprecationWarning.java
@@ -3,6 +3,8 @@ package com.neo4j.docker;
 import com.neo4j.docker.utils.Neo4jVersion;
 import com.neo4j.docker.utils.TestSettings;
 import com.neo4j.docker.utils.WaitStrategies;
+import java.time.Duration;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
@@ -14,9 +16,6 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 
-import java.time.Duration;
-import java.util.regex.Pattern;
-
 /**Tests to make sure that deprecated base OS images give suitable warnings.
  * The opposite test to make sure there are no deprecation warnings in un-deprecated images
  * already exists at {@code TestBasic.testNoUnexpectedErrors()}
@@ -27,128 +26,155 @@ import java.util.regex.Pattern;
  * - Any image created after the final deprecated version using the deprecated OS should be a failure.
  * */
 public class TestDeprecationWarning {
-    private final Logger log = LoggerFactory.getLogger( TestDeprecationWarning.class );
+    private final Logger log = LoggerFactory.getLogger(TestDeprecationWarning.class);
 
     private static final String DEPRECATION_WARN_SUPPRESS_FLAG = "NEO4J_DEPRECATION_WARNING";
-    private final Pattern earlyWarningRegex = Pattern.compile( "Neo4j (Red Hat|Debian) %s images are deprecated in favour of "
-                                                                       .formatted( TestSettings.BASE_OS.toString().toUpperCase()) );
-    private final Pattern finalWarningRegex = Pattern.compile( "This is the last Neo4j image available on (Red Hat|Debian) %s"
-                                                                       .formatted( TestSettings.BASE_OS.toString().toUpperCase() ));
+    private final Pattern earlyWarningRegex =
+            Pattern.compile("Neo4j (Red Hat|Debian) %s images are deprecated in favour of "
+                    .formatted(TestSettings.BASE_OS.toString().toUpperCase()));
+    private final Pattern finalWarningRegex =
+            Pattern.compile("This is the last Neo4j image available on (Red Hat|Debian) %s"
+                    .formatted(TestSettings.BASE_OS.toString().toUpperCase()));
     private Neo4jVersion deprecatedIn;
 
     @BeforeAll
     static void assume5xOrLater() {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( Neo4jVersion.NEO4J_VERSION_500 ) );
-        Assumptions.assumeTrue( TestSettings.BASE_OS.isDeprecatedOs(),
-                                "Tests only valid for deprecated base images");
+        Assumptions.assumeTrue(TestSettings.NEO4J_VERSION.isAtLeastVersion(Neo4jVersion.NEO4J_VERSION_500));
+        Assumptions.assumeTrue(TestSettings.BASE_OS.isDeprecatedOs(), "Tests only valid for deprecated base images");
     }
 
     @BeforeEach
     void findDeprecatedInVersion() {
         if (TestSettings.NEO4J_VERSION.isCalver()) {
             deprecatedIn = TestSettings.BASE_OS.lastAppearsInCalver;
-        }
-        else {
+        } else {
             deprecatedIn = TestSettings.BASE_OS.lastAppearsIn5x;
         }
     }
 
     @Test
     void testEarlyDeprecationWarning_coreDB() {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isOlderThan( deprecatedIn ),
-                                "%s does not have early deprecation warning".formatted( TestSettings.NEO4J_VERSION ) );
-        String logs = runCoreDBGetErrorLogs( false );
-        Assertions.assertTrue( earlyWarningRegex.matcher( logs ).find(),
-                               "Container did not warn about "+TestSettings.BASE_OS+" deprecation. " +
-                               "Actual error logs:\n"+logs);
-        Assertions.assertTrue( logs.contains( deprecatedIn.toString() ),
-                               "Error did not mention which version OS is deprecated in" );
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isOlderThan(deprecatedIn),
+                "%s does not have early deprecation warning".formatted(TestSettings.NEO4J_VERSION));
+        String logs = runCoreDBGetErrorLogs(false);
+        Assertions.assertTrue(
+                earlyWarningRegex.matcher(logs).find(),
+                "Container did not warn about " + TestSettings.BASE_OS + " deprecation. " + "Actual error logs:\n"
+                        + logs);
+        Assertions.assertTrue(
+                logs.contains(deprecatedIn.toString()), "Error did not mention which version OS is deprecated in");
     }
+
     @Test
     void testEarlyDeprecationWarning_neo4jAdmin() {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isOlderThan( deprecatedIn ),
-                                "%s does not have early deprecation warning".formatted( TestSettings.NEO4J_VERSION ) );
-        String logs = runNeo4jAdminGetErrorLogs( false );
-        Assertions.assertTrue( earlyWarningRegex.matcher( logs ).find(),
-                               "Container did not warn about "+TestSettings.BASE_OS+" deprecation. " +
-                               "Actual error logs:\n"+logs);
-        Assertions.assertTrue( logs.contains( deprecatedIn.toString() ),
-                               "Error did not mention which version OS is deprecated in" );
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isOlderThan(deprecatedIn),
+                "%s does not have early deprecation warning".formatted(TestSettings.NEO4J_VERSION));
+        String logs = runNeo4jAdminGetErrorLogs(false);
+        Assertions.assertTrue(
+                earlyWarningRegex.matcher(logs).find(),
+                "Container did not warn about " + TestSettings.BASE_OS + " deprecation. " + "Actual error logs:\n"
+                        + logs);
+        Assertions.assertTrue(
+                logs.contains(deprecatedIn.toString()), "Error did not mention which version OS is deprecated in");
     }
+
     @Test
     void testEarlyDeprecationWarningSuppressed_coreDB() {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isOlderThan( deprecatedIn ),
-                                "%s does not have early deprecation warning".formatted( TestSettings.NEO4J_VERSION ) );
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isOlderThan(deprecatedIn),
+                "%s does not have early deprecation warning".formatted(TestSettings.NEO4J_VERSION));
         String logs = runCoreDBGetErrorLogs(true);
-        Assertions.assertFalse( earlyWarningRegex.matcher( logs ).find(),
-                                "Container incorrectly warned about "+TestSettings.BASE_OS+" deprecation. " +
-                                "Actual error logs:\n"+logs);
+        Assertions.assertFalse(
+                earlyWarningRegex.matcher(logs).find(),
+                "Container incorrectly warned about " + TestSettings.BASE_OS + " deprecation. " + "Actual error logs:\n"
+                        + logs);
     }
+
     @Test
     void testEarlyDeprecationWarningSuppressed_neo4jAdmin() {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isOlderThan( deprecatedIn ),
-                                "%s does not have early deprecation warning".formatted( TestSettings.NEO4J_VERSION ) );
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isOlderThan(deprecatedIn),
+                "%s does not have early deprecation warning".formatted(TestSettings.NEO4J_VERSION));
         String logs = runNeo4jAdminGetErrorLogs(true);
-        Assertions.assertFalse( earlyWarningRegex.matcher( logs ).find(),
-                                "Container incorrectly warned about "+TestSettings.BASE_OS+" deprecation. " +
-                                "Actual error logs:\n"+logs);
+        Assertions.assertFalse(
+                earlyWarningRegex.matcher(logs).find(),
+                "Container incorrectly warned about " + TestSettings.BASE_OS + " deprecation. " + "Actual error logs:\n"
+                        + logs);
     }
 
     @Test
     void testFinalWarning_coreDB() {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.equals( deprecatedIn ),
-                                "%s does not need final deprecation warning".formatted( TestSettings.NEO4J_VERSION ) );
-        String logs = runCoreDBGetErrorLogs( false );
-        Assertions.assertTrue( earlyWarningRegex.matcher( logs ).find(),
-                               "Container did not warn about "+TestSettings.BASE_OS+" deprecation. " +
-                               "Actual error logs:\n"+logs);
-        Assertions.assertTrue( finalWarningRegex.matcher( logs ).find(),
-                               "Container did not warn about "+TestSettings.BASE_OS+" deprecation. " +
-                               "Actual error logs:\n"+logs);
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.equals(deprecatedIn),
+                "%s does not need final deprecation warning".formatted(TestSettings.NEO4J_VERSION));
+        String logs = runCoreDBGetErrorLogs(false);
+        Assertions.assertTrue(
+                earlyWarningRegex.matcher(logs).find(),
+                "Container did not warn about " + TestSettings.BASE_OS + " deprecation. " + "Actual error logs:\n"
+                        + logs);
+        Assertions.assertTrue(
+                finalWarningRegex.matcher(logs).find(),
+                "Container did not warn about " + TestSettings.BASE_OS + " deprecation. " + "Actual error logs:\n"
+                        + logs);
     }
+
     @Test
     void testFinalWarning_neo4jAdmin() {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.equals( deprecatedIn ),
-                                "%s does not need final deprecation warning".formatted( TestSettings.NEO4J_VERSION ) );
-        String logs = runNeo4jAdminGetErrorLogs( false );
-        Assertions.assertTrue( earlyWarningRegex.matcher( logs ).find(),
-                               "Container did not warn about "+TestSettings.BASE_OS+" deprecation. " +
-                               "Actual error logs:\n"+logs);
-        Assertions.assertTrue( finalWarningRegex.matcher( logs ).find(),
-                               "Container did not warn about "+TestSettings.BASE_OS+" deprecation. " +
-                               "Actual error logs:\n"+logs);
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.equals(deprecatedIn),
+                "%s does not need final deprecation warning".formatted(TestSettings.NEO4J_VERSION));
+        String logs = runNeo4jAdminGetErrorLogs(false);
+        Assertions.assertTrue(
+                earlyWarningRegex.matcher(logs).find(),
+                "Container did not warn about " + TestSettings.BASE_OS + " deprecation. " + "Actual error logs:\n"
+                        + logs);
+        Assertions.assertTrue(
+                finalWarningRegex.matcher(logs).find(),
+                "Container did not warn about " + TestSettings.BASE_OS + " deprecation. " + "Actual error logs:\n"
+                        + logs);
     }
+
     @Test
     void testFinalWarningSuppressionIgnored_coreDB() {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.equals( deprecatedIn ),
-                                "%s does not need final deprecation warning".formatted( TestSettings.NEO4J_VERSION ) );
-        String logs = runCoreDBGetErrorLogs( true );
-        Assertions.assertTrue( earlyWarningRegex.matcher( logs ).find(),
-                               "Container did not warn about "+TestSettings.BASE_OS+" deprecation. " +
-                               "Actual error logs:\n"+logs);
-        Assertions.assertTrue( finalWarningRegex.matcher( logs ).find(),
-                               "Container did not warn about "+TestSettings.BASE_OS+" deprecation. " +
-                               "Actual error logs:\n"+logs);
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.equals(deprecatedIn),
+                "%s does not need final deprecation warning".formatted(TestSettings.NEO4J_VERSION));
+        String logs = runCoreDBGetErrorLogs(true);
+        Assertions.assertTrue(
+                earlyWarningRegex.matcher(logs).find(),
+                "Container did not warn about " + TestSettings.BASE_OS + " deprecation. " + "Actual error logs:\n"
+                        + logs);
+        Assertions.assertTrue(
+                finalWarningRegex.matcher(logs).find(),
+                "Container did not warn about " + TestSettings.BASE_OS + " deprecation. " + "Actual error logs:\n"
+                        + logs);
     }
+
     @Test
     void testFinalWarningSuppressionIgnored_neo4jAdmin() {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.equals( deprecatedIn ),
-                                "%s does not need final deprecation warning".formatted( TestSettings.NEO4J_VERSION ) );
-        String logs = runNeo4jAdminGetErrorLogs( true );
-        Assertions.assertTrue( earlyWarningRegex.matcher( logs ).find(),
-                               "Container did not warn about "+TestSettings.BASE_OS+" deprecation. " +
-                               "Actual error logs:\n"+logs);
-        Assertions.assertTrue( finalWarningRegex.matcher( logs ).find(),
-                               "Container did not warn about "+TestSettings.BASE_OS+" deprecation. " +
-                               "Actual error logs:\n"+logs);
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.equals(deprecatedIn),
+                "%s does not need final deprecation warning".formatted(TestSettings.NEO4J_VERSION));
+        String logs = runNeo4jAdminGetErrorLogs(true);
+        Assertions.assertTrue(
+                earlyWarningRegex.matcher(logs).find(),
+                "Container did not warn about " + TestSettings.BASE_OS + " deprecation. " + "Actual error logs:\n"
+                        + logs);
+        Assertions.assertTrue(
+                finalWarningRegex.matcher(logs).find(),
+                "Container did not warn about " + TestSettings.BASE_OS + " deprecation. " + "Actual error logs:\n"
+                        + logs);
     }
 
     @Test
     void shouldNotCreateImageAfterDeprecation() {
         // To get here we must be testing an image flagged for deprecation.
         // This test makes sure we don't make a deprecated image newer than we expect.
-        Assertions.assertFalse( TestSettings.NEO4J_VERSION.isNewerThan( deprecatedIn ),
-                                "Should not be releasing %s newer than %s".formatted( TestSettings.BASE_OS, deprecatedIn ) );
+        Assertions.assertFalse(
+                TestSettings.NEO4J_VERSION.isNewerThan(deprecatedIn),
+                "Should not be releasing %s newer than %s".formatted(TestSettings.BASE_OS, deprecatedIn));
     }
 
     String runCoreDBGetErrorLogs(boolean suppressWarning) {
@@ -184,21 +210,22 @@ public class TestDeprecationWarning {
 
     // this is a requirement for docker official images, so doesn't need testing for neo4j-admin
     @Test
-    void shouldOnlyWarnWhenRunningNeo4jCommands() throws Exception
-    {
-        try(GenericContainer<?> container = new GenericContainer<>(TestSettings.IMAGE_ID))
-        {
-            container.withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
-                     .withExposedPorts( 7474, 7687 )
-                     .withLogConsumer( new Slf4jLogConsumer( log ))
-                     .withCommand( "cat", "/etc/os-release" );
-            WaitStrategies.waitUntilContainerFinished( container, Duration.ofSeconds( 30 ) );
+    void shouldOnlyWarnWhenRunningNeo4jCommands() throws Exception {
+        try (GenericContainer<?> container = new GenericContainer<>(TestSettings.IMAGE_ID)) {
+            container
+                    .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+                    .withExposedPorts(7474, 7687)
+                    .withLogConsumer(new Slf4jLogConsumer(log))
+                    .withCommand("cat", "/etc/os-release");
+            WaitStrategies.waitUntilContainerFinished(container, Duration.ofSeconds(30));
             container.start();
-            String logs = container.getLogs( OutputFrame.OutputType.STDERR );
-            Assertions.assertFalse(earlyWarningRegex.matcher( logs ).find(),
-                                   "Container should not have warned about deprecation. Actual error logs:\n"+logs);
-            Assertions.assertFalse(finalWarningRegex.matcher( logs ).find(),
-                                   "Container should not have warned about deprecation. Actual error logs:\n"+logs);
+            String logs = container.getLogs(OutputFrame.OutputType.STDERR);
+            Assertions.assertFalse(
+                    earlyWarningRegex.matcher(logs).find(),
+                    "Container should not have warned about deprecation. Actual error logs:\n" + logs);
+            Assertions.assertFalse(
+                    finalWarningRegex.matcher(logs).find(),
+                    "Container should not have warned about deprecation. Actual error logs:\n" + logs);
         }
     }
 }

--- a/src/test/java/com/neo4j/docker/TestDockerComposeSecrets.java
+++ b/src/test/java/com/neo4j/docker/TestDockerComposeSecrets.java
@@ -1,11 +1,19 @@
 package com.neo4j.docker;
 
+import static com.neo4j.docker.utils.WaitStrategies.waitForBoltReady;
+
 import com.github.dockerjava.api.DockerClient;
 import com.neo4j.docker.coredb.configurations.Configuration;
 import com.neo4j.docker.coredb.configurations.Setting;
 import com.neo4j.docker.utils.DatabaseIO;
 import com.neo4j.docker.utils.TemporaryFolderManager;
 import com.neo4j.docker.utils.TestSettings;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermissions;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
@@ -18,43 +26,33 @@ import org.testcontainers.containers.ComposeContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.output.ToStringConsumer;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.attribute.PosixFilePermissions;
-
-import static com.neo4j.docker.utils.WaitStrategies.waitForBoltReady;
-
-public class TestDockerComposeSecrets
-{
-    private final Logger log = LoggerFactory.getLogger( TestDockerComposeSecrets.class );
+public class TestDockerComposeSecrets {
+    private final Logger log = LoggerFactory.getLogger(TestDockerComposeSecrets.class);
 
     private static final int DEFAULT_BOLT_PORT = 7687;
     private static final int DEFAULT_HTTP_PORT = 7474;
-    private static final Path TEST_RESOURCES_PATH = Paths.get( "src", "test", "resources", "dockersecrets" );
+    private static final Path TEST_RESOURCES_PATH = Paths.get("src", "test", "resources", "dockersecrets");
 
     @RegisterExtension
     public static TemporaryFolderManager temporaryFolderManager = new TemporaryFolderManager();
 
     @BeforeAll
-    public static void skipTestsForARM()
-    {
-        Assumptions.assumeFalse( System.getProperty( "os.arch" ).equals( "aarch64" ),
-                                 "This test is ignored on ARM architecture, because Docker Compose Container doesn't support it." );
+    public static void skipTestsForARM() {
+        Assumptions.assumeFalse(
+                System.getProperty("os.arch").equals("aarch64"),
+                "This test is ignored on ARM architecture, because Docker Compose Container doesn't support it.");
     }
 
-    private ComposeContainer createContainer( File composeFile, Path containerRootDir, String serviceName )
-    {
-        var container = new ComposeContainer( composeFile );
+    private ComposeContainer createContainer(File composeFile, Path containerRootDir, String serviceName) {
+        var container = new ComposeContainer(composeFile);
 
-        container.withExposedService( serviceName, DEFAULT_BOLT_PORT )
-                 .withExposedService( serviceName, DEFAULT_HTTP_PORT )
-                 .withEnv( "NEO4J_IMAGE", TestSettings.IMAGE_ID.asCanonicalNameString() )
-                 .withEnv( "HOST_ROOT", containerRootDir.toAbsolutePath().toString() )
-                 .waitingFor( serviceName, waitForBoltReady() )
-                 .withLogConsumer( serviceName, new Slf4jLogConsumer( log ) );
+        container
+                .withExposedService(serviceName, DEFAULT_BOLT_PORT)
+                .withExposedService(serviceName, DEFAULT_HTTP_PORT)
+                .withEnv("NEO4J_IMAGE", TestSettings.IMAGE_ID.asCanonicalNameString())
+                .withEnv("HOST_ROOT", containerRootDir.toAbsolutePath().toString())
+                .waitingFor(serviceName, waitForBoltReady())
+                .withLogConsumer(serviceName, new Slf4jLogConsumer(log));
 
         return container;
     }
@@ -62,150 +60,162 @@ public class TestDockerComposeSecrets
     /* We need to stop the neo4j service before we stop the docker compose container otherwise there is a race condition for
        files that are written in mounted folders. This should not be needed when https://github.com/testcontainers/testcontainers-java/issues/9870 is fixed
     */
-    private void stopContainerSafely( ComposeContainer container, String serviceName ) throws IOException
-    {
-        var containerId = container.getContainerByServiceName( serviceName ).get().getContainerId();
+    private void stopContainerSafely(ComposeContainer container, String serviceName) throws IOException {
+        var containerId = container.getContainerByServiceName(serviceName).get().getContainerId();
 
         DockerClient dockerClient = DockerClientFactory.lazyClient();
-        dockerClient.stopContainerCmd( containerId ).exec();
+        dockerClient.stopContainerCmd(containerId).exec();
 
         container.stop();
     }
 
     @Test
-    void shouldCreateContainerAndConnect() throws Exception
-    {
-        var tmpDir = temporaryFolderManager.createFolder( "Simple_Container_Compose" );
-        var composeFile = copyDockerComposeResourceFile( tmpDir, TEST_RESOURCES_PATH.resolve( "simple-container-compose.yml" ).toFile() );
+    void shouldCreateContainerAndConnect() throws Exception {
+        var tmpDir = temporaryFolderManager.createFolder("Simple_Container_Compose");
+        var composeFile = copyDockerComposeResourceFile(
+                tmpDir,
+                TEST_RESOURCES_PATH.resolve("simple-container-compose.yml").toFile());
         var serviceName = "simplecontainer";
 
-        try ( var dockerComposeContainer = createContainer( composeFile, tmpDir, serviceName ) )
-        {
+        try (var dockerComposeContainer = createContainer(composeFile, tmpDir, serviceName)) {
             dockerComposeContainer.start();
 
-            var dbio = new DatabaseIO( dockerComposeContainer.getServiceHost( serviceName, DEFAULT_BOLT_PORT ),
-                                       dockerComposeContainer.getServicePort( serviceName, DEFAULT_BOLT_PORT ) );
-            dbio.verifyConnectivity( "neo4j", "simplecontainerpassword" );
-            stopContainerSafely( dockerComposeContainer, serviceName );
+            var dbio = new DatabaseIO(
+                    dockerComposeContainer.getServiceHost(serviceName, DEFAULT_BOLT_PORT),
+                    dockerComposeContainer.getServicePort(serviceName, DEFAULT_BOLT_PORT));
+            dbio.verifyConnectivity("neo4j", "simplecontainerpassword");
+            stopContainerSafely(dockerComposeContainer, serviceName);
         }
     }
 
     @Test
-    void shouldCreateContainerWithSecretPasswordAndConnect() throws Exception
-    {
-        var tmpDir = temporaryFolderManager.createFolder( "Container_Compose_With_Secrets" );
-        var composeFile = copyDockerComposeResourceFile( tmpDir, TEST_RESOURCES_PATH.resolve( "container-compose-with-secrets.yml" ).toFile() );
+    void shouldCreateContainerWithSecretPasswordAndConnect() throws Exception {
+        var tmpDir = temporaryFolderManager.createFolder("Container_Compose_With_Secrets");
+        var composeFile = copyDockerComposeResourceFile(
+                tmpDir,
+                TEST_RESOURCES_PATH
+                        .resolve("container-compose-with-secrets.yml")
+                        .toFile());
         var serviceName = "secretscontainer";
 
         var newSecretPassword = "neo4j/newSecretPassword";
-        Files.createFile( tmpDir.resolve( "neo4j_auth.txt" ) );
-        Files.writeString( tmpDir.resolve( "neo4j_auth.txt" ), newSecretPassword );
+        Files.createFile(tmpDir.resolve("neo4j_auth.txt"));
+        Files.writeString(tmpDir.resolve("neo4j_auth.txt"), newSecretPassword);
 
-        try ( var dockerComposeContainer = createContainer( composeFile, tmpDir, serviceName ) )
-        {
+        try (var dockerComposeContainer = createContainer(composeFile, tmpDir, serviceName)) {
             dockerComposeContainer.start();
-            var dbio = new DatabaseIO( dockerComposeContainer.getServiceHost( serviceName, DEFAULT_BOLT_PORT ),
-                                       dockerComposeContainer.getServicePort( serviceName, DEFAULT_BOLT_PORT ) );
-            dbio.verifyConnectivity( "neo4j", "newSecretPassword" );
-            stopContainerSafely( dockerComposeContainer, serviceName );
+            var dbio = new DatabaseIO(
+                    dockerComposeContainer.getServiceHost(serviceName, DEFAULT_BOLT_PORT),
+                    dockerComposeContainer.getServicePort(serviceName, DEFAULT_BOLT_PORT));
+            dbio.verifyConnectivity("neo4j", "newSecretPassword");
+            stopContainerSafely(dockerComposeContainer, serviceName);
         }
     }
 
     @Test
-    void shouldOverrideVariableWithSecretValue() throws Exception
-    {
-        var tmpDir = temporaryFolderManager.createFolder( "Container_Compose_With_Secrets_Override" );
-        Files.createDirectories( tmpDir.resolve( "neo4j" ).resolve( "config" ) );
+    void shouldOverrideVariableWithSecretValue() throws Exception {
+        var tmpDir = temporaryFolderManager.createFolder("Container_Compose_With_Secrets_Override");
+        Files.createDirectories(tmpDir.resolve("neo4j").resolve("config"));
 
-        var composeFile = copyDockerComposeResourceFile( tmpDir, TEST_RESOURCES_PATH.resolve( "container-compose-with-secrets-override.yml" ).toFile() );
+        var composeFile = copyDockerComposeResourceFile(
+                tmpDir,
+                TEST_RESOURCES_PATH
+                        .resolve("container-compose-with-secrets-override.yml")
+                        .toFile());
         var serviceName = "secretsoverridecontainer";
 
         var newSecretPageCache = "50M";
-        Files.createFile( tmpDir.resolve( "neo4j_pagecache.txt" ) );
-        Files.writeString( tmpDir.resolve( "neo4j_pagecache.txt" ), newSecretPageCache );
+        Files.createFile(tmpDir.resolve("neo4j_pagecache.txt"));
+        Files.writeString(tmpDir.resolve("neo4j_pagecache.txt"), newSecretPageCache);
 
-        try ( var dockerComposeContainer = createContainer( composeFile, tmpDir, serviceName ) )
-        {
+        try (var dockerComposeContainer = createContainer(composeFile, tmpDir, serviceName)) {
             dockerComposeContainer.start();
 
-            var dbio = new DatabaseIO( dockerComposeContainer.getServiceHost( serviceName, DEFAULT_BOLT_PORT ),
-                                       dockerComposeContainer.getServicePort( serviceName, DEFAULT_BOLT_PORT ) );
+            var dbio = new DatabaseIO(
+                    dockerComposeContainer.getServiceHost(serviceName, DEFAULT_BOLT_PORT),
+                    dockerComposeContainer.getServicePort(serviceName, DEFAULT_BOLT_PORT));
 
-            var secretSetting = dbio.getConfigurationSettingAsString( "neo4j",
-                                                                      "secretsoverridecontainerpassword",
-                                                                      Configuration.getConfigurationNameMap().get( Setting.MEMORY_PAGECACHE_SIZE ) );
+            var secretSetting = dbio.getConfigurationSettingAsString(
+                    "neo4j",
+                    "secretsoverridecontainerpassword",
+                    Configuration.getConfigurationNameMap().get(Setting.MEMORY_PAGECACHE_SIZE));
 
-            Assertions.assertTrue( secretSetting.contains( "50" ) );
+            Assertions.assertTrue(secretSetting.contains("50"));
 
-            stopContainerSafely( dockerComposeContainer, serviceName );
+            stopContainerSafely(dockerComposeContainer, serviceName);
         }
     }
 
     @Test
-    void shouldFailIfSecretFileDoesNotExist() throws Exception
-    {
-        var tmpDir = temporaryFolderManager.createFolder( "Container_Compose_With_Secrets_Override" );
-        var composeFile = copyDockerComposeResourceFile( tmpDir, TEST_RESOURCES_PATH.resolve( "container-compose-with-secrets-override.yml" ).toFile() );
+    void shouldFailIfSecretFileDoesNotExist() throws Exception {
+        var tmpDir = temporaryFolderManager.createFolder("Container_Compose_With_Secrets_Override");
+        var composeFile = copyDockerComposeResourceFile(
+                tmpDir,
+                TEST_RESOURCES_PATH
+                        .resolve("container-compose-with-secrets-override.yml")
+                        .toFile());
         var serviceName = "secretsoverridecontainer";
 
-        try ( var dockerComposeContainer = createContainer( composeFile, tmpDir, serviceName ) )
-        {
-            Assertions.assertThrows( Exception.class, dockerComposeContainer::start );
+        try (var dockerComposeContainer = createContainer(composeFile, tmpDir, serviceName)) {
+            Assertions.assertThrows(Exception.class, dockerComposeContainer::start);
         }
     }
 
     @Test
-    void shouldFailAndPrintMessageIfFileIsNotReadable() throws Exception
-    {
-        var tmpDir = temporaryFolderManager.createFolder( "Container_Compose_With_Secrets_Override" );
-        var composeFile = copyDockerComposeResourceFile( tmpDir, TEST_RESOURCES_PATH.resolve( "container-compose-with-secrets-override.yml" ).toFile() );
+    void shouldFailAndPrintMessageIfFileIsNotReadable() throws Exception {
+        var tmpDir = temporaryFolderManager.createFolder("Container_Compose_With_Secrets_Override");
+        var composeFile = copyDockerComposeResourceFile(
+                tmpDir,
+                TEST_RESOURCES_PATH
+                        .resolve("container-compose-with-secrets-override.yml")
+                        .toFile());
         var serviceName = "secretsoverridecontainer";
 
-        Files.createFile( tmpDir.resolve( "neo4j_pagecache.txt" ) );
-        Files.writeString( tmpDir.resolve( "neo4j_pagecache.txt" ), "50M" );
+        Files.createFile(tmpDir.resolve("neo4j_pagecache.txt"));
+        Files.writeString(tmpDir.resolve("neo4j_pagecache.txt"), "50M");
 
-        var newPermissions = PosixFilePermissions.fromString( "rw-------" );
-        Files.setPosixFilePermissions( tmpDir.resolve( "neo4j_pagecache.txt" ), newPermissions );
+        var newPermissions = PosixFilePermissions.fromString("rw-------");
+        Files.setPosixFilePermissions(tmpDir.resolve("neo4j_pagecache.txt"), newPermissions);
 
-        try ( var dockerComposeContainer = createContainer( composeFile, tmpDir, serviceName ) )
-        {
+        try (var dockerComposeContainer = createContainer(composeFile, tmpDir, serviceName)) {
             var containerLogConsumer = new ToStringConsumer();
-            dockerComposeContainer.withLogConsumer( serviceName, containerLogConsumer );
-            var expectedLogLine = "The secret file '/run/secrets/neo4j_dbms_memory_pagecache_size_file' does not exist or is not readable. " +
-                                  "Make sure you have correctly configured docker secrets.";
-            Assertions.assertThrows( Exception.class, dockerComposeContainer::start );
-            Assertions.assertTrue( containerLogConsumer.toUtf8String().contains( expectedLogLine ) );
+            dockerComposeContainer.withLogConsumer(serviceName, containerLogConsumer);
+            var expectedLogLine =
+                    "The secret file '/run/secrets/neo4j_dbms_memory_pagecache_size_file' does not exist or is not readable. "
+                            + "Make sure you have correctly configured docker secrets.";
+            Assertions.assertThrows(Exception.class, dockerComposeContainer::start);
+            Assertions.assertTrue(containerLogConsumer.toUtf8String().contains(expectedLogLine));
         }
     }
 
     @Test
-    void shouldIgnoreNonNeo4jFileEnvVars() throws Exception
-    {
-        var tmpDir = temporaryFolderManager.createFolder( "Simple_Container_Compose_With_File_Var" );
-        var composeFile =
-                copyDockerComposeResourceFile( tmpDir, TEST_RESOURCES_PATH.resolve( "simple-container-compose-with-external-file-var.yml" ).toFile() );
+    void shouldIgnoreNonNeo4jFileEnvVars() throws Exception {
+        var tmpDir = temporaryFolderManager.createFolder("Simple_Container_Compose_With_File_Var");
+        var composeFile = copyDockerComposeResourceFile(
+                tmpDir,
+                TEST_RESOURCES_PATH
+                        .resolve("simple-container-compose-with-external-file-var.yml")
+                        .toFile());
         var serviceName = "simplecontainer";
 
-        try ( var dockerComposeContainer = createContainer( composeFile, tmpDir, serviceName ) )
-        {
+        try (var dockerComposeContainer = createContainer(composeFile, tmpDir, serviceName)) {
             dockerComposeContainer.start();
 
-            var dbio = new DatabaseIO( dockerComposeContainer.getServiceHost( serviceName, DEFAULT_BOLT_PORT ),
-                                       dockerComposeContainer.getServicePort( serviceName, DEFAULT_BOLT_PORT ) );
-            dbio.verifyConnectivity( "neo4j", "simplecontainerpassword" );
+            var dbio = new DatabaseIO(
+                    dockerComposeContainer.getServiceHost(serviceName, DEFAULT_BOLT_PORT),
+                    dockerComposeContainer.getServicePort(serviceName, DEFAULT_BOLT_PORT));
+            dbio.verifyConnectivity("neo4j", "simplecontainerpassword");
 
-            stopContainerSafely( dockerComposeContainer, serviceName );
+            stopContainerSafely(dockerComposeContainer, serviceName);
         }
     }
 
-    private File copyDockerComposeResourceFile( Path targetDirectory, File resourceFile ) throws IOException
-    {
-        File compose_file = new File( targetDirectory.toString(), resourceFile.getName() );
-        if ( compose_file.exists() )
-        {
-            Files.delete( compose_file.toPath() );
+    private File copyDockerComposeResourceFile(Path targetDirectory, File resourceFile) throws IOException {
+        File compose_file = new File(targetDirectory.toString(), resourceFile.getName());
+        if (compose_file.exists()) {
+            Files.delete(compose_file.toPath());
         }
-        Files.copy( resourceFile.toPath(), Paths.get( compose_file.getPath() ) );
+        Files.copy(resourceFile.toPath(), Paths.get(compose_file.getPath()));
         return compose_file;
     }
 }

--- a/src/test/java/com/neo4j/docker/coredb/TestAdminReport.java
+++ b/src/test/java/com/neo4j/docker/coredb/TestAdminReport.java
@@ -3,9 +3,14 @@ package com.neo4j.docker.coredb;
 import com.neo4j.docker.utils.DatabaseIO;
 import com.neo4j.docker.utils.Neo4jVersion;
 import com.neo4j.docker.utils.SetContainerUser;
-import com.neo4j.docker.utils.WaitStrategies;
 import com.neo4j.docker.utils.TemporaryFolderManager;
 import com.neo4j.docker.utils.TestSettings;
+import com.neo4j.docker.utils.WaitStrategies;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -20,182 +25,152 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 
-import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.Duration;
-import java.util.List;
-
-
-public class TestAdminReport
-{
-    private final Logger log = LoggerFactory.getLogger( TestAdminReport.class );
+public class TestAdminReport {
+    private final Logger log = LoggerFactory.getLogger(TestAdminReport.class);
     private final String PASSWORD = "supersecretpassword";
+
     @RegisterExtension
     public static TemporaryFolderManager temporaryFolderManager = new TemporaryFolderManager();
+
     private static String reportDestinationFlag;
 
     @BeforeAll
-    static void setCorrectPathFlagForVersion()
-    {
-        if( TestSettings.NEO4J_VERSION.isOlderThan( Neo4jVersion.NEO4J_VERSION_500 ) )
-        {
+    static void setCorrectPathFlagForVersion() {
+        if (TestSettings.NEO4J_VERSION.isOlderThan(Neo4jVersion.NEO4J_VERSION_500)) {
             reportDestinationFlag = "--to";
-        }
-        else
-        {
+        } else {
             reportDestinationFlag = "--to-path";
         }
     }
 
-    private GenericContainer createNeo4jContainer( boolean asCurrentUser)
-    {
-        GenericContainer container = new GenericContainer( TestSettings.IMAGE_ID )
-                .withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
-                .withEnv( "NEO4J_AUTH", "neo4j/"+PASSWORD )
-                .withExposedPorts( 7474, 7687 )
-                .withLogConsumer( new Slf4jLogConsumer( log ) )
-                .waitingFor(WaitStrategies.waitForNeo4jReady( PASSWORD ));
-        if(asCurrentUser)
-        {
-            SetContainerUser.nonRootUser( container );
+    private GenericContainer createNeo4jContainer(boolean asCurrentUser) {
+        GenericContainer container = new GenericContainer(TestSettings.IMAGE_ID)
+                .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+                .withEnv("NEO4J_AUTH", "neo4j/" + PASSWORD)
+                .withExposedPorts(7474, 7687)
+                .withLogConsumer(new Slf4jLogConsumer(log))
+                .waitingFor(WaitStrategies.waitForNeo4jReady(PASSWORD));
+        if (asCurrentUser) {
+            SetContainerUser.nonRootUser(container);
         }
         return container;
     }
 
     @ParameterizedTest(name = "ascurrentuser_{0}")
     @ValueSource(booleans = {true, false})
-    void testMountToTmpReports(boolean asCurrentUser) throws Exception
-    {
-        try(GenericContainer container = createNeo4jContainer(asCurrentUser))
-        {
+    void testMountToTmpReports(boolean asCurrentUser) throws Exception {
+        try (GenericContainer container = createNeo4jContainer(asCurrentUser)) {
             temporaryFolderManager.createFolderAndMountAsVolume(container, "/logs");
             Path reportFolder = temporaryFolderManager.createFolderAndMountAsVolume(container, "/tmp/reports");
             container.start();
-            DatabaseIO dbio = new DatabaseIO( container );
-            dbio.putInitialDataIntoContainer( "neo4j", PASSWORD );
+            DatabaseIO dbio = new DatabaseIO(container);
+            dbio.putInitialDataIntoContainer("neo4j", PASSWORD);
 
-            Container.ExecResult execResult = container.execInContainer( "neo4j-admin-report" );
-            verifyCreatesReport( reportFolder, execResult );
+            Container.ExecResult execResult = container.execInContainer("neo4j-admin-report");
+            verifyCreatesReport(reportFolder, execResult);
         }
     }
 
     @ParameterizedTest(name = "ascurrentuser_{0}")
     @ValueSource(booleans = {true, false})
-    void testCanWriteReportToAnyMountedLocation_toPathWithEquals(boolean asCurrentUser) throws Exception
-    {
-        String reportFolderName = "reportAnywhere-"+ (asCurrentUser? "currentuser-":"defaultuser-") + "withEqualsArg-";
-        verifyCanWriteToMountedLocation( asCurrentUser,
-                                         reportFolderName,
-                                         new String[]{"neo4j-admin-report", "--verbose", reportDestinationFlag+"=/reports"} );
+    void testCanWriteReportToAnyMountedLocation_toPathWithEquals(boolean asCurrentUser) throws Exception {
+        String reportFolderName =
+                "reportAnywhere-" + (asCurrentUser ? "currentuser-" : "defaultuser-") + "withEqualsArg-";
+        verifyCanWriteToMountedLocation(asCurrentUser, reportFolderName, new String[] {
+            "neo4j-admin-report", "--verbose", reportDestinationFlag + "=/reports"
+        });
     }
 
     @ParameterizedTest(name = "ascurrentuser_{0}")
     @ValueSource(booleans = {true, false})
-    void testCanWriteReportToAnyMountedLocation_toPathWithSpace(boolean asCurrentUser) throws Exception
-    {
-        String reportFolderName = "reportAnywhere-"+ (asCurrentUser? "currentuser-":"defaultuser-") + "withSpaceArg-";
-        verifyCanWriteToMountedLocation( asCurrentUser,
-                                         reportFolderName,
-                                         new String[]{"neo4j-admin-report", "--verbose", reportDestinationFlag, "/reports"} );
+    void testCanWriteReportToAnyMountedLocation_toPathWithSpace(boolean asCurrentUser) throws Exception {
+        String reportFolderName =
+                "reportAnywhere-" + (asCurrentUser ? "currentuser-" : "defaultuser-") + "withSpaceArg-";
+        verifyCanWriteToMountedLocation(asCurrentUser, reportFolderName, new String[] {
+            "neo4j-admin-report", "--verbose", reportDestinationFlag, "/reports"
+        });
     }
 
-    private void verifyCanWriteToMountedLocation(boolean asCurrentUser, String testFolderPrefix, String[] execArgs) throws Exception
-    {
-        try(GenericContainer container = createNeo4jContainer(asCurrentUser))
-        {
+    private void verifyCanWriteToMountedLocation(boolean asCurrentUser, String testFolderPrefix, String[] execArgs)
+            throws Exception {
+        try (GenericContainer container = createNeo4jContainer(asCurrentUser)) {
             temporaryFolderManager.createFolderAndMountAsVolume(container, "/logs");
             Path reportFolder = temporaryFolderManager.createFolderAndMountAsVolume(container, "/reports");
             container.start();
-            DatabaseIO dbio = new DatabaseIO( container );
-            dbio.putInitialDataIntoContainer( "neo4j", PASSWORD );
+            DatabaseIO dbio = new DatabaseIO(container);
+            dbio.putInitialDataIntoContainer("neo4j", PASSWORD);
             Container.ExecResult execResult = container.execInContainer(execArgs);
             // log exec results, because the results of an exec don't get logged automatically.
-            log.info( execResult.getStdout() );
-            log.warn( execResult.getStderr() );
-            verifyCreatesReport( reportFolder, execResult );
+            log.info(execResult.getStdout());
+            log.warn(execResult.getStderr());
+            verifyCreatesReport(reportFolder, execResult);
         }
     }
 
     @Test
-    void shouldShowNeo4jAdminHelpText_whenCMD() throws Exception
-    {
-        try(GenericContainer container = createNeo4jContainer(false))
-        {
-            container.withCommand( "neo4j-admin-report", "--help" );
-            WaitStrategies.waitUntilContainerFinished( container, Duration.ofSeconds( 20 ) );
-            try
-            {
+    void shouldShowNeo4jAdminHelpText_whenCMD() throws Exception {
+        try (GenericContainer container = createNeo4jContainer(false)) {
+            container.withCommand("neo4j-admin-report", "--help");
+            WaitStrategies.waitUntilContainerFinished(container, Duration.ofSeconds(20));
+            try {
                 container.start();
-            }
-            catch ( ContainerLaunchException e )
-            {
+            } catch (ContainerLaunchException e) {
                 // consume any failed to start exceptions
-                log.warn( "Running 'neo4j-admin-report --help' caused the container to fail rather than " +
-                          "successfully complete. This is allowable, so the test is not going to fail." );
+                log.warn("Running 'neo4j-admin-report --help' caused the container to fail rather than "
+                        + "successfully complete. This is allowable, so the test is not going to fail.");
             }
-            verifyHelpText( container.getLogs(OutputFrame.OutputType.STDOUT),
-                            container.getLogs(OutputFrame.OutputType.STDERR) );
+            verifyHelpText(
+                    container.getLogs(OutputFrame.OutputType.STDOUT), container.getLogs(OutputFrame.OutputType.STDERR));
         }
     }
 
     @Test
-    void shouldShowNeo4jAdminHelpText_whenEXEC() throws Exception
-    {
-        try(GenericContainer container = createNeo4jContainer(false))
-        {
+    void shouldShowNeo4jAdminHelpText_whenEXEC() throws Exception {
+        try (GenericContainer container = createNeo4jContainer(false)) {
             temporaryFolderManager.createFolderAndMountAsVolume(container, "/logs");
             container.start();
-            Container.ExecResult execResult = container.execInContainer( "neo4j-admin-report", "--help" );
+            Container.ExecResult execResult = container.execInContainer("neo4j-admin-report", "--help");
             // log exec results, because the results of an exec don't get logged automatically.
-            log.info( "STDOUT:\n" + execResult.getStdout() );
-            log.warn( "STDERR:\n" + execResult.getStderr() );
-            verifyHelpText( execResult.getStdout(), execResult.getStderr() );
+            log.info("STDOUT:\n" + execResult.getStdout());
+            log.warn("STDERR:\n" + execResult.getStderr());
+            verifyHelpText(execResult.getStdout(), execResult.getStderr());
         }
     }
 
-    private void verifyCreatesReport( Path reportFolder,Container.ExecResult reportExecOut ) throws Exception
-    {
-        List<File> reports = Files.list( reportFolder )
-                                  .map( Path::toFile )
-                                  .filter( file -> ! file.isDirectory() )
-                                  .toList();
-        if( TestSettings.NEO4J_VERSION.isOlderThan( Neo4jVersion.NEO4J_VERSION_500 ) )
-        {
+    private void verifyCreatesReport(Path reportFolder, Container.ExecResult reportExecOut) throws Exception {
+        List<File> reports = Files.list(reportFolder)
+                .map(Path::toFile)
+                .filter(file -> !file.isDirectory())
+                .toList();
+        if (TestSettings.NEO4J_VERSION.isOlderThan(Neo4jVersion.NEO4J_VERSION_500)) {
             // for some reason neo4j-admin report prints jvm details to stderr
-            String[] lines = reportExecOut.getStderr().split( "\n" );
-            Assertions.assertEquals( 1, lines.length,
-                                     "There were errors during report generation" );
-            Assertions.assertTrue( lines[0].startsWith( "Selecting JVM" ),
-                                   "There were unexpected error messages in the neo4j-admin report:\n"+reportExecOut.getStderr() );
+            String[] lines = reportExecOut.getStderr().split("\n");
+            Assertions.assertEquals(1, lines.length, "There were errors during report generation");
+            Assertions.assertTrue(
+                    lines[0].startsWith("Selecting JVM"),
+                    "There were unexpected error messages in the neo4j-admin report:\n" + reportExecOut.getStderr());
+        } else {
+            Assertions.assertEquals("", reportExecOut.getStderr(), "There were errors during report generation");
         }
-        else
-        {
-            Assertions.assertEquals( "", reportExecOut.getStderr(),
-                                     "There were errors during report generation" );
-        }
-        Assertions.assertEquals( 1, reports.size(), "Expected exactly 1 report to be produced" );
-        Assertions.assertFalse( reportExecOut.toString().contains( "No running instance of neo4j was found" ),
-                                "neo4j-admin could not locate running neo4j database" );
+        Assertions.assertEquals(1, reports.size(), "Expected exactly 1 report to be produced");
+        Assertions.assertFalse(
+                reportExecOut.toString().contains("No running instance of neo4j was found"),
+                "neo4j-admin could not locate running neo4j database");
     }
 
-    private void verifyHelpText(String stdout, String stderr)
-    {
+    private void verifyHelpText(String stdout, String stderr) {
         // in 4.4 the help text goes in stderr
-        if( TestSettings.NEO4J_VERSION.isOlderThan( Neo4jVersion.NEO4J_VERSION_500 ) )
-        {
-            Assertions.assertTrue( stderr.contains(
-                    "Produces a zip/tar of the most common information needed for remote assessments." ) );
-            Assertions.assertTrue( stderr.contains( "USAGE" ) );
-            Assertions.assertTrue( stderr.contains( "OPTIONS" ) );
-        }
-        else
-        {
-            Assertions.assertTrue( stdout.contains(
-                    "Produces a zip/tar of the most common information needed for remote assessments." ) );
-            Assertions.assertTrue( stdout.contains( "USAGE" ) );
-            Assertions.assertTrue( stdout.contains( "OPTIONS" ) );
-            Assertions.assertEquals( "", stderr, "There were errors when trying to get neo4j-admin-report help text" );
+        if (TestSettings.NEO4J_VERSION.isOlderThan(Neo4jVersion.NEO4J_VERSION_500)) {
+            Assertions.assertTrue(stderr.contains(
+                    "Produces a zip/tar of the most common information needed for remote assessments."));
+            Assertions.assertTrue(stderr.contains("USAGE"));
+            Assertions.assertTrue(stderr.contains("OPTIONS"));
+        } else {
+            Assertions.assertTrue(stdout.contains(
+                    "Produces a zip/tar of the most common information needed for remote assessments."));
+            Assertions.assertTrue(stdout.contains("USAGE"));
+            Assertions.assertTrue(stdout.contains("OPTIONS"));
+            Assertions.assertEquals("", stderr, "There were errors when trying to get neo4j-admin-report help text");
         }
     }
 }

--- a/src/test/java/com/neo4j/docker/coredb/TestAuthentication.java
+++ b/src/test/java/com/neo4j/docker/coredb/TestAuthentication.java
@@ -5,9 +5,14 @@ import com.neo4j.docker.coredb.configurations.Setting;
 import com.neo4j.docker.utils.DatabaseIO;
 import com.neo4j.docker.utils.Neo4jVersion;
 import com.neo4j.docker.utils.SetContainerUser;
-import com.neo4j.docker.utils.WaitStrategies;
 import com.neo4j.docker.utils.TemporaryFolderManager;
 import com.neo4j.docker.utils.TestSettings;
+import com.neo4j.docker.utils.WaitStrategies;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
@@ -22,382 +27,362 @@ import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.output.WaitingConsumer;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.Duration;
-import java.util.concurrent.TimeUnit;
-
-public class TestAuthentication
-{
+public class TestAuthentication {
     private static Logger log = LoggerFactory.getLogger(TestAuthentication.class);
     private static final String NEO4J_AUTH_FILE_ENV = "NEO4J_AUTH_PATH";
 
     @RegisterExtension
     public static TemporaryFolderManager temporaryFolderManager = new TemporaryFolderManager();
 
-    private GenericContainer createContainer( boolean asCurrentUser )
-    {
-        GenericContainer container = new GenericContainer( TestSettings.IMAGE_ID );
-        container.withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
-                 .withExposedPorts( 7474, 7687 )
-                 .withLogConsumer( new Slf4jLogConsumer( log ) )
-                 .waitingFor(WaitStrategies.waitForBoltReady());
-        if(asCurrentUser)
-        {
-            SetContainerUser.nonRootUser( container );
+    private GenericContainer createContainer(boolean asCurrentUser) {
+        GenericContainer container = new GenericContainer(TestSettings.IMAGE_ID);
+        container
+                .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+                .withExposedPorts(7474, 7687)
+                .withLogConsumer(new Slf4jLogConsumer(log))
+                .waitingFor(WaitStrategies.waitForBoltReady());
+        if (asCurrentUser) {
+            SetContainerUser.nonRootUser(container);
         }
         return container;
     }
 
-    private Path setInitialPasswordWithSecretsFile(GenericContainer container, String password) throws IOException
-    {
-        Path secretsFolder = temporaryFolderManager.createFolderAndMountAsVolume( container, "/secrets" );
-        Files.writeString( secretsFolder.resolve( "passwordfile" ), "neo4j/"+password );
-        container.withEnv( NEO4J_AUTH_FILE_ENV, "/secrets/passwordfile" );
+    private Path setInitialPasswordWithSecretsFile(GenericContainer container, String password) throws IOException {
+        Path secretsFolder = temporaryFolderManager.createFolderAndMountAsVolume(container, "/secrets");
+        Files.writeString(secretsFolder.resolve("passwordfile"), "neo4j/" + password);
+        container.withEnv(NEO4J_AUTH_FILE_ENV, "/secrets/passwordfile");
         return secretsFolder;
     }
 
-	@Test
-	void testNoPassword() throws IOException
-    {
-		// we test that setting NEO4J_AUTH to "none" lets the database start in TestBasic.java,
+    @Test
+    void testNoPassword() throws IOException {
+        // we test that setting NEO4J_AUTH to "none" lets the database start in TestBasic.java,
         // but that does not test that we can read/write the database
-		try(GenericContainer container = createContainer( false ))
-		{
-			container.withEnv( "NEO4J_AUTH", "none");
-            temporaryFolderManager.createFolderAndMountAsVolume( container, "/data" );
-            temporaryFolderManager.createFolderAndMountAsVolume( container, "/logs" );
+        try (GenericContainer container = createContainer(false)) {
+            container.withEnv("NEO4J_AUTH", "none");
+            temporaryFolderManager.createFolderAndMountAsVolume(container, "/data");
+            temporaryFolderManager.createFolderAndMountAsVolume(container, "/logs");
 
-			container.start();
+            container.start();
             DatabaseIO db = new DatabaseIO(container);
-            db.putInitialDataIntoContainer( "neo4j", "none" );
-			db.verifyInitialDataInContainer( "neo4j", "none" );
-		}
-	}
-
-	@Test
-    void testPasswordCantBeNeo4j() throws Exception
-    {
-        try(GenericContainer failContainer = new GenericContainer( TestSettings.IMAGE_ID ).withLogConsumer( new Slf4jLogConsumer( log ) ))
-        {
-            if ( TestSettings.EDITION == TestSettings.Edition.ENTERPRISE )
-            {
-                failContainer.withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" );
-            }
-            failContainer.withEnv( "NEO4J_AUTH", "neo4j/neo4j" );
-            failContainer.start();
-
-            WaitingConsumer waitingConsumer = new WaitingConsumer();
-            failContainer.followOutput( waitingConsumer );
-
-            Assertions.assertDoesNotThrow( () -> waitingConsumer.waitUntil(
-                    frame -> frame.getUtf8String().contains("Invalid value for password" ), 20, TimeUnit.SECONDS ),
-                                           "did not error due to invalid password" );
+            db.putInitialDataIntoContainer("neo4j", "none");
+            db.verifyInitialDataInContainer("neo4j", "none");
         }
     }
 
-	@Test
-	void testDefaultPasswordAndPasswordResetIfNoNeo4jAuthSet()
-	{
-		try(GenericContainer container = createContainer( true ))
-        {
-            log.info( "Starting first container as current user and not specifying NEO4J_AUTH" );
-            container.waitingFor( WaitStrategies.waitForNeo4jReady( "neo4j" ) );
+    @Test
+    void testPasswordCantBeNeo4j() throws Exception {
+        try (GenericContainer failContainer =
+                new GenericContainer(TestSettings.IMAGE_ID).withLogConsumer(new Slf4jLogConsumer(log))) {
+            if (TestSettings.EDITION == TestSettings.Edition.ENTERPRISE) {
+                failContainer.withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes");
+            }
+            failContainer.withEnv("NEO4J_AUTH", "neo4j/neo4j");
+            failContainer.start();
+
+            WaitingConsumer waitingConsumer = new WaitingConsumer();
+            failContainer.followOutput(waitingConsumer);
+
+            Assertions.assertDoesNotThrow(
+                    () -> waitingConsumer.waitUntil(
+                            frame -> frame.getUtf8String().contains("Invalid value for password"),
+                            20,
+                            TimeUnit.SECONDS),
+                    "did not error due to invalid password");
+        }
+    }
+
+    @Test
+    void testDefaultPasswordAndPasswordResetIfNoNeo4jAuthSet() {
+        try (GenericContainer container = createContainer(true)) {
+            log.info("Starting first container as current user and not specifying NEO4J_AUTH");
+            container.waitingFor(WaitStrategies.waitForNeo4jReady("neo4j"));
             container.start();
             DatabaseIO db = new DatabaseIO(container);
-            // try with no password, this should fail because the default password should be applied with no NEO4J_AUTH env variable
-			Assertions.assertThrows( org.neo4j.driver.exceptions.AuthenticationException.class,
-									 () -> db.putInitialDataIntoContainer( "neo4j", "none" ),
-									 "Able to access database with no password, even though NEO4J_AUTH=none was not specified!");
-			Assertions.assertThrows( org.neo4j.driver.exceptions.ClientException.class,
-									 () -> db.putInitialDataIntoContainer( "neo4j", "neo4j" ),
-									 "Was not prompted for a new password when using default");
-			db.changePassword( "neo4j", "neo4j", "newpassword" );
-            db.putInitialDataIntoContainer( "neo4j", "newpassword" );
+            // try with no password, this should fail because the default password should be applied with no NEO4J_AUTH
+            // env variable
+            Assertions.assertThrows(
+                    org.neo4j.driver.exceptions.AuthenticationException.class,
+                    () -> db.putInitialDataIntoContainer("neo4j", "none"),
+                    "Able to access database with no password, even though NEO4J_AUTH=none was not specified!");
+            Assertions.assertThrows(
+                    org.neo4j.driver.exceptions.ClientException.class,
+                    () -> db.putInitialDataIntoContainer("neo4j", "neo4j"),
+                    "Was not prompted for a new password when using default");
+            db.changePassword("neo4j", "neo4j", "newpassword");
+            db.putInitialDataIntoContainer("neo4j", "newpassword");
         }
-	}
+    }
 
-	@ParameterizedTest(name = "as_current_user_{0}")
+    @ParameterizedTest(name = "as_current_user_{0}")
     @ValueSource(booleans = {true, false})
-    void testCanSetPassword( boolean asCurrentUser ) throws Exception
-    {
+    void testCanSetPassword(boolean asCurrentUser) throws Exception {
         // create container and mount /data folder so that data can persist between sessions
         String password = "some_valid_password";
         Path dataMount;
 
-        try(GenericContainer firstContainer = createContainer( asCurrentUser ))
-		{
-			firstContainer.withEnv( "NEO4J_AUTH", "neo4j/"+password )
-                          .waitingFor(WaitStrategies.waitForNeo4jReady(password));
-			dataMount = temporaryFolderManager.createFolderAndMountAsVolume(firstContainer, "/data");
-			log.info( String.format( "Starting first container as %s user and setting password",
-									 asCurrentUser? "current" : "default" ) );
+        try (GenericContainer firstContainer = createContainer(asCurrentUser)) {
+            firstContainer
+                    .withEnv("NEO4J_AUTH", "neo4j/" + password)
+                    .waitingFor(WaitStrategies.waitForNeo4jReady(password));
+            dataMount = temporaryFolderManager.createFolderAndMountAsVolume(firstContainer, "/data");
+            log.info(String.format(
+                    "Starting first container as %s user and setting password", asCurrentUser ? "current" : "default"));
             // create a database with stuff in
             firstContainer.start();
             DatabaseIO db = new DatabaseIO(firstContainer);
-            db.putInitialDataIntoContainer( "neo4j", password );
+            db.putInitialDataIntoContainer("neo4j", password);
         }
 
         // with a new container, check the database data.
-        try(GenericContainer secondContainer = createContainer( asCurrentUser )
-                .waitingFor(WaitStrategies.waitForNeo4jReady(password)))
-        {
-            temporaryFolderManager.mountHostFolderAsVolume( secondContainer, dataMount, "/data" );
-            log.info( "starting new container with same /data mount as same user without setting password" );
+        try (GenericContainer secondContainer =
+                createContainer(asCurrentUser).waitingFor(WaitStrategies.waitForNeo4jReady(password))) {
+            temporaryFolderManager.mountHostFolderAsVolume(secondContainer, dataMount, "/data");
+            log.info("starting new container with same /data mount as same user without setting password");
             secondContainer.start();
             DatabaseIO db = new DatabaseIO(secondContainer);
-            db.verifyInitialDataInContainer( "neo4j", password );
+            db.verifyInitialDataInContainer("neo4j", password);
         }
     }
 
     @ParameterizedTest(name = "as_current_user_{0}")
     @ValueSource(booleans = {true, false})
-    void testCanSetPasswordFromSecretsFile( boolean asCurrentUser ) throws Exception
-    {
+    void testCanSetPasswordFromSecretsFile(boolean asCurrentUser) throws Exception {
         String password = "some_valid_password";
 
-        try(GenericContainer container = createContainer( asCurrentUser )
-                .waitingFor(WaitStrategies.waitForNeo4jReady(password)))
-		{
-			setInitialPasswordWithSecretsFile( container, password );
-			log.info( String.format( "Starting first container as %s user and setting password",
-									 asCurrentUser? "current" : "default" ) );
+        try (GenericContainer container =
+                createContainer(asCurrentUser).waitingFor(WaitStrategies.waitForNeo4jReady(password))) {
+            setInitialPasswordWithSecretsFile(container, password);
+            log.info(String.format(
+                    "Starting first container as %s user and setting password", asCurrentUser ? "current" : "default"));
             container.start();
             DatabaseIO db = new DatabaseIO(container);
-            db.putInitialDataIntoContainer( "neo4j", password );
-            db.verifyInitialDataInContainer( "neo4j", password );
+            db.putInitialDataIntoContainer("neo4j", password);
+            db.verifyInitialDataInContainer("neo4j", password);
         }
     }
 
     @Test
-    void testSecretsFileTakesPriorityOverEnvAuthentication() throws Exception
-    {
+    void testSecretsFileTakesPriorityOverEnvAuthentication() throws Exception {
         String password = "some_valid_password";
         String wrongPassword = "not_the_password";
 
-        try(GenericContainer container = createContainer(false )
-                .waitingFor(WaitStrategies.waitForNeo4jReady(password)))
-		{
-            container.withEnv( "NEO4J_AUTH", "neo4j/" + wrongPassword );
-			setInitialPasswordWithSecretsFile( container, password );
+        try (GenericContainer container =
+                createContainer(false).waitingFor(WaitStrategies.waitForNeo4jReady(password))) {
+            container.withEnv("NEO4J_AUTH", "neo4j/" + wrongPassword);
+            setInitialPasswordWithSecretsFile(container, password);
             container.start();
             DatabaseIO db = new DatabaseIO(container);
-			Assertions.assertThrows( org.neo4j.driver.exceptions.AuthenticationException.class,
-									 () -> db.putInitialDataIntoContainer("neo4j", wrongPassword),
-									 "Able to access database with password set in the environment rather than secrets");
+            Assertions.assertThrows(
+                    org.neo4j.driver.exceptions.AuthenticationException.class,
+                    () -> db.putInitialDataIntoContainer("neo4j", wrongPassword),
+                    "Able to access database with password set in the environment rather than secrets");
 
-            db.putInitialDataIntoContainer( "neo4j", password );
-            db.verifyInitialDataInContainer( "neo4j", password );
+            db.putInitialDataIntoContainer("neo4j", password);
+            db.verifyInitialDataInContainer("neo4j", password);
         }
     }
 
     @Test
-    void testFailsIfSecretsFileSetButMissing()
-    {
-        try(GenericContainer failContainer = createContainer( false ))
-		{
-            WaitStrategies.waitUntilContainerFinished( failContainer, Duration.ofSeconds( 30 ) );
-            failContainer.withEnv( NEO4J_AUTH_FILE_ENV, "/secrets/doesnotexist.secret" );
+    void testFailsIfSecretsFileSetButMissing() {
+        try (GenericContainer failContainer = createContainer(false)) {
+            WaitStrategies.waitUntilContainerFinished(failContainer, Duration.ofSeconds(30));
+            failContainer.withEnv(NEO4J_AUTH_FILE_ENV, "/secrets/doesnotexist.secret");
 
-            Assertions.assertThrows( ContainerLaunchException.class, failContainer::start,
-                                     "Neo4j started even though the password file does not exist" );
+            Assertions.assertThrows(
+                    ContainerLaunchException.class,
+                    failContainer::start,
+                    "Neo4j started even though the password file does not exist");
             // an error message should be printed to stderr
-            String errors = failContainer.getLogs( OutputFrame.OutputType.STDERR);
-            Assertions.assertTrue( errors.contains( "The password file '/secrets/doesnotexist.secret' does not exist" ),
-                                   "Did not error about missing password file. Actual error was: "+errors);
+            String errors = failContainer.getLogs(OutputFrame.OutputType.STDERR);
+            Assertions.assertTrue(
+                    errors.contains("The password file '/secrets/doesnotexist.secret' does not exist"),
+                    "Did not error about missing password file. Actual error was: " + errors);
         }
     }
 
     @Test
-    void testCanSetPasswordWithDebugging() throws Exception
-    {
+    void testCanSetPasswordWithDebugging() throws Exception {
         String password = "some_valid_password";
 
-        try ( GenericContainer container = createContainer( false  ) )
-        {
-            container.withEnv( "NEO4J_AUTH", "neo4j/" + password )
-                     .withEnv( "NEO4J_DEBUG", "yes" )
-                     .waitingFor(WaitStrategies.waitForNeo4jReady( password ));
+        try (GenericContainer container = createContainer(false)) {
+            container
+                    .withEnv("NEO4J_AUTH", "neo4j/" + password)
+                    .withEnv("NEO4J_DEBUG", "yes")
+                    .waitingFor(WaitStrategies.waitForNeo4jReady(password));
             // create a database with stuff in
             container.start();
-            DatabaseIO db = new DatabaseIO( container );
-            db.putInitialDataIntoContainer( "neo4j", password );
+            DatabaseIO db = new DatabaseIO(container);
+            db.putInitialDataIntoContainer("neo4j", password);
         }
     }
 
     @ParameterizedTest(name = "as_current_user_{0}")
     @ValueSource(booleans = {true, false})
-    void testSettingNeo4jAuthDoesntOverrideExistingPassword( boolean asCurrentUser ) throws Exception
-    {
+    void testSettingNeo4jAuthDoesntOverrideExistingPassword(boolean asCurrentUser) throws Exception {
         String password = "some_valid_password";
         Path dataMount;
 
-		try(GenericContainer firstContainer = createContainer( asCurrentUser ))
-		{
-			firstContainer.withEnv( "NEO4J_AUTH", "neo4j/"+password )
-                          .waitingFor(WaitStrategies.waitForNeo4jReady( password));
-			dataMount = temporaryFolderManager.createFolderAndMountAsVolume(firstContainer, "/data");
+        try (GenericContainer firstContainer = createContainer(asCurrentUser)) {
+            firstContainer
+                    .withEnv("NEO4J_AUTH", "neo4j/" + password)
+                    .waitingFor(WaitStrategies.waitForNeo4jReady(password));
+            dataMount = temporaryFolderManager.createFolderAndMountAsVolume(firstContainer, "/data");
 
-			// create a database with stuff in
-			log.info( String.format( "Starting first container as %s user and setting password",
-									 asCurrentUser? "current" : "default" ) );
-			firstContainer.start();
-			DatabaseIO db = new DatabaseIO(firstContainer);
-			db.putInitialDataIntoContainer( "neo4j", password );
+            // create a database with stuff in
+            log.info(String.format(
+                    "Starting first container as %s user and setting password", asCurrentUser ? "current" : "default"));
+            firstContainer.start();
+            DatabaseIO db = new DatabaseIO(firstContainer);
+            db.putInitialDataIntoContainer("neo4j", password);
         }
 
         // with a new container, check the database data.
-        try(GenericContainer secondContainer = createContainer( asCurrentUser ))
-        {
+        try (GenericContainer secondContainer = createContainer(asCurrentUser)) {
             String wrongPassword = "not_the_password";
-            secondContainer.withEnv( "NEO4J_AUTH", "neo4j/"+wrongPassword );
-            temporaryFolderManager.mountHostFolderAsVolume( secondContainer, dataMount, "/data" );
-            log.info( "starting new container with same /data mount as same user without setting password" );
+            secondContainer.withEnv("NEO4J_AUTH", "neo4j/" + wrongPassword);
+            temporaryFolderManager.mountHostFolderAsVolume(secondContainer, dataMount, "/data");
+            log.info("starting new container with same /data mount as same user without setting password");
             secondContainer.start();
             DatabaseIO db = new DatabaseIO(secondContainer);
-            db.verifyInitialDataInContainer( "neo4j", password );
-        Assertions.assertThrows( org.neo4j.driver.exceptions.AuthenticationException.class,
-                () -> db.verifyConnectivity( "neo4j", wrongPassword) );
+            db.verifyInitialDataInContainer("neo4j", password);
+            Assertions.assertThrows(
+                    org.neo4j.driver.exceptions.AuthenticationException.class,
+                    () -> db.verifyConnectivity("neo4j", wrongPassword));
         }
     }
 
     @Test
-    void testPromptsForPasswordReset()
-    {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 3,6,0 ) ),
-                                "Require password reset is only a feature in 3.6 onwards");
-        try(GenericContainer container = createContainer( false ))
-        {
+    void testPromptsForPasswordReset() {
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isAtLeastVersion(new Neo4jVersion(3, 6, 0)),
+                "Require password reset is only a feature in 3.6 onwards");
+        try (GenericContainer container = createContainer(false)) {
             String user = "neo4j";
             String intialPass = "apassword";
             String resetPass = "new_password";
-            container.withEnv("NEO4J_AUTH", user+"/"+intialPass+"/true" )
-                     .waitingFor(   WaitStrategies.waitForNeo4jReady( intialPass ) );
+            container
+                    .withEnv("NEO4J_AUTH", user + "/" + intialPass + "/true")
+                    .waitingFor(WaitStrategies.waitForNeo4jReady(intialPass));
             container.start();
             DatabaseIO db = new DatabaseIO(container);
-            Assertions.assertThrows( org.neo4j.driver.exceptions.ClientException.class,
-                                     () -> db.putInitialDataIntoContainer( user, intialPass ),
-                                     "Neo4j did not error because of password reset requirement");
+            Assertions.assertThrows(
+                    org.neo4j.driver.exceptions.ClientException.class,
+                    () -> db.putInitialDataIntoContainer(user, intialPass),
+                    "Neo4j did not error because of password reset requirement");
 
-            db.changePassword( user, intialPass, resetPass );
-            db.putInitialDataIntoContainer( user, resetPass );
-            db.verifyInitialDataInContainer( user, resetPass );
+            db.changePassword(user, intialPass, resetPass);
+            db.putInitialDataIntoContainer(user, resetPass);
+            db.verifyInitialDataInContainer(user, resetPass);
         }
     }
 
     @ParameterizedTest(name = "use_secrets_file_{0}")
     @ValueSource(booleans = {true, false})
-    void testWarnAndFailIfPasswordLessThan8Chars(boolean usePasswordFile) throws Exception
-    {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 5,2,0 ) ),
-                                "Minimum password length introduced in 5.2.0");
+    void testWarnAndFailIfPasswordLessThan8Chars(boolean usePasswordFile) throws Exception {
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isAtLeastVersion(new Neo4jVersion(5, 2, 0)),
+                "Minimum password length introduced in 5.2.0");
         String shortPassword = "123";
-        try(GenericContainer failContainer = createContainer( false ))
-        {
-            if(usePasswordFile)
-            {
-                setInitialPasswordWithSecretsFile( failContainer, shortPassword );
+        try (GenericContainer failContainer = createContainer(false)) {
+            if (usePasswordFile) {
+                setInitialPasswordWithSecretsFile(failContainer, shortPassword);
+            } else {
+                failContainer.withEnv("NEO4J_AUTH", "neo4j/" + shortPassword);
             }
-            else
-            {
-                failContainer.withEnv( "NEO4J_AUTH", "neo4j/"+shortPassword );
-            }
-            WaitStrategies.waitUntilContainerFinished( failContainer, Duration.ofSeconds( 30 ) );
-            Assertions.assertThrows( ContainerLaunchException.class, failContainer::start,
-                                     "Neo4j started even though initial password was too short" );
+            WaitStrategies.waitUntilContainerFinished(failContainer, Duration.ofSeconds(30));
+            Assertions.assertThrows(
+                    ContainerLaunchException.class,
+                    failContainer::start,
+                    "Neo4j started even though initial password was too short");
             String logsOut = failContainer.getLogs();
-            Assertions.assertTrue( logsOut.contains( "Invalid value for password" ),
-                                   "did not error due to too short password");
-            Assertions.assertFalse( logsOut.contains( "Remote interface available at http://localhost:7474/" ),
-                                    "Neo4j started even though an invalid password was set");
+            Assertions.assertTrue(
+                    logsOut.contains("Invalid value for password"), "did not error due to too short password");
+            Assertions.assertFalse(
+                    logsOut.contains("Remote interface available at http://localhost:7474/"),
+                    "Neo4j started even though an invalid password was set");
         }
     }
 
     @ParameterizedTest(name = "use_secrets_file_{0}")
     @ValueSource(booleans = {true, false})
-    void testWarnAndFailIfPasswordLessThanOverride(boolean usePasswordFile) throws Exception
-    {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 5,2,0 ) ),
-                                "Minimum password length introduced in 5.2.0");
+    void testWarnAndFailIfPasswordLessThanOverride(boolean usePasswordFile) throws Exception {
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isAtLeastVersion(new Neo4jVersion(5, 2, 0)),
+                "Minimum password length introduced in 5.2.0");
         String shortPassword = "123";
-        try(GenericContainer failContainer = createContainer( false ))
-        {
-            if(usePasswordFile)
-            {
-                setInitialPasswordWithSecretsFile( failContainer, shortPassword );
-            }
-            else
-            {
-                failContainer.withEnv( "NEO4J_AUTH", "neo4j/"+shortPassword );
+        try (GenericContainer failContainer = createContainer(false)) {
+            if (usePasswordFile) {
+                setInitialPasswordWithSecretsFile(failContainer, shortPassword);
+            } else {
+                failContainer.withEnv("NEO4J_AUTH", "neo4j/" + shortPassword);
             }
 
-            WaitStrategies.waitUntilContainerFinished( failContainer, Duration.ofSeconds( 30 ) )
-                          .withEnv(Configuration.getConfigurationNameMap().get( Setting.MINIMUM_PASSWORD_LENGTH ).envName, "20");
-            Assertions.assertThrows( ContainerLaunchException.class, failContainer::start,
-                                     "Neo4j started even though initial password was too short" );
+            WaitStrategies.waitUntilContainerFinished(failContainer, Duration.ofSeconds(30))
+                    .withEnv(
+                            Configuration.getConfigurationNameMap().get(Setting.MINIMUM_PASSWORD_LENGTH).envName, "20");
+            Assertions.assertThrows(
+                    ContainerLaunchException.class,
+                    failContainer::start,
+                    "Neo4j started even though initial password was too short");
             String logsOut = failContainer.getLogs();
-            Assertions.assertTrue( logsOut.contains( "Invalid value for password" ),
-                                   "did not error due to too short password");
-            Assertions.assertFalse( logsOut.contains( "Remote interface available at http://localhost:7474/" ),
-                                    "Neo4j started even though an invalid password was set");
+            Assertions.assertTrue(
+                    logsOut.contains("Invalid value for password"), "did not error due to too short password");
+            Assertions.assertFalse(
+                    logsOut.contains("Remote interface available at http://localhost:7474/"),
+                    "Neo4j started even though an invalid password was set");
         }
     }
 
     @ParameterizedTest(name = "use_secrets_file_{0}")
     @ValueSource(booleans = {true, false})
-    void shouldNotWarnAboutMinimumPasswordLengthIfSettingOverridden_env(boolean usePasswordFile) throws Exception
-    {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 5,2,0 ) ),
-                                "Minimum password length introduced in 5.2.0");
+    void shouldNotWarnAboutMinimumPasswordLengthIfSettingOverridden_env(boolean usePasswordFile) throws Exception {
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isAtLeastVersion(new Neo4jVersion(5, 2, 0)),
+                "Minimum password length introduced in 5.2.0");
         String shortPassword = "123";
-        try(GenericContainer container = createContainer( false ))
-        {
-            if(usePasswordFile)
-            {
-                setInitialPasswordWithSecretsFile( container, shortPassword );
+        try (GenericContainer container = createContainer(false)) {
+            if (usePasswordFile) {
+                setInitialPasswordWithSecretsFile(container, shortPassword);
+            } else {
+                container.withEnv("NEO4J_AUTH", "neo4j/" + shortPassword);
             }
-            else
-            {
-                container.withEnv( "NEO4J_AUTH", "neo4j/"+shortPassword );
-            }
-            container.withEnv(Configuration.getConfigurationNameMap().get( Setting.MINIMUM_PASSWORD_LENGTH ).envName, "2");
-            verifyDoesNotWarnAboutMinimumPasswordLengthIfSettingOverridden( container, shortPassword );
+            container.withEnv(
+                    Configuration.getConfigurationNameMap().get(Setting.MINIMUM_PASSWORD_LENGTH).envName, "2");
+            verifyDoesNotWarnAboutMinimumPasswordLengthIfSettingOverridden(container, shortPassword);
         }
     }
 
     @ParameterizedTest(name = "use_secrets_file_{0}")
     @ValueSource(booleans = {true, false})
-    void shouldNotWarnAboutMinimumPasswordLengthIfSettingOverridden_conf(boolean usePasswordFile) throws Exception
-    {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 5,2,0 ) ),
-                                "Minimum password length introduced in 5.2.0");
+    void shouldNotWarnAboutMinimumPasswordLengthIfSettingOverridden_conf(boolean usePasswordFile) throws Exception {
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isAtLeastVersion(new Neo4jVersion(5, 2, 0)),
+                "Minimum password length introduced in 5.2.0");
         String shortPassword = "123";
-        try(GenericContainer container = createContainer( false ))
-        {
-            if(usePasswordFile)
-            {
-                setInitialPasswordWithSecretsFile( container, shortPassword );
-            }
-            else
-            {
-                container.withEnv( "NEO4J_AUTH", "neo4j/"+shortPassword );
+        try (GenericContainer container = createContainer(false)) {
+            if (usePasswordFile) {
+                setInitialPasswordWithSecretsFile(container, shortPassword);
+            } else {
+                container.withEnv("NEO4J_AUTH", "neo4j/" + shortPassword);
             }
             Path confMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/conf");
-            Files.writeString(confMount.resolve( "neo4j.conf" ),
-                              Configuration.getConfigurationNameMap().get( Setting.MINIMUM_PASSWORD_LENGTH ).name+"=2");
-            verifyDoesNotWarnAboutMinimumPasswordLengthIfSettingOverridden( container, shortPassword );
+            Files.writeString(
+                    confMount.resolve("neo4j.conf"),
+                    Configuration.getConfigurationNameMap().get(Setting.MINIMUM_PASSWORD_LENGTH).name + "=2");
+            verifyDoesNotWarnAboutMinimumPasswordLengthIfSettingOverridden(container, shortPassword);
         }
     }
 
-    private void verifyDoesNotWarnAboutMinimumPasswordLengthIfSettingOverridden(GenericContainer container, String password) throws Exception
-    {
-            container.start();
-            String logs = container.getLogs();
-            Assertions.assertFalse( logs.contains( "Invalid value for password. The minimum password length is 8 characters." ),
-                                    "Should not error about minimum password length if overridden.");
-            DatabaseIO db = new DatabaseIO( container );
-            db.putInitialDataIntoContainer( "neo4j", password );
-            db.verifyInitialDataInContainer( "neo4j", password );
+    private void verifyDoesNotWarnAboutMinimumPasswordLengthIfSettingOverridden(
+            GenericContainer container, String password) throws Exception {
+        container.start();
+        String logs = container.getLogs();
+        Assertions.assertFalse(
+                logs.contains("Invalid value for password. The minimum password length is 8 characters."),
+                "Should not error about minimum password length if overridden.");
+        DatabaseIO db = new DatabaseIO(container);
+        db.putInitialDataIntoContainer("neo4j", password);
+        db.verifyInitialDataInContainer("neo4j", password);
     }
 }

--- a/src/test/java/com/neo4j/docker/coredb/TestBasic.java
+++ b/src/test/java/com/neo4j/docker/coredb/TestBasic.java
@@ -1,5 +1,9 @@
 package com.neo4j.docker.coredb;
 
+import static com.neo4j.docker.utils.WaitStrategies.waitForBoltReady;
+import static com.neo4j.docker.utils.WaitStrategies.waitForNeo4jReady;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
 import com.github.dockerjava.api.command.KillContainerCmd;
 import com.github.dockerjava.api.command.StopContainerCmd;
 import com.neo4j.docker.utils.DatabaseIO;
@@ -7,6 +11,12 @@ import com.neo4j.docker.utils.Neo4jVersion;
 import com.neo4j.docker.utils.TemporaryFolderManager;
 import com.neo4j.docker.utils.TestSettings;
 import com.neo4j.docker.utils.WaitStrategies;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
@@ -22,261 +32,248 @@ import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.Duration;
-import java.util.List;
-import java.util.stream.Stream;
+public class TestBasic {
+    private Logger log = LoggerFactory.getLogger(TestBasic.class);
 
-import static com.neo4j.docker.utils.WaitStrategies.*;
-import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
-
-public class TestBasic
-{
-    private Logger log = LoggerFactory.getLogger( TestBasic.class );
     @RegisterExtension
     public static TemporaryFolderManager temporaryFolderManager = new TemporaryFolderManager();
+
     private Duration STARTUP_TIMEOUT_DURATION = Duration.ofSeconds(180);
 
-    private GenericContainer createBasicContainer()
-    {
-        GenericContainer<?> container = new GenericContainer<>( TestSettings.IMAGE_ID );
-        container.withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
-                 .withExposedPorts( 7474, 7687 )
-                 .withLogConsumer( new Slf4jLogConsumer( log ) );
+    private GenericContainer createBasicContainer() {
+        GenericContainer<?> container = new GenericContainer<>(TestSettings.IMAGE_ID);
+        container
+                .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+                .withExposedPorts(7474, 7687)
+                .withLogConsumer(new Slf4jLogConsumer(log));
         return container;
     }
 
     @Test
-    void testListensOn7687()
-    {
-        try ( GenericContainer container = createBasicContainer() )
-        {
-            container.waitingFor( waitForNeo4jReady( "neo4j" ) );
+    void testListensOn7687() {
+        try (GenericContainer container = createBasicContainer()) {
+            container.waitingFor(waitForNeo4jReady("neo4j"));
             container.start();
-            Assertions.assertTrue( container.isRunning() );
+            Assertions.assertTrue(container.isRunning());
             String stdout = container.getLogs();
-            Assertions.assertFalse( stdout.contains( "DEBUGGING ENABLED" ),
-                                    "Debugging was enabled even though we did not set debugging" );
+            Assertions.assertFalse(
+                    stdout.contains("DEBUGGING ENABLED"), "Debugging was enabled even though we did not set debugging");
         }
     }
 
     @Test
-    void testNoUnexpectedErrors()
-    {
-        Assumptions.assumeFalse( TestSettings.BASE_OS.isDeprecatedOs());
-        try ( GenericContainer container = createBasicContainer() )
-        {
-            container.waitingFor( waitForNeo4jReady( "neo4j" ) );
+    void testNoUnexpectedErrors() {
+        Assumptions.assumeFalse(TestSettings.BASE_OS.isDeprecatedOs());
+        try (GenericContainer container = createBasicContainer()) {
+            container.waitingFor(waitForNeo4jReady("neo4j"));
             container.start();
-            Assertions.assertTrue( container.isRunning() );
+            Assertions.assertTrue(container.isRunning());
 
-            String stderr = container.getLogs( OutputFrame.OutputType.STDERR );
-            Assertions.assertEquals( "", stderr,
-                                     "Unexpected errors in stderr from container!\n" +
-                                     stderr );
+            String stderr = container.getLogs(OutputFrame.OutputType.STDERR);
+            Assertions.assertEquals("", stderr, "Unexpected errors in stderr from container!\n" + stderr);
         }
     }
 
     @Test
-    void testLicenseAcceptanceRequired_Neo4jServer()
-    {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 3, 3, 0 ) ),
-                                "No license checks before version 3.3.0" );
-        Assumptions.assumeTrue( TestSettings.EDITION == TestSettings.Edition.ENTERPRISE,
-                                "No license checks for community edition" );
+    void testLicenseAcceptanceRequired_Neo4jServer() {
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isAtLeastVersion(new Neo4jVersion(3, 3, 0)),
+                "No license checks before version 3.3.0");
+        Assumptions.assumeTrue(
+                TestSettings.EDITION == TestSettings.Edition.ENTERPRISE, "No license checks for community edition");
 
         String logsOut;
-        try ( GenericContainer<?> container = new GenericContainer<>( TestSettings.IMAGE_ID )
-                .withLogConsumer( new Slf4jLogConsumer( log ) ) )
-        {
-            WaitStrategies.waitUntilContainerFinished( container, Duration.ofSeconds( 30 ) );
+        try (GenericContainer<?> container =
+                new GenericContainer<>(TestSettings.IMAGE_ID).withLogConsumer(new Slf4jLogConsumer(log))) {
+            WaitStrategies.waitUntilContainerFinished(container, Duration.ofSeconds(30));
             // container start should fail due to licensing.
-            Assertions.assertThrows( ContainerLaunchException.class, container::start,
-                                     "Neo4j did not notify about accepting the license agreement" );
+            Assertions.assertThrows(
+                    ContainerLaunchException.class,
+                    container::start,
+                    "Neo4j did not notify about accepting the license agreement");
             logsOut = container.getLogs();
         }
         // double check the container didn't warn and start neo4j anyway
-        Assertions.assertTrue( logsOut.contains( "must accept the license" ),
-                               "Neo4j did not notify about accepting the license agreement" );
-        Assertions.assertFalse( logsOut.contains( "Remote interface available" ),
-                                "Neo4j was started even though the license was not accepted" );
+        Assertions.assertTrue(
+                logsOut.contains("must accept the license"),
+                "Neo4j did not notify about accepting the license agreement");
+        Assertions.assertFalse(
+                logsOut.contains("Remote interface available"),
+                "Neo4j was started even though the license was not accepted");
     }
 
     @Test
-    void testLicenseAcceptanceAvoidsWarning()
-    {
-        Assumptions.assumeTrue( TestSettings.EDITION == TestSettings.Edition.ENTERPRISE,
-                                "No license checks for community edition" );
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 5, 0, 0 ) ),
-                                "No unified license acceptance method before 5.0.0" );
-        try ( GenericContainer container = createBasicContainer() )
-        {
-            container.waitingFor( waitForNeo4jReady( "neo4j" ) );
+    void testLicenseAcceptanceAvoidsWarning() {
+        Assumptions.assumeTrue(
+                TestSettings.EDITION == TestSettings.Edition.ENTERPRISE, "No license checks for community edition");
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isAtLeastVersion(new Neo4jVersion(5, 0, 0)),
+                "No unified license acceptance method before 5.0.0");
+        try (GenericContainer container = createBasicContainer()) {
+            container.waitingFor(waitForNeo4jReady("neo4j"));
             container.start();
-            Assertions.assertTrue( container.isRunning() );
+            Assertions.assertTrue(container.isRunning());
 
-            String stdout = container.getLogs( OutputFrame.OutputType.STDOUT );
-            Assertions.assertTrue( stdout.contains( "The license agreement was accepted with environment variable " +
-                                                    "NEO4J_ACCEPT_LICENSE_AGREEMENT=yes when the Software was started." ),
-                                   "Neo4j did not register that the license was agreed to." );
+            String stdout = container.getLogs(OutputFrame.OutputType.STDOUT);
+            Assertions.assertTrue(
+                    stdout.contains("The license agreement was accepted with environment variable "
+                            + "NEO4J_ACCEPT_LICENSE_AGREEMENT=yes when the Software was started."),
+                    "Neo4j did not register that the license was agreed to.");
         }
     }
 
     @Test
-    void testLicenseAcceptanceAvoidsWarning_evaluation()
-    {
-        Assumptions.assumeTrue( TestSettings.EDITION == TestSettings.Edition.ENTERPRISE,
-                                "No license checks for community edition" );
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 5, 0, 0 ) ),
-                                "No unified license acceptance method before 5.0.0" );
-        try ( GenericContainer container = createBasicContainer() )
-        {
-            container.withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "eval" )
-                     .waitingFor( waitForNeo4jReady( "neo4j" ) );
+    void testLicenseAcceptanceAvoidsWarning_evaluation() {
+        Assumptions.assumeTrue(
+                TestSettings.EDITION == TestSettings.Edition.ENTERPRISE, "No license checks for community edition");
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isAtLeastVersion(new Neo4jVersion(5, 0, 0)),
+                "No unified license acceptance method before 5.0.0");
+        try (GenericContainer container = createBasicContainer()) {
+            container.withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "eval").waitingFor(waitForNeo4jReady("neo4j"));
             container.start();
-            Assertions.assertTrue( container.isRunning() );
+            Assertions.assertTrue(container.isRunning());
 
-            String stdout = container.getLogs( OutputFrame.OutputType.STDOUT );
-            Assertions.assertTrue( stdout.contains( "The license agreement was accepted with environment variable " +
-                                                    "NEO4J_ACCEPT_LICENSE_AGREEMENT=eval when the Software was started." ),
-                                   "Neo4j did not register that the evaluation license was agreed to." );
+            String stdout = container.getLogs(OutputFrame.OutputType.STDOUT);
+            Assertions.assertTrue(
+                    stdout.contains("The license agreement was accepted with environment variable "
+                            + "NEO4J_ACCEPT_LICENSE_AGREEMENT=eval when the Software was started."),
+                    "Neo4j did not register that the evaluation license was agreed to.");
         }
     }
 
     @Test
-    void testCypherShellOnPath() throws Exception
-    {
+    void testCypherShellOnPath() throws Exception {
         String expectedCypherShellPath = "/var/lib/neo4j/bin/cypher-shell";
-        try ( GenericContainer container = createBasicContainer() )
-        {
-            container.waitingFor( waitForNeo4jReady( "neo4j" ) );
+        try (GenericContainer container = createBasicContainer()) {
+            container.waitingFor(waitForNeo4jReady("neo4j"));
             container.start();
 
-            Container.ExecResult whichResult = container.execInContainer( "which", "cypher-shell" );
-            Assertions.assertTrue( whichResult.getStdout().contains( expectedCypherShellPath ),
-                                   "cypher-shell not on path" );
+            Container.ExecResult whichResult = container.execInContainer("which", "cypher-shell");
+            Assertions.assertTrue(
+                    whichResult.getStdout().contains(expectedCypherShellPath), "cypher-shell not on path");
         }
     }
 
     @Test
-    void testCanChangeWorkDir()
-    {
-        try ( GenericContainer container = createBasicContainer() )
-        {
-            container.waitingFor( waitForNeo4jReady( "neo4j" ) );
-            container.setWorkingDirectory( "/tmp" );
-            Assertions.assertDoesNotThrow( container::start,
-                                           "Could not start neo4j from workdir other than NEO4J_HOME" );
+    void testCanChangeWorkDir() {
+        try (GenericContainer container = createBasicContainer()) {
+            container.waitingFor(waitForNeo4jReady("neo4j"));
+            container.setWorkingDirectory("/tmp");
+            Assertions.assertDoesNotThrow(container::start, "Could not start neo4j from workdir other than NEO4J_HOME");
         }
     }
 
     @Test
-    void testPackagingInfoContainsDocker() throws Exception
-    {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 5, 0, 0 ) ),
-                "No packaging_info file before 5.0.0" );
-        try ( GenericContainer container = createBasicContainer() )
-        {
-            container.waitingFor( waitForNeo4jReady( "neo4j" ) );
+    void testPackagingInfoContainsDocker() throws Exception {
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isAtLeastVersion(new Neo4jVersion(5, 0, 0)),
+                "No packaging_info file before 5.0.0");
+        try (GenericContainer container = createBasicContainer()) {
+            container.waitingFor(waitForNeo4jReady("neo4j"));
             container.start();
-            String packagingInfo = container.execInContainer("cat", "/var/lib/neo4j/packaging_info").getStdout();
-            List<String> actualPackageType = Stream.of(packagingInfo.split( "\n" ))
+            String packagingInfo = container
+                    .execInContainer("cat", "/var/lib/neo4j/packaging_info")
+                    .getStdout();
+            List<String> actualPackageType = Stream.of(packagingInfo.split("\n"))
                     .filter(line -> line.startsWith("Package Type:"))
                     .toList();
-            Assertions.assertEquals(1, actualPackageType.size(),
-                    "There should only be 1 Package Type declarations in the packaging_info:\n"+actualPackageType);
-            Assertions.assertEquals("Package Type: docker " + TestSettings.BASE_OS.name().toLowerCase(),
-                    actualPackageType.get(0), "Docker packaging type is missing from packaging info file");
+            Assertions.assertEquals(
+                    1,
+                    actualPackageType.size(),
+                    "There should only be 1 Package Type declarations in the packaging_info:\n" + actualPackageType);
+            Assertions.assertEquals(
+                    "Package Type: docker " + TestSettings.BASE_OS.name().toLowerCase(),
+                    actualPackageType.get(0),
+                    "Docker packaging type is missing from packaging info file");
         }
     }
 
-    @ParameterizedTest( name = "ShutsDownCorrectly_{0}" )
-    @ValueSource( strings = {"SIGTERM", "SIGINT"} )
-    void testShutsDownCleanly( String signal )
-    {
-        try ( GenericContainer container = createBasicContainer() )
-        {
-            container.withEnv( "NEO4J_AUTH", "none" )
-                     .waitingFor( waitForNeo4jReady( "none" ) );
+    @ParameterizedTest(name = "ShutsDownCorrectly_{0}")
+    @ValueSource(strings = {"SIGTERM", "SIGINT"})
+    void testShutsDownCleanly(String signal) {
+        try (GenericContainer container = createBasicContainer()) {
+            container.withEnv("NEO4J_AUTH", "none").waitingFor(waitForNeo4jReady("none"));
             container.start();
-            DatabaseIO dbio = new DatabaseIO( container );
-            dbio.putInitialDataIntoContainer( "neo4j", "none" );
-            try(KillContainerCmd kill = container.getDockerClient().killContainerCmd(container.getContainerId());
-                StopContainerCmd stop = container.getDockerClient().stopContainerCmd(container.getContainerId()))
-            {
-                log.info( "issuing container stop command " + signal );
+            DatabaseIO dbio = new DatabaseIO(container);
+            dbio.putInitialDataIntoContainer("neo4j", "none");
+            try (KillContainerCmd kill = container.getDockerClient().killContainerCmd(container.getContainerId());
+                    StopContainerCmd stop = container.getDockerClient().stopContainerCmd(container.getContainerId())) {
+                log.info("issuing container stop command " + signal);
                 kill.withSignal(signal).exec();
                 log.info("waiting for container to shut down.");
                 stop.withTimeout(30).exec();
             }
             String stdout = container.getLogs();
-            Assertions.assertTrue( stdout.contains( "Neo4j Server shutdown initiated by request" ),
-                                   "clean shutdown not initiated by " + signal + "\n" + stdout);
-            Assertions.assertTrue( stdout.contains( "Stopped." ),
-                                   "clean shutdown not initiated by " + signal + "\n" + stdout);
+            Assertions.assertTrue(
+                    stdout.contains("Neo4j Server shutdown initiated by request"),
+                    "clean shutdown not initiated by " + signal + "\n" + stdout);
+            Assertions.assertTrue(
+                    stdout.contains("Stopped."), "clean shutdown not initiated by " + signal + "\n" + stdout);
         }
     }
 
     @Test
-    void testStartsWhenDebuggingEnabled()
-    {
-        try ( GenericContainer container = createBasicContainer() )
-        {
-            container.withEnv( "NEO4J_DEBUG", "true" );
+    void testStartsWhenDebuggingEnabled() {
+        try (GenericContainer container = createBasicContainer()) {
+            container.withEnv("NEO4J_DEBUG", "true");
             container.start();
-            Assertions.assertTrue( container.isRunning() );
+            Assertions.assertTrue(container.isRunning());
         }
     }
 
     /*
-        This test emulates a termination of the Docker Desktop or Docker Engine by the user. In these
-        cases the container receives a SIGKILL signal and neo4j doesn't have time to clean up the PID
-        file. In turn this causes the container to not be re-startable.
-     */
+       This test emulates a termination of the Docker Desktop or Docker Engine by the user. In these
+       cases the container receives a SIGKILL signal and neo4j doesn't have time to clean up the PID
+       file. In turn this causes the container to not be re-startable.
+    */
     @Test
-    void testContainerCanBeRestartedAfterUnexpectedTermination() throws IOException
-    {
-        try ( GenericContainer container = createBasicContainer() )
-        {
-            Wait.forLogMessage( ".*Started.*", 1).withStartupTimeout( STARTUP_TIMEOUT_DURATION );
+    void testContainerCanBeRestartedAfterUnexpectedTermination() throws IOException {
+        try (GenericContainer container = createBasicContainer()) {
+            Wait.forLogMessage(".*Started.*", 1).withStartupTimeout(STARTUP_TIMEOUT_DURATION);
             container.withEnv("NEO4J_AUTH", "none");
 
             // Ensuring host ports are constant with container restarts
             container.start();
 
-            // Terminating container with a SIGKILL signal to emulate docker engine (docker desktop) being terminated by user.
+            // Terminating container with a SIGKILL signal to emulate docker engine (docker desktop) being terminated by
+            // user.
             // This also keeps around the container unlike GenericContainer::stop(), which cleans up everything
-            log.info( "Terminating container with SIGKILL signal" );
-            container.getDockerClient().killContainerCmd( container.getContainerId() ).withSignal( "SIGKILL" ).exec();
+            log.info("Terminating container with SIGKILL signal");
+            container
+                    .getDockerClient()
+                    .killContainerCmd(container.getContainerId())
+                    .withSignal("SIGKILL")
+                    .exec();
 
-            await().atMost( Duration.ofSeconds( 120 ) ).untilAsserted( () -> {
-                Assertions.assertFalse( container.isRunning());
-            } );
+            await().atMost(Duration.ofSeconds(120)).untilAsserted(() -> {
+                Assertions.assertFalse(container.isRunning());
+            });
 
-            // Restarting the container with DockerClient because the GenericContainer was not terminates and GenericContainer::start()
+            // Restarting the container with DockerClient because the GenericContainer was not terminates and
+            // GenericContainer::start()
             // does not work
-            log.info( "Starting container" );
-            container.getDockerClient().startContainerCmd( container.getContainerId() ).exec();
+            log.info("Starting container");
+            container
+                    .getDockerClient()
+                    .startContainerCmd(container.getContainerId())
+                    .exec();
 
-            // Applying the Waiting strategy to ensure container is correctly running, because DockerClient does not check
-            Wait.forLogMessage( ".*Started.*", 2).withStartupTimeout( STARTUP_TIMEOUT_DURATION );
+            // Applying the Waiting strategy to ensure container is correctly running, because DockerClient does not
+            // check
+            Wait.forLogMessage(".*Started.*", 2).withStartupTimeout(STARTUP_TIMEOUT_DURATION);
         }
     }
 
     @Test
-    void testExtensionScriptIsExecuted() throws IOException
-    {
+    void testExtensionScriptIsExecuted() throws IOException {
         Path scriptFolder = temporaryFolderManager.createFolder("extension_script");
         Path script = scriptFolder.resolve("startscript.sh");
         Files.writeString(script, "#!/bin/bash\n\necho \"SCRIPT EXECUTED!\"");
 
-        try ( GenericContainer container = createBasicContainer() )
-        {
+        try (GenericContainer container = createBasicContainer()) {
             temporaryFolderManager.mountHostFolderAsVolume(container, scriptFolder, "/extension");
-            container.waitingFor(waitForBoltReady())
-                    .withEnv("EXTENSION_SCRIPT", "/extension/startscript.sh");
+            container.waitingFor(waitForBoltReady()).withEnv("EXTENSION_SCRIPT", "/extension/startscript.sh");
             container.start();
             String logs = container.getLogs(OutputFrame.OutputType.STDOUT);
             Assertions.assertTrue(logs.contains("SCRIPT EXECUTED!"), "The extension script did not get executed");

--- a/src/test/java/com/neo4j/docker/coredb/TestMounting.java
+++ b/src/test/java/com/neo4j/docker/coredb/TestMounting.java
@@ -9,6 +9,14 @@ import com.neo4j.docker.utils.SetContainerUser;
 import com.neo4j.docker.utils.TemporaryFolderManager;
 import com.neo4j.docker.utils.TestSettings;
 import com.neo4j.docker.utils.WaitStrategies;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Random;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
@@ -28,244 +36,222 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.Duration;
-import java.util.Random;
-import java.util.function.Consumer;
-import java.util.stream.Stream;
-
-public class TestMounting
-{
-    private static Logger log = LoggerFactory.getLogger( TestMounting.class );
+public class TestMounting {
+    private static Logger log = LoggerFactory.getLogger(TestMounting.class);
 
     @RegisterExtension
     public static TemporaryFolderManager temporaryFolderManager = new TemporaryFolderManager();
 
     @AfterEach
-    void archiveTestArtifacts() throws Exception
-    {
+    void archiveTestArtifacts() throws Exception {
         temporaryFolderManager.triggerCleanup();
     }
 
-    static Stream<Arguments> defaultUserFlagSecurePermissionsFlag()
-    {
+    static Stream<Arguments> defaultUserFlagSecurePermissionsFlag() {
         // "asUser={0}, secureFlag={1}"
         // expected behaviour is that if you set --user flag, your data should be read/writable
         // if you don't set --user flag then read/writability should be controlled by the secure file permissions flag
-        // the asCurrentUser=false, secureflag=true combination is tested separately because the container should fail to start.
+        // the asCurrentUser=false, secureflag=true combination is tested separately because the container should fail
+        // to start.
         return Stream.of(
-                Arguments.arguments( false, false ),
-                Arguments.arguments( true, false ),
-                Arguments.arguments( true, true ) );
+                Arguments.arguments(false, false), Arguments.arguments(true, false), Arguments.arguments(true, true));
     }
 
-    private GenericContainer setupBasicContainer( boolean asCurrentUser, boolean isSecurityFlagSet )
-    {
-        log.info( "Running as user {}, {}",
-                  asCurrentUser ? "non-root" : "root",
-                  isSecurityFlagSet ? "with secure file permissions" : "with unsecured file permissions" );
+    private GenericContainer setupBasicContainer(boolean asCurrentUser, boolean isSecurityFlagSet) {
+        log.info(
+                "Running as user {}, {}",
+                asCurrentUser ? "non-root" : "root",
+                isSecurityFlagSet ? "with secure file permissions" : "with unsecured file permissions");
 
-        GenericContainer container = new GenericContainer( TestSettings.IMAGE_ID );
-        container.withExposedPorts( 7474, 7687 )
-                 .withLogConsumer( new Slf4jLogConsumer( log ) )
-                 .withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
-                 .withEnv( "NEO4J_AUTH", "none" )
-                 .waitingFor( WaitStrategies.waitForNeo4jReady( "none" ) );
-        if ( asCurrentUser )
-        {
-            SetContainerUser.nonRootUser( container );
+        GenericContainer container = new GenericContainer(TestSettings.IMAGE_ID);
+        container
+                .withExposedPorts(7474, 7687)
+                .withLogConsumer(new Slf4jLogConsumer(log))
+                .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+                .withEnv("NEO4J_AUTH", "none")
+                .waitingFor(WaitStrategies.waitForNeo4jReady("none"));
+        if (asCurrentUser) {
+            SetContainerUser.nonRootUser(container);
         }
-        if ( isSecurityFlagSet )
-        {
-            container.withEnv( "SECURE_FILE_PERMISSIONS", "yes" );
+        if (isSecurityFlagSet) {
+            container.withEnv("SECURE_FILE_PERMISSIONS", "yes");
         }
         return container;
     }
 
-    private void verifySingleFolder( Path folderToCheck, boolean shouldBeWritable )
-    {
+    private void verifySingleFolder(Path folderToCheck, boolean shouldBeWritable) {
         String folderForDiagnostics = folderToCheck.toAbsolutePath().toString();
 
-        Assertions.assertTrue( folderToCheck.toFile().exists(), "did not create " + folderForDiagnostics + " folder on host" );
-        if ( shouldBeWritable )
-        {
-            Assertions.assertTrue( folderToCheck.toFile().canRead(), "cannot read host " + folderForDiagnostics + " folder" );
-            Assertions.assertTrue( folderToCheck.toFile().canWrite(), "cannot write to host " + folderForDiagnostics + " folder" );
+        Assertions.assertTrue(
+                folderToCheck.toFile().exists(), "did not create " + folderForDiagnostics + " folder on host");
+        if (shouldBeWritable) {
+            Assertions.assertTrue(
+                    folderToCheck.toFile().canRead(), "cannot read host " + folderForDiagnostics + " folder");
+            Assertions.assertTrue(
+                    folderToCheck.toFile().canWrite(), "cannot write to host " + folderForDiagnostics + " folder");
         }
     }
 
-    private void verifyDataFolderContentsArePresentOnHost( Path dataMount, boolean shouldBeWritable )
-    {
-        verifySingleFolder( dataMount.resolve( "databases" ), shouldBeWritable );
+    private void verifyDataFolderContentsArePresentOnHost(Path dataMount, boolean shouldBeWritable) {
+        verifySingleFolder(dataMount.resolve("databases"), shouldBeWritable);
 
-        if ( TestSettings.NEO4J_VERSION.isAtLeastVersion( Neo4jVersion.NEO4J_VERSION_400 ) )
-        {
-            verifySingleFolder( dataMount.resolve( "transactions" ), shouldBeWritable );
+        if (TestSettings.NEO4J_VERSION.isAtLeastVersion(Neo4jVersion.NEO4J_VERSION_400)) {
+            verifySingleFolder(dataMount.resolve("transactions"), shouldBeWritable);
         }
     }
 
-    private void verifyLogsFolderContentsArePresentOnHost( Path logsMount, boolean shouldBeWritable )
-    {
-        verifySingleFolder( logsMount, shouldBeWritable );
-        Assertions.assertTrue( logsMount.resolve( "debug.log" ).toFile().exists(),
-                               "Neo4j did not write a debug.log file to " + logsMount.toString() );
-        Assertions.assertEquals( shouldBeWritable,
-                                 logsMount.resolve( "debug.log" ).toFile().canWrite(),
-                                 String.format( "The debug.log file should %sbe writable", shouldBeWritable ? "" : "not " ) );
+    private void verifyLogsFolderContentsArePresentOnHost(Path logsMount, boolean shouldBeWritable) {
+        verifySingleFolder(logsMount, shouldBeWritable);
+        Assertions.assertTrue(
+                logsMount.resolve("debug.log").toFile().exists(),
+                "Neo4j did not write a debug.log file to " + logsMount.toString());
+        Assertions.assertEquals(
+                shouldBeWritable,
+                logsMount.resolve("debug.log").toFile().canWrite(),
+                String.format("The debug.log file should %sbe writable", shouldBeWritable ? "" : "not "));
     }
 
     @ParameterizedTest(name = "as_current_user_{0}")
-    @ValueSource( booleans = {true, false} )
-    void canDumpConfig( boolean asCurrentUser ) throws Exception
-    {
+    @ValueSource(booleans = {true, false})
+    void canDumpConfig(boolean asCurrentUser) throws Exception {
         File confFile;
         Path confMount;
         String assertMsg = "Conf file was not successfully dumped when running container as "
-                           + (asCurrentUser? "current user" : "root");
+                + (asCurrentUser ? "current user" : "root");
 
-        try ( GenericContainer container = setupBasicContainer( asCurrentUser, false ) )
-        {
-            //Mount /conf
+        try (GenericContainer container = setupBasicContainer(asCurrentUser, false)) {
+            // Mount /conf
             confMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/conf");
-            confFile = confMount.resolve( "neo4j.conf" ).toFile();
+            confFile = confMount.resolve("neo4j.conf").toFile();
 
-            //Start the container
+            // Start the container
             container.setWaitStrategy(
-                    Wait.forLogMessage( ".*Config Dumped.*", 1 )
-                        .withStartupTimeout( Duration.ofSeconds( 30 ) ) );
-            container.setStartupCheckStrategy( new OneShotStartupCheckStrategy() );
-            container.setCommand( "dump-config" );
+                    Wait.forLogMessage(".*Config Dumped.*", 1).withStartupTimeout(Duration.ofSeconds(30)));
+            container.setStartupCheckStrategy(new OneShotStartupCheckStrategy());
+            container.setCommand("dump-config");
             container.start();
         }
 
         // verify conf file was written
-        Assertions.assertTrue( confFile.exists(), assertMsg );
+        Assertions.assertTrue(confFile.exists(), assertMsg);
         // verify conf folder does not have new owner if not running as root
-        if ( asCurrentUser )
-        {
-            int fileUID = (Integer) Files.getAttribute( confFile.toPath(), "unix:uid" );
-            int expectedUID = Integer.parseInt( SetContainerUser.getNonRootUserString().split( ":" )[0] );
-            Assertions.assertEquals( expectedUID, fileUID, "Owner of dumped conf file is not the currently running user" );
+        if (asCurrentUser) {
+            int fileUID = (Integer) Files.getAttribute(confFile.toPath(), "unix:uid");
+            int expectedUID =
+                    Integer.parseInt(SetContainerUser.getNonRootUserString().split(":")[0]);
+            Assertions.assertEquals(
+                    expectedUID, fileUID, "Owner of dumped conf file is not the currently running user");
         }
     }
 
     @Test
-    void canDumpConfig_errorsWithoutConfMount() throws Exception
-    {
-        try ( GenericContainer container = setupBasicContainer( false, false ) )
-        {
+    void canDumpConfig_errorsWithoutConfMount() throws Exception {
+        try (GenericContainer container = setupBasicContainer(false, false)) {
             container.setWaitStrategy(
-                    Wait.forLogMessage( ".*Config Dumped.*", 1 )
-                        .withStartupTimeout( Duration.ofSeconds( 30 ) ) );
-            container.setStartupCheckStrategy( new OneShotStartupCheckStrategy() );
-            container.setCommand( "dump-config" );
-            Assertions.assertThrows( ContainerLaunchException.class,
-                                     () -> container.start(),
-                                     "Did not error when dump config requested without mounted /conf folder" );
-            String stderr = container.getLogs( OutputFrame.OutputType.STDERR );
-            Assertions.assertTrue( stderr.endsWith( "You must mount a folder to /conf so that the configuration file(s) can be dumped to there.\n" ) );
+                    Wait.forLogMessage(".*Config Dumped.*", 1).withStartupTimeout(Duration.ofSeconds(30)));
+            container.setStartupCheckStrategy(new OneShotStartupCheckStrategy());
+            container.setCommand("dump-config");
+            Assertions.assertThrows(
+                    ContainerLaunchException.class,
+                    () -> container.start(),
+                    "Did not error when dump config requested without mounted /conf folder");
+            String stderr = container.getLogs(OutputFrame.OutputType.STDERR);
+            Assertions.assertTrue(stderr.endsWith(
+                    "You must mount a folder to /conf so that the configuration file(s) can be dumped to there.\n"));
         }
     }
 
-    @ParameterizedTest( name = "asUser={0}, secureFlag={1}" )
-    @MethodSource( "defaultUserFlagSecurePermissionsFlag" )
-    void testCanMountJustDataFolder( boolean asCurrentUser, boolean isSecurityFlagSet ) throws IOException
-    {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 3, 1, 0 ) ),
-                                "User checks not valid before 3.1" );
+    @ParameterizedTest(name = "asUser={0}, secureFlag={1}")
+    @MethodSource("defaultUserFlagSecurePermissionsFlag")
+    void testCanMountJustDataFolder(boolean asCurrentUser, boolean isSecurityFlagSet) throws IOException {
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isAtLeastVersion(new Neo4jVersion(3, 1, 0)),
+                "User checks not valid before 3.1");
 
-        try ( GenericContainer container = setupBasicContainer( asCurrentUser, isSecurityFlagSet ) )
-        {
+        try (GenericContainer container = setupBasicContainer(asCurrentUser, isSecurityFlagSet)) {
             Path dataMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/data");
             container.start();
 
             // neo4j should now have started, so there'll be stuff in the data folder
             // we need to check that stuff is readable and owned by the correct user
-            verifyDataFolderContentsArePresentOnHost( dataMount, asCurrentUser );
+            verifyDataFolderContentsArePresentOnHost(dataMount, asCurrentUser);
         }
     }
 
-    @ParameterizedTest( name = "asUser={0}, secureFlag={1}" )
-    @MethodSource( "defaultUserFlagSecurePermissionsFlag" )
-    void testCanMountJustLogsFolder( boolean asCurrentUser, boolean isSecurityFlagSet ) throws IOException
-    {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 3, 1, 0 ) ),
-                                "User checks not valid before 3.1" );
+    @ParameterizedTest(name = "asUser={0}, secureFlag={1}")
+    @MethodSource("defaultUserFlagSecurePermissionsFlag")
+    void testCanMountJustLogsFolder(boolean asCurrentUser, boolean isSecurityFlagSet) throws IOException {
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isAtLeastVersion(new Neo4jVersion(3, 1, 0)),
+                "User checks not valid before 3.1");
 
-        try ( GenericContainer container = setupBasicContainer( asCurrentUser, isSecurityFlagSet ) )
-        {
+        try (GenericContainer container = setupBasicContainer(asCurrentUser, isSecurityFlagSet)) {
             Path logsMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/logs");
             container.start();
 
-            verifyLogsFolderContentsArePresentOnHost( logsMount, asCurrentUser );
+            verifyLogsFolderContentsArePresentOnHost(logsMount, asCurrentUser);
         }
     }
 
-    @ParameterizedTest( name = "asUser={0}, secureFlag={1}" )
-    @MethodSource( "defaultUserFlagSecurePermissionsFlag" )
-    void testCanMountDataAndLogsFolder( boolean asCurrentUser, boolean isSecurityFlagSet ) throws IOException
-    {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 3, 1, 0 ) ),
-                                "User checks not valid before 3.1" );
+    @ParameterizedTest(name = "asUser={0}, secureFlag={1}")
+    @MethodSource("defaultUserFlagSecurePermissionsFlag")
+    void testCanMountDataAndLogsFolder(boolean asCurrentUser, boolean isSecurityFlagSet) throws IOException {
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isAtLeastVersion(new Neo4jVersion(3, 1, 0)),
+                "User checks not valid before 3.1");
 
-        try ( GenericContainer container = setupBasicContainer( asCurrentUser, isSecurityFlagSet ) )
-        {
+        try (GenericContainer container = setupBasicContainer(asCurrentUser, isSecurityFlagSet)) {
             Path dataMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/data");
             Path logsMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/logs");
             container.start();
 
-            verifyDataFolderContentsArePresentOnHost( dataMount, asCurrentUser );
-            verifyLogsFolderContentsArePresentOnHost( logsMount, asCurrentUser );
+            verifyDataFolderContentsArePresentOnHost(dataMount, asCurrentUser);
+            verifyLogsFolderContentsArePresentOnHost(logsMount, asCurrentUser);
         }
     }
 
     @Test
-    void testCantWriteIfSecureEnabledAndNoPermissions_data() throws IOException
-    {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 3, 1, 0 ) ),
-                                "User checks not valid before 3.1" );
+    void testCantWriteIfSecureEnabledAndNoPermissions_data() throws IOException {
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isAtLeastVersion(new Neo4jVersion(3, 1, 0)),
+                "User checks not valid before 3.1");
 
-        try ( GenericContainer container = setupBasicContainer( false, true ) )
-        {
+        try (GenericContainer container = setupBasicContainer(false, true)) {
             temporaryFolderManager.createFolderAndMountAsVolume(container, "/data");
 
             // currently Neo4j will try to start and fail. It should be fixed to throw an error and not try starting
-            container.setWaitStrategy( Wait.forLogMessage( "[fF]older /data is not accessible for user", 1 )
-                                           .withStartupTimeout( Duration.ofSeconds( 20 ) ) );
-            Assertions.assertThrows( ContainerLaunchException.class,
-                                     () -> container.start(),
-                                     "Neo4j should not start in secure mode if data folder is unwritable" );
+            container.setWaitStrategy(Wait.forLogMessage("[fF]older /data is not accessible for user", 1)
+                    .withStartupTimeout(Duration.ofSeconds(20)));
+            Assertions.assertThrows(
+                    ContainerLaunchException.class,
+                    () -> container.start(),
+                    "Neo4j should not start in secure mode if data folder is unwritable");
         }
     }
 
     @Test
-    void testCantWriteIfSecureEnabledAndNoPermissions_logs() throws IOException
-    {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 3, 1, 0 ) ),
-                                "User checks not valid before 3.1" );
+    void testCantWriteIfSecureEnabledAndNoPermissions_logs() throws IOException {
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isAtLeastVersion(new Neo4jVersion(3, 1, 0)),
+                "User checks not valid before 3.1");
 
-        try ( GenericContainer container = setupBasicContainer( false, true ) )
-        {
+        try (GenericContainer container = setupBasicContainer(false, true)) {
             temporaryFolderManager.createFolderAndMountAsVolume(container, "/logs");
 
             // currently Neo4j will try to start and fail. It should be fixed to throw an error and not try starting
-            container.setWaitStrategy( Wait.forLogMessage( "[fF]older /logs is not accessible for user", 1 )
-                                           .withStartupTimeout( Duration.ofSeconds( 20 ) ) );
-            Assertions.assertThrows( ContainerLaunchException.class,
-                                     () -> container.start(),
-                                     "Neo4j should not start in secure mode if logs folder is unwritable" );
+            container.setWaitStrategy(Wait.forLogMessage("[fF]older /logs is not accessible for user", 1)
+                    .withStartupTimeout(Duration.ofSeconds(20)));
+            Assertions.assertThrows(
+                    ContainerLaunchException.class,
+                    () -> container.start(),
+                    "Neo4j should not start in secure mode if logs folder is unwritable");
         }
     }
 
     @ParameterizedTest(name = "as_current_user_{0}")
-    @ValueSource( booleans = {true, false} )
-    void canMountAllTheThings_fileMounts( boolean asCurrentUser ) throws Exception
-    {
-        try ( GenericContainer container = setupBasicContainer( asCurrentUser, false ) )
-        {
+    @ValueSource(booleans = {true, false})
+    void canMountAllTheThings_fileMounts(boolean asCurrentUser) throws Exception {
+        try (GenericContainer container = setupBasicContainer(asCurrentUser, false)) {
             temporaryFolderManager.createFolderAndMountAsVolume(container, "/conf");
             temporaryFolderManager.createFolderAndMountAsVolume(container, "/data");
             temporaryFolderManager.createFolderAndMountAsVolume(container, "/import");
@@ -273,68 +259,64 @@ public class TestMounting
             temporaryFolderManager.createFolderAndMountAsVolume(container, "/metrics");
             temporaryFolderManager.createFolderAndMountAsVolume(container, "/plugins");
             container.start();
-            DatabaseIO databaseIO = new DatabaseIO( container );
+            DatabaseIO databaseIO = new DatabaseIO(container);
             // do some database writes so that we try writing to writable folders.
-            databaseIO.putInitialDataIntoContainer( "neo4j", "none" );
-            databaseIO.verifyInitialDataInContainer( "neo4j", "none" );
+            databaseIO.putInitialDataIntoContainer("neo4j", "none");
+            databaseIO.verifyInitialDataInContainer("neo4j", "none");
         }
     }
 
     @ParameterizedTest(name = "as_current_user_{0}")
-    @ValueSource( booleans = {true, false} )
-    void canMountAllTheThings_namedVolumes( boolean asCurrentUser ) throws Exception
-    {
-        String id = String.format( "%04d", new Random().nextInt( 10000 ) );
-        try ( GenericContainer container = setupBasicContainer( asCurrentUser, false ) )
-        {
-            container.withCreateContainerCmdModifier(
-                    (Consumer<CreateContainerCmd>) cmd -> cmd.getHostConfig().withBinds(
-                            Bind.parse( "conf-" + id + ":/conf" ),
-                            Bind.parse( "data-" + id + ":/data" ),
-                            Bind.parse( "import-" + id + ":/import" ),
-                            Bind.parse( "logs-" + id + ":/logs" ),
-                            //Bind.parse("metrics-"+id+":/metrics"), 	//todo metrics needs to be writable but we aren't chowning in the dockerfile, so a named volume for metrics will fail
-                            Bind.parse( "plugins-" + id + ":/plugins" )
-                    ) );
+    @ValueSource(booleans = {true, false})
+    void canMountAllTheThings_namedVolumes(boolean asCurrentUser) throws Exception {
+        String id = String.format("%04d", new Random().nextInt(10000));
+        try (GenericContainer container = setupBasicContainer(asCurrentUser, false)) {
+            container.withCreateContainerCmdModifier((Consumer<CreateContainerCmd>) cmd -> cmd.getHostConfig()
+                    .withBinds(
+                            Bind.parse("conf-" + id + ":/conf"),
+                            Bind.parse("data-" + id + ":/data"),
+                            Bind.parse("import-" + id + ":/import"),
+                            Bind.parse("logs-" + id + ":/logs"),
+                            // Bind.parse("metrics-"+id+":/metrics"), 	//todo metrics needs to be writable but we aren't
+                            // chowning in the dockerfile, so a named volume for metrics will fail
+                            Bind.parse("plugins-" + id + ":/plugins")));
             container.start();
-            DatabaseIO databaseIO = new DatabaseIO( container );
+            DatabaseIO databaseIO = new DatabaseIO(container);
             // do some database writes so that we try writing to writable folders.
-            databaseIO.putInitialDataIntoContainer( "neo4j", "none" );
-            databaseIO.verifyInitialDataInContainer( "neo4j", "none" );
+            databaseIO.putInitialDataIntoContainer("neo4j", "none");
+            databaseIO.verifyInitialDataInContainer("neo4j", "none");
         } finally {
             cleanupVolumes(id);
         }
     }
 
     @Test
-    void shouldReownSubfilesToNeo4j() throws Exception
-    {
+    void shouldReownSubfilesToNeo4j() throws Exception {
         Assumptions.assumeTrue(
-                TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 4, 0, 0 ) ),
-                "User checks not valid before 4.0" );
+                TestSettings.NEO4J_VERSION.isAtLeastVersion(new Neo4jVersion(4, 0, 0)),
+                "User checks not valid before 4.0");
 
-        Path logMount = temporaryFolderManager.createFolder( "subfileownership" );
-        Path debugLog = logMount.resolve( "debug.log" );
+        Path logMount = temporaryFolderManager.createFolder("subfileownership");
+        Path debugLog = logMount.resolve("debug.log");
         // put file in logMount
-        Files.write( debugLog, "some log words".getBytes() );
+        Files.write(debugLog, "some log words".getBytes());
         // make neo4j own the conf folder but NOT the neo4j.conf
-        temporaryFolderManager.setFolderOwnerToNeo4j( logMount );
-        temporaryFolderManager.setFolderOwnerToCurrentUser( debugLog );
+        temporaryFolderManager.setFolderOwnerToNeo4j(logMount);
+        temporaryFolderManager.setFolderOwnerToCurrentUser(debugLog);
 
-        try ( GenericContainer container = setupBasicContainer( false, false ) )
-        {
-            temporaryFolderManager.mountHostFolderAsVolume( container, logMount, "/logs" );
+        try (GenericContainer container = setupBasicContainer(false, false)) {
+            temporaryFolderManager.mountHostFolderAsVolume(container, logMount, "/logs");
             container.start();
             // if debug.log doesn't get re-owned, neo4j will not start and this test will fail here
         }
     }
 
-    private static void cleanupVolumes(String id){
+    private static void cleanupVolumes(String id) {
         DockerClient client = DockerClientFactory.instance().client();
-        client.removeVolumeCmd( "conf-"+id ).exec();
-        client.removeVolumeCmd( "data-"+id ).exec();
-        client.removeVolumeCmd( "import-"+id ).exec();
-        client.removeVolumeCmd( "logs-"+id ).exec();
-        client.removeVolumeCmd( "plugins-"+id ).exec();
+        client.removeVolumeCmd("conf-" + id).exec();
+        client.removeVolumeCmd("data-" + id).exec();
+        client.removeVolumeCmd("import-" + id).exec();
+        client.removeVolumeCmd("logs-" + id).exec();
+        client.removeVolumeCmd("plugins-" + id).exec();
     }
 }

--- a/src/test/java/com/neo4j/docker/coredb/TestUpgrade.java
+++ b/src/test/java/com/neo4j/docker/coredb/TestUpgrade.java
@@ -1,10 +1,22 @@
 package com.neo4j.docker.coredb;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.Bind;
-import com.neo4j.docker.utils.*;
+import com.neo4j.docker.utils.DatabaseIO;
+import com.neo4j.docker.utils.Neo4jVersion;
+import com.neo4j.docker.utils.TemporaryFolderManager;
+import com.neo4j.docker.utils.TestSettings;
+import com.neo4j.docker.utils.WaitStrategies;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -17,240 +29,218 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.images.RemoteDockerImage;
 import org.testcontainers.utility.DockerImageName;
 
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Random;
-import java.util.function.Consumer;
-
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
-
-public class TestUpgrade
-{
-	private final Logger log = LoggerFactory.getLogger( TestUpgrade.class );
-	private final String user = "neo4j";
-	private final String password = "verylongpassword";
+public class TestUpgrade {
+    private final Logger log = LoggerFactory.getLogger(TestUpgrade.class);
+    private final String user = "neo4j";
+    private final String password = "verylongpassword";
 
     @RegisterExtension
     public static TemporaryFolderManager temporaryFolderManager = new TemporaryFolderManager();
 
-	private GenericContainer makeContainer(DockerImageName image)
-	{
-        GenericContainer container = new GenericContainer<>( image );
-        container.withEnv( "NEO4J_AUTH", user + "/" + password )
-                 .withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
-                 .withExposedPorts( 7474 )
-                 .withExposedPorts( 7687 )
-                 .withLogConsumer( new Slf4jLogConsumer( log ) )
-				 .waitingFor(WaitStrategies.waitForBoltReady())
-				 .withStartupAttempts(3);
+    private GenericContainer makeContainer(DockerImageName image) {
+        GenericContainer container = new GenericContainer<>(image);
+        container
+                .withEnv("NEO4J_AUTH", user + "/" + password)
+                .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+                .withExposedPorts(7474)
+                .withExposedPorts(7687)
+                .withLogConsumer(new Slf4jLogConsumer(log))
+                .waitingFor(WaitStrategies.waitForBoltReady())
+                .withStartupAttempts(3);
 
         return container;
-	}
-
-	private static List<Neo4jVersion> upgradableNeo4jVersionsPre5()
-	{
-		return Arrays.asList( new Neo4jVersion( 3, 5, 35 ),
-							  new Neo4jVersion( 4, 4, 0 ),
-							  new Neo4jVersion( 4, 4, 25 ));
     }
 
-    private static List<Neo4jVersion> upgradableNeo4jVersions5x()
-    {
+    private static List<Neo4jVersion> upgradableNeo4jVersionsPre5() {
+        return Arrays.asList(new Neo4jVersion(3, 5, 35), new Neo4jVersion(4, 4, 0), new Neo4jVersion(4, 4, 25));
+    }
+
+    private static List<Neo4jVersion> upgradableNeo4jVersions5x() {
         // instead of returning ALL 5.x versions just run a few to check that upgrading works and the volume/bind mount
         // settings do not break upgrade.
         // Running every upgrade path used up all the test agent memorry and caused unneccessary failures.
         // We must assume that Neo4j upgrades are fully tested elsewhere, and just make sure that the
         // docker infrastructure doesn't break upgrading.
-		return Arrays.asList( new Neo4jVersion( 5, 1, 0 ),
-                              new Neo4jVersion( 5, 5, 0 ),
-							  new Neo4jVersion( 5, 10, 0 ));
+        return Arrays.asList(new Neo4jVersion(5, 1, 0), new Neo4jVersion(5, 5, 0), new Neo4jVersion(5, 10, 0));
     }
 
-    private static List<Neo4jVersion> upgradableNeo4jVersionsCalVer()
-    {
-        return Arrays.asList(new Neo4jVersion(5, 26, 0),
-                             new Neo4jVersion(2025, 4, 0),
-                             new Neo4jVersion(2025, 8, 0),
-                             new Neo4jVersion(2026, 1, 4));
+    private static List<Neo4jVersion> upgradableNeo4jVersionsCalVer() {
+        return Arrays.asList(
+                new Neo4jVersion(5, 26, 0),
+                new Neo4jVersion(2025, 4, 0),
+                new Neo4jVersion(2025, 8, 0),
+                new Neo4jVersion(2026, 1, 4));
     }
 
-    private static void assumeUpgradeSupported( Neo4jVersion upgradeFrom )
-    {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isNewerThan( upgradeFrom ),
-                    "cannot upgrade from " + upgradeFrom + " to " + TestSettings.NEO4J_VERSION);
-        if(isArm()) Assumptions.assumeTrue( upgradeFrom.isAtLeastVersion( new Neo4jVersion( 4, 4, 0 ) ), "ARM only supported since 4.4" );
+    private static void assumeUpgradeSupported(Neo4jVersion upgradeFrom) {
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isNewerThan(upgradeFrom),
+                "cannot upgrade from " + upgradeFrom + " to " + TestSettings.NEO4J_VERSION);
+        if (isArm())
+            Assumptions.assumeTrue(
+                    upgradeFrom.isAtLeastVersion(new Neo4jVersion(4, 4, 0)), "ARM only supported since 4.4");
 
         // if we're preparing a new release, then it's possible the version we're upgrading from hasn't been released to
         // dockerhub, so the test will fail when pulling the upgrade-from image.
         // If this happens we should ignore rather than fail the test.
-        try
-        {
-            RemoteDockerImage img = new RemoteDockerImage( getUpgradeFromImage( upgradeFrom ) );
+        try {
+            RemoteDockerImage img = new RemoteDockerImage(getUpgradeFromImage(upgradeFrom));
             img.get(); // docker pull
-        }
-        catch ( NotFoundException nfex )
-        {
+        } catch (NotFoundException nfex) {
             // purposely fail an assumption if the image was not found
-            Assumptions.assumeTrue( false, "neo4j:"+upgradeFrom+" is not available on dockerhub yet. Ignoring test.");
+            Assumptions.assumeTrue(
+                    false, "neo4j:" + upgradeFrom + " is not available on dockerhub yet. Ignoring test.");
         }
     }
 
-    private static boolean isArm()
-    {
-        return System.getProperty( "os.arch" ).equals( "aarch64" );
+    private static boolean isArm() {
+        return System.getProperty("os.arch").equals("aarch64");
     }
 
-	@ParameterizedTest(name = "from_{0}")
-    @MethodSource( "upgradableNeo4jVersionsPre5" )
-	void canUpgradeNeo4j_fileMounts_Pre5( Neo4jVersion upgradeFrom) throws Exception
-	{
-		assumeTrue( TestSettings.NEO4J_VERSION.isOlderThan( Neo4jVersion.NEO4J_VERSION_500 ),
-                    "this test only for upgrades before 5.0: " + TestSettings.NEO4J_VERSION );
-		testUpgradeFileMounts( upgradeFrom );
-	}
+    @ParameterizedTest(name = "from_{0}")
+    @MethodSource("upgradableNeo4jVersionsPre5")
+    void canUpgradeNeo4j_fileMounts_Pre5(Neo4jVersion upgradeFrom) throws Exception {
+        assumeTrue(
+                TestSettings.NEO4J_VERSION.isOlderThan(Neo4jVersion.NEO4J_VERSION_500),
+                "this test only for upgrades before 5.0: " + TestSettings.NEO4J_VERSION);
+        testUpgradeFileMounts(upgradeFrom);
+    }
 
-	@ParameterizedTest(name = "from_{0}")
-	@MethodSource( "upgradableNeo4jVersionsPre5" )
-	void canUpgradeNeo4j_namedVolumes_Pre5(Neo4jVersion upgradeFrom) throws Exception
-	{
-		assumeTrue( TestSettings.NEO4J_VERSION.isOlderThan( Neo4jVersion.NEO4J_VERSION_500 ),
-                    "this test only for upgrades before 5.0: " + TestSettings.NEO4J_VERSION );
-		testUpgradeNamedVolumes( upgradeFrom );
-	}
+    @ParameterizedTest(name = "from_{0}")
+    @MethodSource("upgradableNeo4jVersionsPre5")
+    void canUpgradeNeo4j_namedVolumes_Pre5(Neo4jVersion upgradeFrom) throws Exception {
+        assumeTrue(
+                TestSettings.NEO4J_VERSION.isOlderThan(Neo4jVersion.NEO4J_VERSION_500),
+                "this test only for upgrades before 5.0: " + TestSettings.NEO4J_VERSION);
+        testUpgradeNamedVolumes(upgradeFrom);
+    }
 
-	@ParameterizedTest(name = "from_{0}")
-    @MethodSource( "upgradableNeo4jVersions5x" )
-	void canUpgradeNeo4j_fileMounts_5x( Neo4jVersion upgradeFrom) throws Exception
-	{
-		assumeTrue( TestSettings.NEO4J_VERSION.major == 5,
-                    "this test only for upgrades on the 5x branch" + TestSettings.NEO4J_VERSION );
-		testUpgradeFileMounts( upgradeFrom );
-	}
+    @ParameterizedTest(name = "from_{0}")
+    @MethodSource("upgradableNeo4jVersions5x")
+    void canUpgradeNeo4j_fileMounts_5x(Neo4jVersion upgradeFrom) throws Exception {
+        assumeTrue(
+                TestSettings.NEO4J_VERSION.major == 5,
+                "this test only for upgrades on the 5x branch" + TestSettings.NEO4J_VERSION);
+        testUpgradeFileMounts(upgradeFrom);
+    }
 
-	@ParameterizedTest(name = "from_{0}")
-	@MethodSource( "upgradableNeo4jVersions5x" )
-	void canUpgradeNeo4j_namedVolumes_5x(Neo4jVersion upgradeFrom) throws Exception
-	{
-        assumeTrue( TestSettings.NEO4J_VERSION.major == 5,
-                    "this test only for upgrades on the 5x branch" + TestSettings.NEO4J_VERSION );
-		testUpgradeNamedVolumes( upgradeFrom );
-	}
+    @ParameterizedTest(name = "from_{0}")
+    @MethodSource("upgradableNeo4jVersions5x")
+    void canUpgradeNeo4j_namedVolumes_5x(Neo4jVersion upgradeFrom) throws Exception {
+        assumeTrue(
+                TestSettings.NEO4J_VERSION.major == 5,
+                "this test only for upgrades on the 5x branch" + TestSettings.NEO4J_VERSION);
+        testUpgradeNamedVolumes(upgradeFrom);
+    }
 
-	@ParameterizedTest(name = "from_{0}")
-    @MethodSource( "upgradableNeo4jVersionsCalVer" )
-	void canUpgradeNeo4j_fileMounts_calver( Neo4jVersion upgradeFrom) throws Exception
-	{
-		assumeTrue( TestSettings.NEO4J_VERSION.isCalver(),
-                    "this test only for upgrades to calver: " + TestSettings.NEO4J_VERSION );
-		testUpgradeFileMounts( upgradeFrom );
-	}
+    @ParameterizedTest(name = "from_{0}")
+    @MethodSource("upgradableNeo4jVersionsCalVer")
+    void canUpgradeNeo4j_fileMounts_calver(Neo4jVersion upgradeFrom) throws Exception {
+        assumeTrue(
+                TestSettings.NEO4J_VERSION.isCalver(),
+                "this test only for upgrades to calver: " + TestSettings.NEO4J_VERSION);
+        testUpgradeFileMounts(upgradeFrom);
+    }
 
-	@ParameterizedTest(name = "from_{0}")
-	@MethodSource( "upgradableNeo4jVersionsCalVer" )
-	void canUpgradeNeo4j_namedVolumes_calver(Neo4jVersion upgradeFrom) throws Exception
-	{
-		assumeTrue( TestSettings.NEO4J_VERSION.isCalver(),
-                    "this test only for upgrades to calver: " + TestSettings.NEO4J_VERSION );
-		testUpgradeNamedVolumes( upgradeFrom );
-	}
+    @ParameterizedTest(name = "from_{0}")
+    @MethodSource("upgradableNeo4jVersionsCalVer")
+    void canUpgradeNeo4j_namedVolumes_calver(Neo4jVersion upgradeFrom) throws Exception {
+        assumeTrue(
+                TestSettings.NEO4J_VERSION.isCalver(),
+                "this test only for upgrades to calver: " + TestSettings.NEO4J_VERSION);
+        testUpgradeNamedVolumes(upgradeFrom);
+    }
 
-	private void testUpgradeFileMounts( Neo4jVersion upgradeFrom ) throws IOException
-	{
-		assumeUpgradeSupported( upgradeFrom );
+    private void testUpgradeFileMounts(Neo4jVersion upgradeFrom) throws IOException {
+        assumeUpgradeSupported(upgradeFrom);
 
-		Path data, logs, imports, metrics;
+        Path data, logs, imports, metrics;
 
-		try(GenericContainer container = makeContainer( getUpgradeFromImage( upgradeFrom ) ))
-		{
-			data = temporaryFolderManager.createFolderAndMountAsVolume(container, "/data");
-			logs = temporaryFolderManager.createFolderAndMountAsVolume(container, "/logs");
-			imports = temporaryFolderManager.createFolderAndMountAsVolume(container, "/import");
-			metrics = temporaryFolderManager.createFolderAndMountAsVolume(container, "/metrics");
-			container.start();
-			DatabaseIO db = new DatabaseIO( container );
-			db.putInitialDataIntoContainer( user, password );
-			// stops container cleanly so that neo4j process has enough time to end. The autoclose doesn't seem to block.
-			container.getDockerClient().stopContainerCmd( container.getContainerId() ).exec();
-		}
+        try (GenericContainer container = makeContainer(getUpgradeFromImage(upgradeFrom))) {
+            data = temporaryFolderManager.createFolderAndMountAsVolume(container, "/data");
+            logs = temporaryFolderManager.createFolderAndMountAsVolume(container, "/logs");
+            imports = temporaryFolderManager.createFolderAndMountAsVolume(container, "/import");
+            metrics = temporaryFolderManager.createFolderAndMountAsVolume(container, "/metrics");
+            container.start();
+            DatabaseIO db = new DatabaseIO(container);
+            db.putInitialDataIntoContainer(user, password);
+            // stops container cleanly so that neo4j process has enough time to end. The autoclose doesn't seem to
+            // block.
+            container
+                    .getDockerClient()
+                    .stopContainerCmd(container.getContainerId())
+                    .exec();
+        }
 
-		try(GenericContainer container = makeContainer( TestSettings.IMAGE_ID ))
-		{
-			temporaryFolderManager.mountHostFolderAsVolume( container, data, "/data" );
-			temporaryFolderManager.mountHostFolderAsVolume( container, logs, "/logs" );
-			temporaryFolderManager.mountHostFolderAsVolume( container, imports, "/import" );
-			temporaryFolderManager.mountHostFolderAsVolume( container, metrics, "/metrics" );
-			container.withEnv( "NEO4J_dbms_allow__upgrade", "true" );
-			container.start();
-			DatabaseIO db = new DatabaseIO( container );
-			db.verifyInitialDataInContainer( user, password );
-		}
-	}
+        try (GenericContainer container = makeContainer(TestSettings.IMAGE_ID)) {
+            temporaryFolderManager.mountHostFolderAsVolume(container, data, "/data");
+            temporaryFolderManager.mountHostFolderAsVolume(container, logs, "/logs");
+            temporaryFolderManager.mountHostFolderAsVolume(container, imports, "/import");
+            temporaryFolderManager.mountHostFolderAsVolume(container, metrics, "/metrics");
+            container.withEnv("NEO4J_dbms_allow__upgrade", "true");
+            container.start();
+            DatabaseIO db = new DatabaseIO(container);
+            db.verifyInitialDataInContainer(user, password);
+        }
+    }
 
-	private void testUpgradeNamedVolumes( Neo4jVersion upgradeFrom )
-	{
-		assumeUpgradeSupported(upgradeFrom);
+    private void testUpgradeNamedVolumes(Neo4jVersion upgradeFrom) {
+        assumeUpgradeSupported(upgradeFrom);
 
-		String id = String.format( "%04d", new Random().nextInt( 10000 ));
-		log.info( "creating volumes with id: "+id );
+        String id = String.format("%04d", new Random().nextInt(10000));
+        log.info("creating volumes with id: " + id);
 
-		try(GenericContainer container = makeContainer(getUpgradeFromImage( upgradeFrom )))
-		{
-			container.withCreateContainerCmdModifier(
-					(Consumer<CreateContainerCmd>) cmd -> cmd.getHostConfig().withBinds(
-							Bind.parse("upgrade-conf-"+id+":/conf"),
-							Bind.parse("upgrade-data-"+id+":/data"),
-							Bind.parse("upgrade-import-"+id+":/import"),
-							Bind.parse("upgrade-logs-"+id+":/logs"),
-							Bind.parse("upgrade-metrics-"+id+":/metrics"),
-							Bind.parse("upgrade-plugins-"+id+":/plugins")
-					));
-			container.start();
-			DatabaseIO db = new DatabaseIO( container );
-			db.putInitialDataIntoContainer( user, password );
-			container.getDockerClient().stopContainerCmd( container.getContainerId() ).exec();
-		}
+        try (GenericContainer container = makeContainer(getUpgradeFromImage(upgradeFrom))) {
+            container.withCreateContainerCmdModifier((Consumer<CreateContainerCmd>) cmd -> cmd.getHostConfig()
+                    .withBinds(
+                            Bind.parse("upgrade-conf-" + id + ":/conf"),
+                            Bind.parse("upgrade-data-" + id + ":/data"),
+                            Bind.parse("upgrade-import-" + id + ":/import"),
+                            Bind.parse("upgrade-logs-" + id + ":/logs"),
+                            Bind.parse("upgrade-metrics-" + id + ":/metrics"),
+                            Bind.parse("upgrade-plugins-" + id + ":/plugins")));
+            container.start();
+            DatabaseIO db = new DatabaseIO(container);
+            db.putInitialDataIntoContainer(user, password);
+            container
+                    .getDockerClient()
+                    .stopContainerCmd(container.getContainerId())
+                    .exec();
+        }
 
-		try(GenericContainer container = makeContainer( TestSettings.IMAGE_ID ))
-		{
-			container.withCreateContainerCmdModifier(
-					(Consumer<CreateContainerCmd>) cmd -> cmd.getHostConfig().withBinds(
-							Bind.parse("upgrade-conf-"+id+":/conf"),
-							Bind.parse("upgrade-data-"+id+":/data"),
-							Bind.parse("upgrade-import-"+id+":/import"),
-							Bind.parse("upgrade-logs-"+id+":/logs"),
-							Bind.parse("upgrade-metrics-"+id+":/metrics"),
-							Bind.parse("upgrade-plugins-"+id+":/plugins")
-					));
-			container.withEnv( "NEO4J_dbms_allow__upgrade", "true" );
-			container.start();
-			DatabaseIO db = new DatabaseIO( container );
-			db.verifyInitialDataInContainer( user, password );
-		} finally {
+        try (GenericContainer container = makeContainer(TestSettings.IMAGE_ID)) {
+            container.withCreateContainerCmdModifier((Consumer<CreateContainerCmd>) cmd -> cmd.getHostConfig()
+                    .withBinds(
+                            Bind.parse("upgrade-conf-" + id + ":/conf"),
+                            Bind.parse("upgrade-data-" + id + ":/data"),
+                            Bind.parse("upgrade-import-" + id + ":/import"),
+                            Bind.parse("upgrade-logs-" + id + ":/logs"),
+                            Bind.parse("upgrade-metrics-" + id + ":/metrics"),
+                            Bind.parse("upgrade-plugins-" + id + ":/plugins")));
+            container.withEnv("NEO4J_dbms_allow__upgrade", "true");
+            container.start();
+            DatabaseIO db = new DatabaseIO(container);
+            db.verifyInitialDataInContainer(user, password);
+        } finally {
             cleanupVolumes(id);
         }
-	}
+    }
 
-	private static DockerImageName getUpgradeFromImage( Neo4jVersion ver)
-	{
-		if(TestSettings.EDITION == TestSettings.Edition.ENTERPRISE)
-		{
-			return DockerImageName.parse("neo4j:" + ver.toString() + "-enterprise");
-		}
-		else
-		{
-			return DockerImageName.parse("neo4j:" + ver.toString());
-		}
-	}
+    private static DockerImageName getUpgradeFromImage(Neo4jVersion ver) {
+        if (TestSettings.EDITION == TestSettings.Edition.ENTERPRISE) {
+            return DockerImageName.parse("neo4j:" + ver.toString() + "-enterprise");
+        } else {
+            return DockerImageName.parse("neo4j:" + ver.toString());
+        }
+    }
 
-	private static void cleanupVolumes(String id){
-		DockerClient client = DockerClientFactory.instance().client();
-		client.removeVolumeCmd( "upgrade-conf-"+id ).exec();
-		client.removeVolumeCmd( "upgrade-data-"+id ).exec();
-		client.removeVolumeCmd( "upgrade-import-"+id ).exec();
-		client.removeVolumeCmd( "upgrade-logs-"+id ).exec();
-		client.removeVolumeCmd( "upgrade-metrics-"+id ).exec();
-		client.removeVolumeCmd( "upgrade-plugins-"+id ).exec();
-	}
+    private static void cleanupVolumes(String id) {
+        DockerClient client = DockerClientFactory.instance().client();
+        client.removeVolumeCmd("upgrade-conf-" + id).exec();
+        client.removeVolumeCmd("upgrade-data-" + id).exec();
+        client.removeVolumeCmd("upgrade-import-" + id).exec();
+        client.removeVolumeCmd("upgrade-logs-" + id).exec();
+        client.removeVolumeCmd("upgrade-metrics-" + id).exec();
+        client.removeVolumeCmd("upgrade-plugins-" + id).exec();
+    }
 }

--- a/src/test/java/com/neo4j/docker/coredb/configurations/Configuration.java
+++ b/src/test/java/com/neo4j/docker/coredb/configurations/Configuration.java
@@ -2,98 +2,94 @@ package com.neo4j.docker.coredb.configurations;
 
 import com.neo4j.docker.utils.Neo4jVersion;
 import com.neo4j.docker.utils.TestSettings;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.EnumMap;
 import java.util.Map;
 
-public class Configuration
-{
-    private static Map<Setting,Configuration> CONFIGURATIONS_5X = new EnumMap<Setting,Configuration>( Setting.class ) {{
-        put( Setting.APOC_EXPORT_FILE_ENABLED, new Configuration( "apoc.export.file.enabled"));
-        put( Setting.BACKUP_ENABLED, new Configuration("server.backup.enabled"));
-        put( Setting.BACKUP_LISTEN_ADDRESS, new Configuration("server.backup.listen_address"));
-        put( Setting.BROWSER_ALLOW_OUTGOING_CONNECTIONS, new Configuration("browser.allow_outgoing_connections"));
-        put( Setting.CLUSTER_RAFT_ADDRESS, new Configuration("server.cluster.raft.advertised_address"));
-        put( Setting.CLUSTER_ROUTING_ADDRESS, new Configuration("server.routing.advertised_address"));
-        put( Setting.CLUSTER_TRANSACTION_ADDRESS, new Configuration("server.cluster.advertised_address"));
-        put( Setting.DEFAULT_LISTEN_ADDRESS, new Configuration("server.default_listen_address"));
-        put( Setting.DIRECTORIES_DATA, new Configuration("server.directories.data"));
-        put( Setting.DIRECTORIES_LOGS, new Configuration("server.directories.logs"));
-        put( Setting.DIRECTORIES_METRICS, new Configuration("server.directories.metrics"));
-        put( Setting.JVM_ADDITIONAL, new Configuration("server.jvm.additional"));
-        put( Setting.LOGS_GC_ROTATION_KEEPNUMBER, new Configuration( "server.logs.gc.rotation.keep_number"));
-        put( Setting.MEMORY_HEAP_INITIALSIZE, new Configuration("server.memory.heap.initial_size"));
-        put( Setting.MEMORY_HEAP_MAXSIZE, new Configuration( "server.memory.heap.max_size"));
-        put( Setting.MEMORY_PAGECACHE_SIZE, new Configuration("server.memory.pagecache.size"));
-        put( Setting.MINIMUM_PASSWORD_LENGTH, new Configuration("dbms.security.auth_minimum_password_length"));
-        put( Setting.SECURITY_PROCEDURES_UNRESTRICTED, new Configuration("dbms.security.procedures.unrestricted"));
-        put( Setting.TXLOG_RETENTION_POLICY, new Configuration("db.tx_log.rotation.retention_policy"));
-    }};
+public class Configuration {
+    private static Map<Setting, Configuration> CONFIGURATIONS_5X = new EnumMap<Setting, Configuration>(Setting.class) {
+        {
+            put(Setting.APOC_EXPORT_FILE_ENABLED, new Configuration("apoc.export.file.enabled"));
+            put(Setting.BACKUP_ENABLED, new Configuration("server.backup.enabled"));
+            put(Setting.BACKUP_LISTEN_ADDRESS, new Configuration("server.backup.listen_address"));
+            put(Setting.BROWSER_ALLOW_OUTGOING_CONNECTIONS, new Configuration("browser.allow_outgoing_connections"));
+            put(Setting.CLUSTER_RAFT_ADDRESS, new Configuration("server.cluster.raft.advertised_address"));
+            put(Setting.CLUSTER_ROUTING_ADDRESS, new Configuration("server.routing.advertised_address"));
+            put(Setting.CLUSTER_TRANSACTION_ADDRESS, new Configuration("server.cluster.advertised_address"));
+            put(Setting.DEFAULT_LISTEN_ADDRESS, new Configuration("server.default_listen_address"));
+            put(Setting.DIRECTORIES_DATA, new Configuration("server.directories.data"));
+            put(Setting.DIRECTORIES_LOGS, new Configuration("server.directories.logs"));
+            put(Setting.DIRECTORIES_METRICS, new Configuration("server.directories.metrics"));
+            put(Setting.JVM_ADDITIONAL, new Configuration("server.jvm.additional"));
+            put(Setting.LOGS_GC_ROTATION_KEEPNUMBER, new Configuration("server.logs.gc.rotation.keep_number"));
+            put(Setting.MEMORY_HEAP_INITIALSIZE, new Configuration("server.memory.heap.initial_size"));
+            put(Setting.MEMORY_HEAP_MAXSIZE, new Configuration("server.memory.heap.max_size"));
+            put(Setting.MEMORY_PAGECACHE_SIZE, new Configuration("server.memory.pagecache.size"));
+            put(Setting.MINIMUM_PASSWORD_LENGTH, new Configuration("dbms.security.auth_minimum_password_length"));
+            put(Setting.SECURITY_PROCEDURES_UNRESTRICTED, new Configuration("dbms.security.procedures.unrestricted"));
+            put(Setting.TXLOG_RETENTION_POLICY, new Configuration("db.tx_log.rotation.retention_policy"));
+        }
+    };
 
-    private static Map<Setting,Configuration> CONFIGURATIONS_4X = new EnumMap<Setting,Configuration>( Setting.class ) {{
-        put( Setting.APOC_EXPORT_FILE_ENABLED, new Configuration( "apoc.export.file.enabled"));
-        put( Setting.BACKUP_ENABLED, new Configuration("dbms.backup.enabled"));
-        put( Setting.BACKUP_LISTEN_ADDRESS, new Configuration("dbms.backup.listen_address"));
-        put( Setting.BROWSER_ALLOW_OUTGOING_CONNECTIONS, new Configuration("browser.allow_outgoing_connections"));
-        put( Setting.CLUSTER_DISCOVERY_ADDRESS, new Configuration("causal_clustering.discovery_advertised_address"));
-        put( Setting.CLUSTER_RAFT_ADDRESS, new Configuration("causal_clustering.raft_advertised_address"));
-        put( Setting.CLUSTER_ROUTING_ADDRESS, new Configuration("dbms.routing.advertised_address"));
-        put( Setting.CLUSTER_TRANSACTION_ADDRESS, new Configuration("causal_clustering.transaction_advertised_address"));
-        put( Setting.DEFAULT_LISTEN_ADDRESS, new Configuration("dbms.default_listen_address"));
-        put( Setting.DIRECTORIES_DATA, new Configuration("dbms.directories.data"));
-        put( Setting.DIRECTORIES_LOGS, new Configuration("dbms.directories.logs"));
-        put( Setting.DIRECTORIES_METRICS, new Configuration("dbms.directories.metrics"));
-        put( Setting.JVM_ADDITIONAL, new Configuration("dbms.jvm.additional"));
-        put( Setting.LOGS_GC_ROTATION_KEEPNUMBER, new Configuration( "dbms.logs.gc.rotation.keep_number"));
-        put( Setting.MEMORY_HEAP_INITIALSIZE, new Configuration("dbms.memory.heap.initial_size"));
-        put( Setting.MEMORY_HEAP_MAXSIZE, new Configuration("dbms.memory.heap.max_size"));
-        put( Setting.MEMORY_PAGECACHE_SIZE, new Configuration("dbms.memory.pagecache.size"));
-        put( Setting.SECURITY_PROCEDURES_UNRESTRICTED, new Configuration("dbms.security.procedures.unrestricted"));
-        put( Setting.TXLOG_RETENTION_POLICY, new Configuration("dbms.tx_log.rotation.retention_policy"));
-    }};
-    public static Map<Setting,Configuration> getConfigurationNameMap()
-    {
-        return getConfigurationNameMap( TestSettings.NEO4J_VERSION );
+    private static Map<Setting, Configuration> CONFIGURATIONS_4X = new EnumMap<Setting, Configuration>(Setting.class) {
+        {
+            put(Setting.APOC_EXPORT_FILE_ENABLED, new Configuration("apoc.export.file.enabled"));
+            put(Setting.BACKUP_ENABLED, new Configuration("dbms.backup.enabled"));
+            put(Setting.BACKUP_LISTEN_ADDRESS, new Configuration("dbms.backup.listen_address"));
+            put(Setting.BROWSER_ALLOW_OUTGOING_CONNECTIONS, new Configuration("browser.allow_outgoing_connections"));
+            put(Setting.CLUSTER_DISCOVERY_ADDRESS, new Configuration("causal_clustering.discovery_advertised_address"));
+            put(Setting.CLUSTER_RAFT_ADDRESS, new Configuration("causal_clustering.raft_advertised_address"));
+            put(Setting.CLUSTER_ROUTING_ADDRESS, new Configuration("dbms.routing.advertised_address"));
+            put(
+                    Setting.CLUSTER_TRANSACTION_ADDRESS,
+                    new Configuration("causal_clustering.transaction_advertised_address"));
+            put(Setting.DEFAULT_LISTEN_ADDRESS, new Configuration("dbms.default_listen_address"));
+            put(Setting.DIRECTORIES_DATA, new Configuration("dbms.directories.data"));
+            put(Setting.DIRECTORIES_LOGS, new Configuration("dbms.directories.logs"));
+            put(Setting.DIRECTORIES_METRICS, new Configuration("dbms.directories.metrics"));
+            put(Setting.JVM_ADDITIONAL, new Configuration("dbms.jvm.additional"));
+            put(Setting.LOGS_GC_ROTATION_KEEPNUMBER, new Configuration("dbms.logs.gc.rotation.keep_number"));
+            put(Setting.MEMORY_HEAP_INITIALSIZE, new Configuration("dbms.memory.heap.initial_size"));
+            put(Setting.MEMORY_HEAP_MAXSIZE, new Configuration("dbms.memory.heap.max_size"));
+            put(Setting.MEMORY_PAGECACHE_SIZE, new Configuration("dbms.memory.pagecache.size"));
+            put(Setting.SECURITY_PROCEDURES_UNRESTRICTED, new Configuration("dbms.security.procedures.unrestricted"));
+            put(Setting.TXLOG_RETENTION_POLICY, new Configuration("dbms.tx_log.rotation.retention_policy"));
+        }
+    };
+
+    public static Map<Setting, Configuration> getConfigurationNameMap() {
+        return getConfigurationNameMap(TestSettings.NEO4J_VERSION);
     }
 
-    public static Map<Setting,Configuration> getConfigurationNameMap( Neo4jVersion version )
-    {
-        switch ( version.major )
-        {
-        case 3:
-            EnumMap<Setting,Configuration> out = new EnumMap<Setting,Configuration>( CONFIGURATIONS_4X );
-            out.put( Setting.DEFAULT_LISTEN_ADDRESS, new Configuration( "dbms.connectors.default_listen_address" ) );
-            return out;
-        case 4:
-            return CONFIGURATIONS_4X;
-        default:
-            return CONFIGURATIONS_5X;
+    public static Map<Setting, Configuration> getConfigurationNameMap(Neo4jVersion version) {
+        switch (version.major) {
+            case 3:
+                EnumMap<Setting, Configuration> out = new EnumMap<Setting, Configuration>(CONFIGURATIONS_4X);
+                out.put(Setting.DEFAULT_LISTEN_ADDRESS, new Configuration("dbms.connectors.default_listen_address"));
+                return out;
+            case 4:
+                return CONFIGURATIONS_4X;
+            default:
+                return CONFIGURATIONS_5X;
         }
     }
-    public static Path getConfigurationResourcesFolder()
-    {
+
+    public static Path getConfigurationResourcesFolder() {
         return getConfigurationResourcesFolder(TestSettings.NEO4J_VERSION);
     }
 
-    public static Path getConfigurationResourcesFolder( Neo4jVersion version )
-    {
-        if(version.isAtLeastVersion( Neo4jVersion.NEO4J_VERSION_500 ))
-        {
-        return Paths.get("src", "test", "resources", "confs");
-        }
-        else return Paths.get( "src", "test", "resources", "confs", "before50");
+    public static Path getConfigurationResourcesFolder(Neo4jVersion version) {
+        if (version.isAtLeastVersion(Neo4jVersion.NEO4J_VERSION_500)) {
+            return Paths.get("src", "test", "resources", "confs");
+        } else return Paths.get("src", "test", "resources", "confs", "before50");
     }
 
     public String name;
     public String envName;
 
-    private Configuration( String name )
-    {
+    private Configuration(String name) {
         this.name = name;
-        this.envName = "NEO4J_" + name.replace( '_', '-' )
-                                      .replace( '.', '_')
-                                      .replace( "-", "__" );
+        this.envName = "NEO4J_" + name.replace('_', '-').replace('.', '_').replace("-", "__");
     }
 }

--- a/src/test/java/com/neo4j/docker/coredb/configurations/Setting.java
+++ b/src/test/java/com/neo4j/docker/coredb/configurations/Setting.java
@@ -1,7 +1,6 @@
 package com.neo4j.docker.coredb.configurations;
 
-public enum Setting
-{
+public enum Setting {
     APOC_EXPORT_FILE_ENABLED,
     BACKUP_ENABLED,
     BACKUP_LISTEN_ADDRESS,

--- a/src/test/java/com/neo4j/docker/coredb/configurations/TestConfSettings.java
+++ b/src/test/java/com/neo4j/docker/coredb/configurations/TestConfSettings.java
@@ -7,6 +7,16 @@ import com.neo4j.docker.utils.SetContainerUser;
 import com.neo4j.docker.utils.TemporaryFolderManager;
 import com.neo4j.docker.utils.TestSettings;
 import com.neo4j.docker.utils.WaitStrategies;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
@@ -21,36 +31,23 @@ import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.Duration;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Scanner;
-import java.util.stream.Stream;
-
-public class TestConfSettings
-{
+public class TestConfSettings {
     private static final String PASSWORD = "none";
     private static final String AUTH = "none"; // or "neo4j/"+PASSWORD if we want authentication
     private final Logger log = LoggerFactory.getLogger(TestConfSettings.class);
     private static Path confFolder;
-    private static Map<Setting,Configuration> confNames;
+    private static Map<Setting, Configuration> confNames;
+
     @RegisterExtension
     public static TemporaryFolderManager temporaryFolderManager = new TemporaryFolderManager();
 
     @BeforeAll
-    static void getVersionSpecificConfigurationSettings()
-    {
+    static void getVersionSpecificConfigurationSettings() {
         confFolder = Configuration.getConfigurationResourcesFolder();
         confNames = Configuration.getConfigurationNameMap();
     }
 
-    private GenericContainer createContainer()
-    {
+    private GenericContainer createContainer() {
         return new GenericContainer(TestSettings.IMAGE_ID)
                 .withEnv("NEO4J_AUTH", AUTH)
                 .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
@@ -58,459 +55,439 @@ public class TestConfSettings
                 .withLogConsumer(new Slf4jLogConsumer(log));
     }
 
-    private GenericContainer makeContainerDumpConfig(GenericContainer container)
-    {
-        SetContainerUser.nonRootUser( container );
+    private GenericContainer makeContainerDumpConfig(GenericContainer container) {
+        SetContainerUser.nonRootUser(container);
         container.setCommand("dump-config");
         WaitStrategies.waitUntilContainerFinished(container, Duration.ofSeconds(30));
         return container;
     }
 
-    private Map<String, String> parseConfFile(File conf) throws FileNotFoundException
-    {
+    private Map<String, String> parseConfFile(File conf) throws FileNotFoundException {
         Map<String, String> configurations = new HashMap<>();
         Scanner scanner = new Scanner(conf);
-        while ( scanner.hasNextLine() )
-        {
-            String[] params = scanner.nextLine().split( "=", 2 );
-            if(params.length < 2)
-            {
+        while (scanner.hasNextLine()) {
+            String[] params = scanner.nextLine().split("=", 2);
+            if (params.length < 2) {
                 continue;
             }
-            log.debug( params[0] + "\t:\t" + params[1] );
-            configurations.put( params[0], params[1] );
+            log.debug(params[0] + "\t:\t" + params[1]);
+            configurations.put(params[0], params[1]);
         }
         return configurations;
     }
 
-    private void assertConfigurationPresentInDebugLog( Path debugLog, Configuration setting, String value, boolean shouldBeFound ) throws IOException
-    {
+    private void assertConfigurationPresentInDebugLog(
+            Path debugLog, Configuration setting, String value, boolean shouldBeFound) throws IOException {
         // searches the debug log for the given string, returns true if present
         Stream<String> lines = Files.lines(debugLog);
-        String actualSetting = lines.filter(s -> s.contains( setting.name ))
-                                    .findFirst()
-                                    .orElse( "" );
+        String actualSetting =
+                lines.filter(s -> s.contains(setting.name)).findFirst().orElse("");
         lines.close();
-        if(shouldBeFound)
-        {
-            Assertions.assertTrue( !actualSetting.isEmpty(), setting.name+" was never set" );
-            Assertions.assertTrue( actualSetting.contains( value ),
-                                   setting.name +" is set to the wrong value. Expected: "+
-                                   value +" Actual: " + actualSetting );
-        }
-        else
-        {
-            Assertions.assertTrue( actualSetting.isEmpty(),setting.name+" was set when it should not have been. " +
-                                                           "Actual value: "+actualSetting );
+        if (shouldBeFound) {
+            Assertions.assertTrue(!actualSetting.isEmpty(), setting.name + " was never set");
+            Assertions.assertTrue(
+                    actualSetting.contains(value),
+                    setting.name + " is set to the wrong value. Expected: " + value + " Actual: " + actualSetting);
+        } else {
+            Assertions.assertTrue(
+                    actualSetting.isEmpty(),
+                    setting.name + " was set when it should not have been. " + "Actual value: " + actualSetting);
         }
     }
 
     @Test
-    void testIgnoreNumericVars()
-    {
-        try(GenericContainer container = createContainer())
-        {
-            container.withEnv( "NEO4J_1a", "1" )
-                     .waitingFor( WaitStrategies.waitForBoltReady() );
+    void testIgnoreNumericVars() {
+        try (GenericContainer container = createContainer()) {
+            container.withEnv("NEO4J_1a", "1").waitingFor(WaitStrategies.waitForBoltReady());
             container.start();
-            Assertions.assertTrue( container.isRunning() );
-            String errorLogs = container.getLogs( OutputFrame.OutputType.STDERR);
-            Assertions.assertTrue( errorLogs.contains( "WARNING: 1a not written to conf file. Settings that start with a number are not permitted" ),
-                                   "Neo4j did not warn about invalid numeric config variable `Neo4j_1a`.\n" +
-                                   "Actual warnings were:\n"+errorLogs);
-		}
-	}
+            Assertions.assertTrue(container.isRunning());
+            String errorLogs = container.getLogs(OutputFrame.OutputType.STDERR);
+            Assertions.assertTrue(
+                    errorLogs.contains(
+                            "WARNING: 1a not written to conf file. Settings that start with a number are not permitted"),
+                    "Neo4j did not warn about invalid numeric config variable `Neo4j_1a`.\n" + "Actual warnings were:\n"
+                            + errorLogs);
+        }
+    }
 
     @Test
-    void testEnvVarsOverrideDefaultConfigurations() throws Exception
-    {
-        Assumptions.assumeTrue(TestSettings.NEO4J_VERSION.isAtLeastVersion(new Neo4jVersion(3, 0, 0)),
-                               "No neo4j-admin in 2.3: skipping neo4j-admin-conf-override test");
+    void testEnvVarsOverrideDefaultConfigurations() throws Exception {
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isAtLeastVersion(new Neo4jVersion(3, 0, 0)),
+                "No neo4j-admin in 2.3: skipping neo4j-admin-conf-override test");
         File conf;
-        Map<Setting,String> expectedValues = new HashMap<Setting,String>() {{
-                put( Setting.MEMORY_PAGECACHE_SIZE, "1000m");
-                put( Setting.MEMORY_HEAP_INITIALSIZE, "2000m");
-                put( Setting.MEMORY_HEAP_MAXSIZE, "3000m");
-                put( Setting.DIRECTORIES_LOGS, "/notdefaultlogs" );
-                put( Setting.DIRECTORIES_DATA, "/notdefaultdata" );
-        }};
-
-        try(GenericContainer container = createContainer())
-        {
-            for(Setting s : expectedValues.keySet())
+        Map<Setting, String> expectedValues = new HashMap<Setting, String>() {
             {
-                container.withEnv( confNames.get( s ).envName, expectedValues.get( s ) );
+                put(Setting.MEMORY_PAGECACHE_SIZE, "1000m");
+                put(Setting.MEMORY_HEAP_INITIALSIZE, "2000m");
+                put(Setting.MEMORY_HEAP_MAXSIZE, "3000m");
+                put(Setting.DIRECTORIES_LOGS, "/notdefaultlogs");
+                put(Setting.DIRECTORIES_DATA, "/notdefaultdata");
+            }
+        };
+
+        try (GenericContainer container = createContainer()) {
+            for (Setting s : expectedValues.keySet()) {
+                container.withEnv(confNames.get(s).envName, expectedValues.get(s));
             }
             Path confMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/conf");
-            conf = confMount.resolve( "neo4j.conf" ).toFile();
-            makeContainerDumpConfig( container );
+            conf = confMount.resolve("neo4j.conf").toFile();
+            makeContainerDumpConfig(container);
             container.start();
         }
 
         // now check the settings we set via env are in the new conf file
-        Assertions.assertTrue( conf.exists(), "configuration file not written" );
-        Assertions.assertTrue( conf.canRead(), "configuration file not readable for some reason?" );
+        Assertions.assertTrue(conf.exists(), "configuration file not written");
+        Assertions.assertTrue(conf.canRead(), "configuration file not readable for some reason?");
 
-        Map<String,String> configurations = parseConfFile( conf );
-        for(Setting s : expectedValues.keySet())
-        {
-            Assertions.assertTrue( configurations.containsKey( confNames.get( s ).name ),
-                               confNames.get( s ).name + " not set at all" );
-            Assertions.assertEquals( expectedValues.get( s ),
-                                 configurations.get( confNames.get( s ).name ),
-                                 confNames.get( s ).name + " not overridden" );
+        Map<String, String> configurations = parseConfFile(conf);
+        for (Setting s : expectedValues.keySet()) {
+            Assertions.assertTrue(
+                    configurations.containsKey(confNames.get(s).name), confNames.get(s).name + " not set at all");
+            Assertions.assertEquals(
+                    expectedValues.get(s),
+                    configurations.get(confNames.get(s).name),
+                    confNames.get(s).name + " not overridden");
         }
     }
 
     @Test
-    void testReadsTheConfFile() throws Exception
-    {
+    void testReadsTheConfFile() throws Exception {
         Path debugLog;
 
-        try(GenericContainer container = createContainer().waitingFor(WaitStrategies.waitForNeo4jReady(PASSWORD)))
-        {
-            //Mount /conf
+        try (GenericContainer container = createContainer().waitingFor(WaitStrategies.waitForNeo4jReady(PASSWORD))) {
+            // Mount /conf
             Path confMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/conf");
             Path logMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/logs");
             debugLog = logMount.resolve("debug.log");
-            SetContainerUser.nonRootUser( container );
-            //Create ReadConf.conf file with the custom env variables
-            Path confFile = confFolder.resolve( "ReadConf.conf" );
-            Files.copy( confFile, confMount.resolve( "neo4j.conf" ) );
-            //Start the container
+            SetContainerUser.nonRootUser(container);
+            // Create ReadConf.conf file with the custom env variables
+            Path confFile = confFolder.resolve("ReadConf.conf");
+            Files.copy(confFile, confMount.resolve("neo4j.conf"));
+            // Start the container
             container.start();
         }
 
-        //Check if the container reads the conf file
-        assertConfigurationPresentInDebugLog( debugLog, confNames.get( Setting.MEMORY_HEAP_MAXSIZE ),
-                                              "512", true );
+        // Check if the container reads the conf file
+        assertConfigurationPresentInDebugLog(debugLog, confNames.get(Setting.MEMORY_HEAP_MAXSIZE), "512", true);
     }
 
     @Test
-    void testDefaultsConfigsAreSet() throws Exception
-    {
-        try(GenericContainer container = createContainer().waitingFor(WaitStrategies.waitForNeo4jReady(PASSWORD)))
-        {
-            //Mount /logs
+    void testDefaultsConfigsAreSet() throws Exception {
+        try (GenericContainer container = createContainer().waitingFor(WaitStrategies.waitForNeo4jReady(PASSWORD))) {
+            // Mount /logs
             Path logMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/logs");
-            SetContainerUser.nonRootUser( container );
-            //Start the container
+            SetContainerUser.nonRootUser(container);
+            // Start the container
             container.start();
-            DatabaseIO dbio = new DatabaseIO( container );
-            Path debugLog = logMount.resolve( "debug.log" );
+            DatabaseIO dbio = new DatabaseIO(container);
+            Path debugLog = logMount.resolve("debug.log");
 
             String expectedDefaultListenAddress = "0.0.0.0";
-            dbio.verifyConfigurationSetting("neo4j", PASSWORD, confNames.get( Setting.DEFAULT_LISTEN_ADDRESS), expectedDefaultListenAddress);
-            assertConfigurationPresentInDebugLog(debugLog, confNames.get( Setting.DEFAULT_LISTEN_ADDRESS), expectedDefaultListenAddress, true);
+            dbio.verifyConfigurationSetting(
+                    "neo4j", PASSWORD, confNames.get(Setting.DEFAULT_LISTEN_ADDRESS), expectedDefaultListenAddress);
+            assertConfigurationPresentInDebugLog(
+                    debugLog, confNames.get(Setting.DEFAULT_LISTEN_ADDRESS), expectedDefaultListenAddress, true);
             // test enterprise only default configurations are set
             if (TestSettings.EDITION == TestSettings.Edition.ENTERPRISE) {
                 String expectedTxAddress = container.getContainerId().substring(0, 12) + ":6000";
                 String expectedRaftAddress = container.getContainerId().substring(0, 12) + ":7000";
                 String expectedRoutingAddress = container.getContainerId().substring(0, 12) + ":7688";
-                dbio.verifyConfigurationSetting("neo4j", PASSWORD, confNames.get( Setting.CLUSTER_TRANSACTION_ADDRESS), expectedTxAddress);
-                assertConfigurationPresentInDebugLog(debugLog, confNames.get( Setting.CLUSTER_TRANSACTION_ADDRESS), expectedTxAddress,true);
-                dbio.verifyConfigurationSetting("neo4j", PASSWORD, confNames.get( Setting.CLUSTER_RAFT_ADDRESS), expectedRaftAddress);
-                assertConfigurationPresentInDebugLog(debugLog, confNames.get( Setting.CLUSTER_RAFT_ADDRESS), expectedRaftAddress,true);
-                dbio.verifyConfigurationSetting("neo4j", PASSWORD, confNames.get( Setting.CLUSTER_ROUTING_ADDRESS), expectedRoutingAddress);
-                assertConfigurationPresentInDebugLog(debugLog, confNames.get( Setting.CLUSTER_ROUTING_ADDRESS), expectedRoutingAddress,true);
+                dbio.verifyConfigurationSetting(
+                        "neo4j", PASSWORD, confNames.get(Setting.CLUSTER_TRANSACTION_ADDRESS), expectedTxAddress);
+                assertConfigurationPresentInDebugLog(
+                        debugLog, confNames.get(Setting.CLUSTER_TRANSACTION_ADDRESS), expectedTxAddress, true);
+                dbio.verifyConfigurationSetting(
+                        "neo4j", PASSWORD, confNames.get(Setting.CLUSTER_RAFT_ADDRESS), expectedRaftAddress);
+                assertConfigurationPresentInDebugLog(
+                        debugLog, confNames.get(Setting.CLUSTER_RAFT_ADDRESS), expectedRaftAddress, true);
+                dbio.verifyConfigurationSetting(
+                        "neo4j", PASSWORD, confNames.get(Setting.CLUSTER_ROUTING_ADDRESS), expectedRoutingAddress);
+                assertConfigurationPresentInDebugLog(
+                        debugLog, confNames.get(Setting.CLUSTER_ROUTING_ADDRESS), expectedRoutingAddress, true);
             }
         }
     }
 
     @Test
-    void testCommentedConfigsAreReplacedByDefaultOnes() throws Exception
-    {
+    void testCommentedConfigsAreReplacedByDefaultOnes() throws Exception {
         File conf;
-        try(GenericContainer container = createContainer())
-        {
-            //Mount /conf
+        try (GenericContainer container = createContainer()) {
+            // Mount /conf
             Path confMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/conf");
-            conf = confMount.resolve( "neo4j.conf" ).toFile();
-            SetContainerUser.nonRootUser( container );
-            //Create ConfsReplaced.conf file in mounted folder
-            Files.copy( confFolder.resolve( "ConfsReplaced.conf" ), conf.toPath() );
-            makeContainerDumpConfig( container );
-            //Start the container
+            conf = confMount.resolve("neo4j.conf").toFile();
+            SetContainerUser.nonRootUser(container);
+            // Create ConfsReplaced.conf file in mounted folder
+            Files.copy(confFolder.resolve("ConfsReplaced.conf"), conf.toPath());
+            makeContainerDumpConfig(container);
+            // Start the container
             container.start();
         }
-        //Read the config file to check if the config is set correctly
-        Map<String,String> configurations = parseConfFile( conf );
-        Assertions.assertTrue( configurations.containsKey( confNames.get( Setting.MEMORY_PAGECACHE_SIZE ).name ),
-                               "conf settings not set correctly by docker-entrypoint" );
-        Assertions.assertEquals( "512M",
-                                 configurations.get(confNames.get( Setting.MEMORY_PAGECACHE_SIZE ).name),
-                                 "conf settings not appended correctly by docker-entrypoint" );
-    }
-
-    @Test
-    void testConfFileNotOverridenByDockerEntrypoint() throws Exception
-    {
-        File conf;
-        try(GenericContainer container = createContainer())
-        {
-            //Mount /conf
-            Path confMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/conf");
-            conf = confMount.resolve( "neo4j.conf" ).toFile();
-            SetContainerUser.nonRootUser( container );
-            //Create ConfsNotOverridden.conf file
-            Path confFile = confFolder.resolve( "ConfsNotOverridden.conf" );
-            Files.copy( confFile, confMount.resolve( "neo4j.conf" ) );
-            makeContainerDumpConfig( container );
-            container.start();
-        }
-
-        //Read the config file to check if the config is not overriden
+        // Read the config file to check if the config is set correctly
         Map<String, String> configurations = parseConfFile(conf);
-        Assertions.assertTrue(configurations.containsKey(confNames.get( Setting.MEMORY_PAGECACHE_SIZE).name),
-                              "conf settings not set correctly by docker-entrypoint");
-        Assertions.assertEquals("1024M",
-                                configurations.get(confNames.get( Setting.MEMORY_PAGECACHE_SIZE).name),
-                                "docker-entrypoint has overridden custom setting set from user's conf");
+        Assertions.assertTrue(
+                configurations.containsKey(confNames.get(Setting.MEMORY_PAGECACHE_SIZE).name),
+                "conf settings not set correctly by docker-entrypoint");
+        Assertions.assertEquals(
+                "512M",
+                configurations.get(confNames.get(Setting.MEMORY_PAGECACHE_SIZE).name),
+                "conf settings not appended correctly by docker-entrypoint");
     }
 
     @Test
-    void testOldConfigNamesNotOverwrittenByDockerDefaults() throws Exception
-    {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( Neo4jVersion.NEO4J_VERSION_500),
-                                "test only applicable after 5.0." );
-        // at some point we will fully deprecate old config names, at which point we add an assume-version-less-than here
-        Path logMount;
-        Map<Setting,Configuration> oldConfMap = Configuration.getConfigurationNameMap( new Neo4jVersion( 4, 4, 0 ) );
-        Map<Setting,String> expectedValues = new HashMap<Setting,String>() {{
-            put( Setting.TXLOG_RETENTION_POLICY, "5M size" );
-            put( Setting.MEMORY_PAGECACHE_SIZE, "100.00KiB" );
-            put( Setting.DEFAULT_LISTEN_ADDRESS, "127.0.0.1" );
-        }};
-        if( TestSettings.EDITION == TestSettings.Edition.ENTERPRISE)
-        {
-            expectedValues.put( Setting.CLUSTER_TRANSACTION_ADDRESS, "1.2.3.4:8000" );
-            expectedValues.put( Setting.CLUSTER_RAFT_ADDRESS, "1.2.3.4:9000" );
+    void testConfFileNotOverridenByDockerEntrypoint() throws Exception {
+        File conf;
+        try (GenericContainer container = createContainer()) {
+            // Mount /conf
+            Path confMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/conf");
+            conf = confMount.resolve("neo4j.conf").toFile();
+            SetContainerUser.nonRootUser(container);
+            // Create ConfsNotOverridden.conf file
+            Path confFile = confFolder.resolve("ConfsNotOverridden.conf");
+            Files.copy(confFile, confMount.resolve("neo4j.conf"));
+            makeContainerDumpConfig(container);
+            container.start();
         }
 
-        try(GenericContainer container = createContainer())
-        {
-            logMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/logs");
-            SetContainerUser.nonRootUser( container );
-            // set configurations using old config names
-            for( Setting s : expectedValues.keySet() )
+        // Read the config file to check if the config is not overriden
+        Map<String, String> configurations = parseConfFile(conf);
+        Assertions.assertTrue(
+                configurations.containsKey(confNames.get(Setting.MEMORY_PAGECACHE_SIZE).name),
+                "conf settings not set correctly by docker-entrypoint");
+        Assertions.assertEquals(
+                "1024M",
+                configurations.get(confNames.get(Setting.MEMORY_PAGECACHE_SIZE).name),
+                "docker-entrypoint has overridden custom setting set from user's conf");
+    }
+
+    @Test
+    void testOldConfigNamesNotOverwrittenByDockerDefaults() throws Exception {
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isAtLeastVersion(Neo4jVersion.NEO4J_VERSION_500),
+                "test only applicable after 5.0.");
+        // at some point we will fully deprecate old config names, at which point we add an assume-version-less-than
+        // here
+        Path logMount;
+        Map<Setting, Configuration> oldConfMap = Configuration.getConfigurationNameMap(new Neo4jVersion(4, 4, 0));
+        Map<Setting, String> expectedValues = new HashMap<Setting, String>() {
             {
-                container.withEnv( oldConfMap.get( s ).envName, expectedValues.get( s ) );
+                put(Setting.TXLOG_RETENTION_POLICY, "5M size");
+                put(Setting.MEMORY_PAGECACHE_SIZE, "100.00KiB");
+                put(Setting.DEFAULT_LISTEN_ADDRESS, "127.0.0.1");
+            }
+        };
+        if (TestSettings.EDITION == TestSettings.Edition.ENTERPRISE) {
+            expectedValues.put(Setting.CLUSTER_TRANSACTION_ADDRESS, "1.2.3.4:8000");
+            expectedValues.put(Setting.CLUSTER_RAFT_ADDRESS, "1.2.3.4:9000");
+        }
+
+        try (GenericContainer container = createContainer()) {
+            logMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/logs");
+            SetContainerUser.nonRootUser(container);
+            // set configurations using old config names
+            for (Setting s : expectedValues.keySet()) {
+                container.withEnv(oldConfMap.get(s).envName, expectedValues.get(s));
             }
             // the container probably won't start nicely because the clustering settings are ivalid.
-            // However we only care that the configs were read properly, so we can kill as soon as neo4j logs that it started.
-            container.waitingFor( new LogMessageWaitStrategy()
-                                          .withRegEx( ".*Remote interface available at http://localhost:7474/.*" )
-                                          .withStartupTimeout( Duration.ofSeconds( 60 ) ));
+            // However we only care that the configs were read properly, so we can kill as soon as neo4j logs that it
+            // started.
+            container.waitingFor(new LogMessageWaitStrategy()
+                    .withRegEx(".*Remote interface available at http://localhost:7474/.*")
+                    .withStartupTimeout(Duration.ofSeconds(60)));
             container.start();
         }
-        for( Setting s : expectedValues.keySet() )
-        {
+        for (Setting s : expectedValues.keySet()) {
             // configuration should be present in debug log under new configuration name
-            assertConfigurationPresentInDebugLog(logMount.resolve( "debug.log" ),
-                                                 confNames.get( s ),
-                                                 expectedValues.get( s ),
-                                                 true );
+            assertConfigurationPresentInDebugLog(
+                    logMount.resolve("debug.log"), confNames.get(s), expectedValues.get(s), true);
         }
     }
 
     @Test
-    void testEnvVarsOverrideConfFile() throws Exception
-    {
-        Assumptions.assumeTrue(TestSettings.NEO4J_VERSION.isAtLeastVersion(new Neo4jVersion(4, 2, 0)),
-                               "test not applicable in versions before 4.2.");
+    void testEnvVarsOverrideConfFile() throws Exception {
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isAtLeastVersion(new Neo4jVersion(4, 2, 0)),
+                "test not applicable in versions before 4.2.");
         Path debugLog;
-        try(GenericContainer container = createContainer()
+        try (GenericContainer container = createContainer()
                 .withEnv(confNames.get(Setting.MEMORY_PAGECACHE_SIZE).envName, "512.00MiB")
-                .waitingFor(WaitStrategies.waitForNeo4jReady(PASSWORD)))
-        {
+                .waitingFor(WaitStrategies.waitForNeo4jReady(PASSWORD))) {
             Path confMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/conf");
             Path logMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/logs");
-            debugLog = logMount.resolve( "debug.log" );
-            SetContainerUser.nonRootUser( container );
-            //Create EnvVarsOverride.conf file
+            debugLog = logMount.resolve("debug.log");
+            SetContainerUser.nonRootUser(container);
+            // Create EnvVarsOverride.conf file
             Path confFile = confFolder.resolve("EnvVarsOverride.conf");
-            Files.copy( confFile, confMount.resolve( "neo4j.conf" ) );
-            //Start the container
+            Files.copy(confFile, confMount.resolve("neo4j.conf"));
+            // Start the container
             container.start();
         }
-        assertConfigurationPresentInDebugLog(debugLog, confNames.get(Setting.MEMORY_PAGECACHE_SIZE), "512.00MiB", true );
+        assertConfigurationPresentInDebugLog(debugLog, confNames.get(Setting.MEMORY_PAGECACHE_SIZE), "512.00MiB", true);
     }
 
     @Test
-    void testEnterpriseOnlyDefaultsDontOverrideConfFile() throws Exception
-    {
-        Assumptions.assumeTrue(TestSettings.EDITION == TestSettings.Edition.ENTERPRISE,
+    void testEnterpriseOnlyDefaultsDontOverrideConfFile() throws Exception {
+        Assumptions.assumeTrue(
+                TestSettings.EDITION == TestSettings.Edition.ENTERPRISE,
                 "This is testing only ENTERPRISE EDITION configs");
 
-        try(GenericContainer container = createContainer().waitingFor(WaitStrategies.waitForNeo4jReady(PASSWORD)))
-        {
+        try (GenericContainer container = createContainer().waitingFor(WaitStrategies.waitForNeo4jReady(PASSWORD))) {
             Path confMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/conf");
             Path logMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/logs");
             // mount a configuration file with enterprise only settings already set
-            Path confFile = confFolder.resolve( "EnterpriseOnlyNotOverwritten.conf" );
-            Files.copy( confFile, confMount.resolve( "neo4j.conf" ) );
+            Path confFile = confFolder.resolve("EnterpriseOnlyNotOverwritten.conf");
+            Files.copy(confFile, confMount.resolve("neo4j.conf"));
 
-            //Start the container
-            SetContainerUser.nonRootUser( container );
+            // Start the container
+            SetContainerUser.nonRootUser(container);
             container.start();
-            //Read debug.log to check that cluster confs are set successfully
-            assertConfigurationPresentInDebugLog( logMount.resolve( "debug.log" ),
-                                                  confNames.get( Setting.CLUSTER_TRANSACTION_ADDRESS ),
-                                                  "localhost:6060", true );
+            // Read debug.log to check that cluster confs are set successfully
+            assertConfigurationPresentInDebugLog(
+                    logMount.resolve("debug.log"),
+                    confNames.get(Setting.CLUSTER_TRANSACTION_ADDRESS),
+                    "localhost:6060",
+                    true);
         }
     }
 
     @Test
-    void testMountingMetricsFolderShouldNotSetConfInCommunity() throws Exception
-    {
-        Assumptions.assumeTrue( TestSettings.EDITION == TestSettings.Edition.COMMUNITY,
-                                "Test only valid with community edition");
+    void testMountingMetricsFolderShouldNotSetConfInCommunity() throws Exception {
+        Assumptions.assumeTrue(
+                TestSettings.EDITION == TestSettings.Edition.COMMUNITY, "Test only valid with community edition");
 
-        try ( GenericContainer container = createContainer() )
-        {
+        try (GenericContainer container = createContainer()) {
             temporaryFolderManager.createFolderAndMountAsVolume(container, "/metrics");
             Path confMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/conf");
-            makeContainerDumpConfig( container );
+            makeContainerDumpConfig(container);
             container.start();
 
-            File conf = confMount.resolve( "neo4j.conf" ).toFile();
+            File conf = confMount.resolve("neo4j.conf").toFile();
             Map<String, String> configurations = parseConfFile(conf);
-            Assertions.assertFalse(configurations.containsKey(confNames.get( Setting.DIRECTORIES_METRICS ).name),
-                                   "should not be setting any metrics configurations in community edition");
+            Assertions.assertFalse(
+                    configurations.containsKey(confNames.get(Setting.DIRECTORIES_METRICS).name),
+                    "should not be setting any metrics configurations in community edition");
         }
     }
 
     @Test
-    void testCommunityDoesNotHaveEnterpriseConfigs() throws Exception
-    {
-        Assumptions.assumeTrue(TestSettings.EDITION == TestSettings.Edition.COMMUNITY,
-                               "This is testing only COMMUNITY EDITION configs");
+    void testCommunityDoesNotHaveEnterpriseConfigs() throws Exception {
+        Assumptions.assumeTrue(
+                TestSettings.EDITION == TestSettings.Edition.COMMUNITY,
+                "This is testing only COMMUNITY EDITION configs");
 
         Path debugLog;
-        try(GenericContainer container = createContainer()
+        try (GenericContainer container = createContainer()
                 .withEnv(confNames.get(Setting.MEMORY_PAGECACHE_SIZE).envName, "512m")
-                .waitingFor(WaitStrategies.waitForNeo4jReady(PASSWORD)))
-        {
-            //Mount /logs
-			Path logMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/logs");
-            debugLog = logMount.resolve( "debug.log" );
-            SetContainerUser.nonRootUser( container );
-            //Start the container
+                .waitingFor(WaitStrategies.waitForNeo4jReady(PASSWORD))) {
+            // Mount /logs
+            Path logMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/logs");
+            debugLog = logMount.resolve("debug.log");
+            SetContainerUser.nonRootUser(container);
+            // Start the container
             container.start();
         }
 
-        //Read debug.log to check that cluster confs are not present
-        assertConfigurationPresentInDebugLog( debugLog, confNames.get(Setting.CLUSTER_TRANSACTION_ADDRESS), "*", false );
+        // Read debug.log to check that cluster confs are not present
+        assertConfigurationPresentInDebugLog(debugLog, confNames.get(Setting.CLUSTER_TRANSACTION_ADDRESS), "*", false);
     }
 
     @Test
     @Tag("BundleTest")
-    void testSettingAppendsToConfFileWithoutEmptyLine_neo4jPlugins() throws Exception
-    {
+    void testSettingAppendsToConfFileWithoutEmptyLine_neo4jPlugins() throws Exception {
         String expectedPageCacheSize = "1000.00MiB";
         String pluginStr = "[\"apoc\"]";
-        if(TestSettings.NEO4J_VERSION.isOlderThan( Neo4jVersion.NEO4J_VERSION_500 ))
-        {
+        if (TestSettings.NEO4J_VERSION.isOlderThan(Neo4jVersion.NEO4J_VERSION_500)) {
             pluginStr = "[\"apoc-core\"]";
         }
 
-        try(GenericContainer container = createContainer().waitingFor(WaitStrategies.waitForNeo4jReady(PASSWORD)))
-        {
+        try (GenericContainer container = createContainer().waitingFor(WaitStrategies.waitForNeo4jReady(PASSWORD))) {
             Path confMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/conf");
-            Files.copy( confFolder.resolve( "NoNewline.conf" ), confMount.resolve( "neo4j.conf" ) );
-            container.withEnv( Neo4jPluginEnv.get(), pluginStr );
-            //Start the container
+            Files.copy(confFolder.resolve("NoNewline.conf"), confMount.resolve("neo4j.conf"));
+            container.withEnv(Neo4jPluginEnv.get(), pluginStr);
+            // Start the container
             container.start();
-            DatabaseIO dbio = new DatabaseIO( container );
-            try
-            {
-                dbio.runCypherQuery( "neo4j", PASSWORD, "RETURN apoc.version()" );
-            }
-            catch( ClientException ex )
-            {
+            DatabaseIO dbio = new DatabaseIO(container);
+            try {
+                dbio.runCypherQuery("neo4j", PASSWORD, "RETURN apoc.version()");
+            } catch (ClientException ex) {
                 Assertions.fail("Did not load apoc plugin.", ex);
             }
-            dbio.verifyConfigurationSetting( "neo4j",
-                                             PASSWORD,
-                                             confNames.get( Setting.MEMORY_PAGECACHE_SIZE ),
-                                             expectedPageCacheSize);
+            dbio.verifyConfigurationSetting(
+                    "neo4j", PASSWORD, confNames.get(Setting.MEMORY_PAGECACHE_SIZE), expectedPageCacheSize);
         }
     }
 
     @Test
-    void testSettingAppendsToConfFileWithoutEmptyLine_envSetting() throws Exception
-    {
+    void testSettingAppendsToConfFileWithoutEmptyLine_envSetting() throws Exception {
         String expectedHeapSize = "128.00MiB";
         String expectedPageCacheSize = "1000.00MiB";
 
-        try(GenericContainer container = createContainer())
-        {
+        try (GenericContainer container = createContainer()) {
             Path confMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/conf");
-            Files.copy( confFolder.resolve( "NoNewline.conf" ), confMount.resolve( "neo4j.conf" ) );
+            Files.copy(confFolder.resolve("NoNewline.conf"), confMount.resolve("neo4j.conf"));
             // set an env variable
-            container.withEnv( confNames.get( Setting.MEMORY_HEAP_MAXSIZE ).envName, expectedHeapSize )
-                     .waitingFor(WaitStrategies.waitForNeo4jReady(PASSWORD));
-            //Start the container
+            container
+                    .withEnv(confNames.get(Setting.MEMORY_HEAP_MAXSIZE).envName, expectedHeapSize)
+                    .waitingFor(WaitStrategies.waitForNeo4jReady(PASSWORD));
+            // Start the container
             container.start();
-            DatabaseIO dbio = new DatabaseIO( container );
-            dbio.verifyConfigurationSetting( "neo4j",
-                                             PASSWORD,
-                                             confNames.get( Setting.MEMORY_HEAP_MAXSIZE ),
-                                             expectedHeapSize);
-            dbio.verifyConfigurationSetting( "neo4j",
-                                             PASSWORD,
-                                             confNames.get( Setting.MEMORY_PAGECACHE_SIZE ),
-                                             expectedPageCacheSize);
+            DatabaseIO dbio = new DatabaseIO(container);
+            dbio.verifyConfigurationSetting(
+                    "neo4j", PASSWORD, confNames.get(Setting.MEMORY_HEAP_MAXSIZE), expectedHeapSize);
+            dbio.verifyConfigurationSetting(
+                    "neo4j", PASSWORD, confNames.get(Setting.MEMORY_PAGECACHE_SIZE), expectedPageCacheSize);
         }
     }
 
     @Test
-    void testApocEnvVarsAreWrittenToApocConf() throws Exception
-    {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 5,3, 0 ) ),
-                                "APOC conf not present before 5.0 and this bug wasn't fixed before 5.3.");
+    void testApocEnvVarsAreWrittenToApocConf() throws Exception {
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isAtLeastVersion(new Neo4jVersion(5, 3, 0)),
+                "APOC conf not present before 5.0 and this bug wasn't fixed before 5.3.");
 
         Path confMount;
-        try(GenericContainer container = createContainer())
-        {
-            container.withEnv( confNames.get( Setting.APOC_EXPORT_FILE_ENABLED ).envName, "true" );
-            container.withEnv( Neo4jPluginEnv.get(), "[\"apoc\"]" );
+        try (GenericContainer container = createContainer()) {
+            container.withEnv(confNames.get(Setting.APOC_EXPORT_FILE_ENABLED).envName, "true");
+            container.withEnv(Neo4jPluginEnv.get(), "[\"apoc\"]");
             confMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/conf");
-            makeContainerDumpConfig( container );
+            makeContainerDumpConfig(container);
             container.start();
         }
         // there's no way to verify that APOC configurations have been set by querying neo4j or the debug log,
         // so the only verification we can do is check that neo4j started ok and that there is an apoc.conf dumped.
-        File apocConf = confMount.resolve( "apoc.conf" ).toFile();
-        Assertions.assertTrue( apocConf.exists(), "Did not create an apoc.conf to contain the apoc settings." );
-        Map<String,String> actualApocSettings = parseConfFile( apocConf );
-        Assertions.assertTrue(actualApocSettings.containsKey(confNames.get(Setting.APOC_EXPORT_FILE_ENABLED).name),
-                              "APOC setting not added to apoc.conf");
-        Assertions.assertEquals("true",
-                                actualApocSettings.get(confNames.get( Setting.APOC_EXPORT_FILE_ENABLED).name),
-                                "Incorrect value written for APOC setting");
+        File apocConf = confMount.resolve("apoc.conf").toFile();
+        Assertions.assertTrue(apocConf.exists(), "Did not create an apoc.conf to contain the apoc settings.");
+        Map<String, String> actualApocSettings = parseConfFile(apocConf);
+        Assertions.assertTrue(
+                actualApocSettings.containsKey(confNames.get(Setting.APOC_EXPORT_FILE_ENABLED).name),
+                "APOC setting not added to apoc.conf");
+        Assertions.assertEquals(
+                "true",
+                actualApocSettings.get(confNames.get(Setting.APOC_EXPORT_FILE_ENABLED).name),
+                "Incorrect value written for APOC setting");
     }
 
     @Test
-    void testShellExpansionAvoided() throws Exception
-    {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( Neo4jVersion.NEO4J_VERSION_400),
-                                "test only applicable to 4.0 and beyond." );
+    void testShellExpansionAvoided() throws Exception {
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isAtLeastVersion(Neo4jVersion.NEO4J_VERSION_400),
+                "test only applicable to 4.0 and beyond.");
 
         Path confMount;
-        try(GenericContainer container = createContainer()
-                .withEnv(confNames.get(Setting.SECURITY_PROCEDURES_UNRESTRICTED).envName, "*"))
-        {
-			confMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/conf");
-            makeContainerDumpConfig( container );
+        try (GenericContainer container =
+                createContainer().withEnv(confNames.get(Setting.SECURITY_PROCEDURES_UNRESTRICTED).envName, "*")) {
+            confMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/conf");
+            makeContainerDumpConfig(container);
             container.start();
         }
-        File conf = confMount.resolve( "neo4j.conf" ).toFile();
+        File conf = confMount.resolve("neo4j.conf").toFile();
         Map<String, String> configurations = parseConfFile(conf);
-        Assertions.assertTrue(configurations.containsKey(confNames.get( Setting.SECURITY_PROCEDURES_UNRESTRICTED).name),
-                              "configuration not set from env var");
-        Assertions.assertEquals("*",
-                configurations.get(confNames.get( Setting.SECURITY_PROCEDURES_UNRESTRICTED).name),
+        Assertions.assertTrue(
+                configurations.containsKey(confNames.get(Setting.SECURITY_PROCEDURES_UNRESTRICTED).name),
+                "configuration not set from env var");
+        Assertions.assertEquals(
+                "*",
+                configurations.get(confNames.get(Setting.SECURITY_PROCEDURES_UNRESTRICTED).name),
                 "Configuration value should be *. If it's not docker-entrypoint.sh probably evaluated it as a glob expression.");
     }
 }

--- a/src/test/java/com/neo4j/docker/coredb/configurations/TestExtendedConf.java
+++ b/src/test/java/com/neo4j/docker/coredb/configurations/TestExtendedConf.java
@@ -2,9 +2,19 @@ package com.neo4j.docker.coredb.configurations;
 
 import com.neo4j.docker.utils.Neo4jVersion;
 import com.neo4j.docker.utils.SetContainerUser;
-import com.neo4j.docker.utils.WaitStrategies;
 import com.neo4j.docker.utils.TemporaryFolderManager;
 import com.neo4j.docker.utils.TestSettings;
+import com.neo4j.docker.utils.WaitStrategies;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
@@ -21,199 +31,174 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.attribute.PosixFilePermission;
-import java.time.Duration;
-import java.util.HashSet;
-import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Stream;
-
-public class TestExtendedConf
-{
-	private final Logger log = LoggerFactory.getLogger( TestExtendedConf.class );
+public class TestExtendedConf {
+    private final Logger log = LoggerFactory.getLogger(TestExtendedConf.class);
     private static Path testConfsFolder;
     private static Configuration logRotationConfig;
+
     @RegisterExtension
     public static TemporaryFolderManager temporaryFolderManager = new TemporaryFolderManager();
 
-	@BeforeAll
-	static void ensureFeaturePresent()
-	{
-		Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isNewerThan( new Neo4jVersion( 4,2,0 ) ),
-								"Extended configuration feature not available before 4.2" );
-	}
+    @BeforeAll
+    static void ensureFeaturePresent() {
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isNewerThan(new Neo4jVersion(4, 2, 0)),
+                "Extended configuration feature not available before 4.2");
+    }
 
     @BeforeAll
     static void createVersionSpecificConfigurationSettings() {
         testConfsFolder = Configuration.getConfigurationResourcesFolder();
-        logRotationConfig = Configuration.getConfigurationNameMap()
-                                         .get( Setting.LOGS_GC_ROTATION_KEEPNUMBER );
+        logRotationConfig = Configuration.getConfigurationNameMap().get(Setting.LOGS_GC_ROTATION_KEEPNUMBER);
     }
 
-	protected GenericContainer createContainer(String password)
-	{
-        GenericContainer container = new GenericContainer( TestSettings.IMAGE_ID )
-                .withEnv( "NEO4J_AUTH", password == null || password.isEmpty() ? "none" : "neo4j/" + password )
-                .withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
-                .withEnv( "EXTENDED_CONF", "yeppers" )
-                .withExposedPorts( 7474, 7687 )
-                .withLogConsumer( new Slf4jLogConsumer( log ) )
-                .waitingFor( WaitStrategies.waitForBoltReady());
-       return container;
+    protected GenericContainer createContainer(String password) {
+        GenericContainer container = new GenericContainer(TestSettings.IMAGE_ID)
+                .withEnv("NEO4J_AUTH", password == null || password.isEmpty() ? "none" : "neo4j/" + password)
+                .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+                .withEnv("EXTENDED_CONF", "yeppers")
+                .withExposedPorts(7474, 7687)
+                .withLogConsumer(new Slf4jLogConsumer(log))
+                .waitingFor(WaitStrategies.waitForBoltReady());
+        return container;
     }
-
-
-	@ParameterizedTest
-	@ValueSource(strings = {"", "supersecretpassword"})
-	public void shouldStartWithExtendedConf(String password)
-	{
-        try(GenericContainer container = createContainer(password))
-        {
-            container.start();
-
-            Assertions.assertTrue( container.isRunning() );
-			assertPasswordChangedLogIsCorrect( password, container );
-		}
-	}
-
-	private void assertPasswordChangedLogIsCorrect( String password, GenericContainer container )
-	{
-		if ( password.isEmpty()) {
-			Assertions.assertFalse( container.getLogs( OutputFrame.OutputType.STDOUT)
-                                             .contains( "Changed password for user 'neo4j'." ) );
-		} else {
-			Assertions.assertTrue( container.getLogs( OutputFrame.OutputType.STDOUT)
-                                            .contains( "Changed password for user 'neo4j'." ) );
-		}
-	}
-
-	@ParameterizedTest
-	@ValueSource(strings = {"", "supersecretpassword"})
-	void testReadsTheExtendedConfFile_defaultUser(String password) throws Exception
-	{
-		// set up test folders
-		Path confFolder = temporaryFolderManager.createFolder("conf");
-		Path logsFolder = temporaryFolderManager.createFolder("logs");
-
-		// copy configuration file and set permissions
-		Path confFile = testConfsFolder.resolve( "ExtendedConf.conf" );
-		Files.copy( confFile, confFolder.resolve( "neo4j.conf" ) );
-        chmodConfFilePermissions( confFolder.resolve( "neo4j.conf" ) );
-		temporaryFolderManager.setFolderOwnerToNeo4j( confFolder.resolve( "neo4j.conf" ) );
-
-		// start  container
-		try(GenericContainer container = createContainer(password))
-		{
-			runContainerAndVerify( container, confFolder, logsFolder, password );
-		}
-	}
 
     @ParameterizedTest
-    @ValueSource( strings = {"", "supersecretpassword"} )
-    void testInvalidExtendedConfFile_nonRootUser( String password ) throws Exception
-    {
+    @ValueSource(strings = {"", "supersecretpassword"})
+    public void shouldStartWithExtendedConf(String password) {
+        try (GenericContainer container = createContainer(password)) {
+            container.start();
+
+            Assertions.assertTrue(container.isRunning());
+            assertPasswordChangedLogIsCorrect(password, container);
+        }
+    }
+
+    private void assertPasswordChangedLogIsCorrect(String password, GenericContainer container) {
+        if (password.isEmpty()) {
+            Assertions.assertFalse(
+                    container.getLogs(OutputFrame.OutputType.STDOUT).contains("Changed password for user 'neo4j'."));
+        } else {
+            Assertions.assertTrue(
+                    container.getLogs(OutputFrame.OutputType.STDOUT).contains("Changed password for user 'neo4j'."));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "supersecretpassword"})
+    void testReadsTheExtendedConfFile_defaultUser(String password) throws Exception {
+        // set up test folders
+        Path confFolder = temporaryFolderManager.createFolder("conf");
+        Path logsFolder = temporaryFolderManager.createFolder("logs");
+
+        // copy configuration file and set permissions
+        Path confFile = testConfsFolder.resolve("ExtendedConf.conf");
+        Files.copy(confFile, confFolder.resolve("neo4j.conf"));
+        chmodConfFilePermissions(confFolder.resolve("neo4j.conf"));
+        temporaryFolderManager.setFolderOwnerToNeo4j(confFolder.resolve("neo4j.conf"));
+
+        // start  container
+        try (GenericContainer container = createContainer(password)) {
+            runContainerAndVerify(container, confFolder, logsFolder, password);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "supersecretpassword"})
+    void testInvalidExtendedConfFile_nonRootUser(String password) throws Exception {
         // set up test folder
         Path confFolder = temporaryFolderManager.createFolder("conf");
 
         // copy configuration file and set permissions
-        Files.copy( testConfsFolder.resolve( "InvalidExtendedConf.conf" ), confFolder.resolve( "neo4j.conf" ) );
-        chmodConfFilePermissions( confFolder.resolve( "neo4j.conf" ) );
+        Files.copy(testConfsFolder.resolve("InvalidExtendedConf.conf"), confFolder.resolve("neo4j.conf"));
+        chmodConfFilePermissions(confFolder.resolve("neo4j.conf"));
 
-        try(GenericContainer container = createContainer( password ))
-        {
-            SetContainerUser.nonRootUser( container );
-            container.withFileSystemBind( "/etc/passwd", "/etc/passwd", BindMode.READ_ONLY );
-            container.withFileSystemBind( "/etc/group", "/etc/group", BindMode.READ_ONLY );
-            temporaryFolderManager.mountHostFolderAsVolume( container, confFolder, "/conf" );
-            container.setStartupCheckStrategy( new OneShotStartupCheckStrategy().withTimeout( Duration.ofSeconds( 30 ) ) );
+        try (GenericContainer container = createContainer(password)) {
+            SetContainerUser.nonRootUser(container);
+            container.withFileSystemBind("/etc/passwd", "/etc/passwd", BindMode.READ_ONLY);
+            container.withFileSystemBind("/etc/group", "/etc/group", BindMode.READ_ONLY);
+            temporaryFolderManager.mountHostFolderAsVolume(container, confFolder, "/conf");
+            container.setStartupCheckStrategy(new OneShotStartupCheckStrategy().withTimeout(Duration.ofSeconds(30)));
             container.setWaitStrategy(
-                    Wait.forLogMessage( ".*this is an error message from inside neo4j config command expansion.*", 1 )
-                        .withStartupTimeout( Duration.ofSeconds( 30 ) ) );
+                    Wait.forLogMessage(".*this is an error message from inside neo4j config command expansion.*", 1)
+                            .withStartupTimeout(Duration.ofSeconds(30)));
 
-            Assertions.assertThrows( ContainerLaunchException.class,
-                                     () -> container.start(),
-                                     "Container should have errored on start");
+            Assertions.assertThrows(
+                    ContainerLaunchException.class, () -> container.start(), "Container should have errored on start");
 
             String logs = container.getLogs();
             // check that error messages from neo4j are visible in docker logs
-            Assertions.assertTrue( logs.contains( "Error evaluating value for setting '" + logRotationConfig.name + "'" ) );
+            Assertions.assertTrue(logs.contains("Error evaluating value for setting '" + logRotationConfig.name + "'"));
             // check that error messages from the command that failed are visible in docker logs
-            Assertions.assertTrue( logs.contains( "this is an error message from inside neo4j config command expansion" ) );
-            // check that the error is only encountered once (i.e. we quit the docker entrypoint the first time it was encountered)
-            Assertions.assertEquals( 1, countOccurrences( Pattern.compile( "Error evaluating value for setting" ), logs ) );
+            Assertions.assertTrue(logs.contains("this is an error message from inside neo4j config command expansion"));
+            // check that the error is only encountered once (i.e. we quit the docker entrypoint the first time it was
+            // encountered)
+            Assertions.assertEquals(1, countOccurrences(Pattern.compile("Error evaluating value for setting"), logs));
         }
     }
 
-	private int countOccurrences( Pattern pattern, String inString )
-	{
-		Matcher matcher = pattern.matcher( inString );
-		int count = 0;
-		while ( matcher.find() )
-		{
-			count = count + 1;
-		}
-		return count;
-	}
+    private int countOccurrences(Pattern pattern, String inString) {
+        Matcher matcher = pattern.matcher(inString);
+        int count = 0;
+        while (matcher.find()) {
+            count = count + 1;
+        }
+        return count;
+    }
 
-	@ParameterizedTest
-	@ValueSource(strings = {"", "supersecretpassword"})
-	void testReadsTheExtendedConfFile_nonRootUser(String password) throws Exception
-	{
-		// set up test folders
-		Path confFolder = temporaryFolderManager.createFolder("conf");
-		Path logsFolder = temporaryFolderManager.createFolder("logs");
+    @ParameterizedTest
+    @ValueSource(strings = {"", "supersecretpassword"})
+    void testReadsTheExtendedConfFile_nonRootUser(String password) throws Exception {
+        // set up test folders
+        Path confFolder = temporaryFolderManager.createFolder("conf");
+        Path logsFolder = temporaryFolderManager.createFolder("logs");
 
-		// copy configuration file and set permissions
-		Path confFile = testConfsFolder.resolve( "ExtendedConf.conf" );
-		Files.copy( confFile, confFolder.resolve( "neo4j.conf" ) );
-		chmodConfFilePermissions( confFolder.resolve( "neo4j.conf" ) );
+        // copy configuration file and set permissions
+        Path confFile = testConfsFolder.resolve("ExtendedConf.conf");
+        Files.copy(confFile, confFolder.resolve("neo4j.conf"));
+        chmodConfFilePermissions(confFolder.resolve("neo4j.conf"));
 
-		try(GenericContainer container = createContainer(password))
-		{
-			SetContainerUser.nonRootUser( container );
-			container.withFileSystemBind( "/etc/passwd", "/etc/passwd", BindMode.READ_ONLY );
-			container.withFileSystemBind( "/etc/group", "/etc/group", BindMode.READ_ONLY );
-			runContainerAndVerify( container, confFolder, logsFolder, password );
-		}
-	}
+        try (GenericContainer container = createContainer(password)) {
+            SetContainerUser.nonRootUser(container);
+            container.withFileSystemBind("/etc/passwd", "/etc/passwd", BindMode.READ_ONLY);
+            container.withFileSystemBind("/etc/group", "/etc/group", BindMode.READ_ONLY);
+            runContainerAndVerify(container, confFolder, logsFolder, password);
+        }
+    }
 
-	private void runContainerAndVerify(GenericContainer container, Path confFolder, Path logsFolder, String password) throws Exception
-	{
-		temporaryFolderManager.mountHostFolderAsVolume( container, confFolder, "/conf" );
-		temporaryFolderManager.mountHostFolderAsVolume( container, logsFolder, "/logs" );
+    private void runContainerAndVerify(GenericContainer container, Path confFolder, Path logsFolder, String password)
+            throws Exception {
+        temporaryFolderManager.mountHostFolderAsVolume(container, confFolder, "/conf");
+        temporaryFolderManager.mountHostFolderAsVolume(container, logsFolder, "/logs");
 
-		container.start();
+        container.start();
 
-		Path debugLog = logsFolder.resolve("debug.log");
-		Assertions.assertTrue(debugLog.toFile().exists(), "Did not write debug log");
+        Path debugLog = logsFolder.resolve("debug.log");
+        Assertions.assertTrue(debugLog.toFile().exists(), "Did not write debug log");
 
-		//Check if the container reads the conf file
-		Stream<String> lines = Files.lines( debugLog);
-		Optional<String> isMatch = lines.filter( s -> s.contains(logRotationConfig.name + "=20")).findFirst();
-		lines.close();
-		Assertions.assertTrue(  isMatch.isPresent(), logRotationConfig.name+" was not set correctly");
+        // Check if the container reads the conf file
+        Stream<String> lines = Files.lines(debugLog);
+        Optional<String> isMatch =
+                lines.filter(s -> s.contains(logRotationConfig.name + "=20")).findFirst();
+        lines.close();
+        Assertions.assertTrue(isMatch.isPresent(), logRotationConfig.name + " was not set correctly");
 
-		//Check the password was changed if set
-		assertPasswordChangedLogIsCorrect( password, container );
-	}
+        // Check the password was changed if set
+        assertPasswordChangedLogIsCorrect(password, container);
+    }
 
-	private void chmodConfFilePermissions( Path file ) throws IOException
-	{
+    private void chmodConfFilePermissions(Path file) throws IOException {
 
-		HashSet<PosixFilePermission> permissions = new HashSet<PosixFilePermission>()
-		{{
-			add( PosixFilePermission.OWNER_READ );
-			add( PosixFilePermission.OWNER_WRITE );
-		}};
+        HashSet<PosixFilePermission> permissions = new HashSet<PosixFilePermission>() {
+            {
+                add(PosixFilePermission.OWNER_READ);
+                add(PosixFilePermission.OWNER_WRITE);
+            }
+        };
 
-		if ( TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 4, 3, 0 ) ) )
-		{
-			permissions.add( PosixFilePermission.GROUP_READ );
-		}
-		Files.setPosixFilePermissions( file, permissions );
-	}
+        if (TestSettings.NEO4J_VERSION.isAtLeastVersion(new Neo4jVersion(4, 3, 0))) {
+            permissions.add(PosixFilePermission.GROUP_READ);
+        }
+        Files.setPosixFilePermissions(file, permissions);
+    }
 }

--- a/src/test/java/com/neo4j/docker/coredb/configurations/TestJVMAdditionalConfig.java
+++ b/src/test/java/com/neo4j/docker/coredb/configurations/TestJVMAdditionalConfig.java
@@ -6,6 +6,8 @@ import com.neo4j.docker.utils.SetContainerUser;
 import com.neo4j.docker.utils.TemporaryFolderManager;
 import com.neo4j.docker.utils.TestSettings;
 import com.neo4j.docker.utils.WaitStrategies;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
@@ -16,144 +18,125 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-
-public class TestJVMAdditionalConfig
-{
-    private final Logger log = LoggerFactory.getLogger( TestJVMAdditionalConfig.class );
+public class TestJVMAdditionalConfig {
+    private final Logger log = LoggerFactory.getLogger(TestJVMAdditionalConfig.class);
     private static final String PASSWORD = "SuperSecretPassword";
-    private static final String AUTH = "neo4j/"+PASSWORD ;
+    private static final String AUTH = "neo4j/" + PASSWORD;
     private static Path confFolder;
-    private static final Configuration JVM_ADDITIONAL_CONFIG = Configuration.getConfigurationNameMap().get( Setting.JVM_ADDITIONAL );
+    private static final Configuration JVM_ADDITIONAL_CONFIG =
+            Configuration.getConfigurationNameMap().get(Setting.JVM_ADDITIONAL);
     private static final String DEFAULT_JVM_CONF = "-XX:+UseG1GC";
 
     @RegisterExtension
     public static TemporaryFolderManager temporaryFolderManager = new TemporaryFolderManager();
 
     @BeforeAll
-    static void getVersionSpecificConfigurationSettings()
-    {
+    static void getVersionSpecificConfigurationSettings() {
         confFolder = Configuration.getConfigurationResourcesFolder();
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( Neo4jVersion.NEO4J_VERSION_440 ),
-                                "JVM Additional tests not applicable before 4.4.0");
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isAtLeastVersion(Neo4jVersion.NEO4J_VERSION_440),
+                "JVM Additional tests not applicable before 4.4.0");
     }
 
-    private GenericContainer createContainer()
-    {
+    private GenericContainer createContainer() {
         return new GenericContainer(TestSettings.IMAGE_ID)
                 .withEnv("NEO4J_AUTH", AUTH)
                 .withEnv("NEO4J_DEBUG", AUTH)
                 .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
                 .withExposedPorts(7474, 7687)
-                .withLogConsumer(new Slf4jLogConsumer( log))
+                .withLogConsumer(new Slf4jLogConsumer(log))
                 .waitingFor(WaitStrategies.waitForNeo4jReady(PASSWORD));
     }
 
     @Test
-    void testJvmAdditionalNotOverridden_noEnv() throws Exception
-    {
+    void testJvmAdditionalNotOverridden_noEnv() throws Exception {
         String expectedJvmAdditional = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005";
-        testJvmAdditionalNotOverridden(expectedJvmAdditional, "" );
+        testJvmAdditionalNotOverridden(expectedJvmAdditional, "");
     }
 
     @Test
-    void testJvmAdditionalNotOverridden_withEnv() throws Exception
-    {
+    void testJvmAdditionalNotOverridden_withEnv() throws Exception {
         String jvmAdditionalFromEnv = "-XX:+HeapDumpOnOutOfMemoryError";
-        String expectedJvmAdditional = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005\n"+jvmAdditionalFromEnv;
-        testJvmAdditionalNotOverridden(expectedJvmAdditional, jvmAdditionalFromEnv );
+        String expectedJvmAdditional =
+                "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005\n" + jvmAdditionalFromEnv;
+        testJvmAdditionalNotOverridden(expectedJvmAdditional, jvmAdditionalFromEnv);
     }
 
-    void testJvmAdditionalNotOverridden( String expectedJvmAdditional, String jvmAdditionalEnv ) throws Exception
-    {
-        try( GenericContainer container = createContainer())
-        {
-            //Mount /conf
+    void testJvmAdditionalNotOverridden(String expectedJvmAdditional, String jvmAdditionalEnv) throws Exception {
+        try (GenericContainer container = createContainer()) {
+            // Mount /conf
             Path confMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/conf");
-            SetContainerUser.nonRootUser( container );
-            container.withEnv( JVM_ADDITIONAL_CONFIG.envName, jvmAdditionalEnv );
-            //Create JvmAdditionalNotOverridden.conf file
-            Path confFile = confFolder.resolve( "JvmAdditionalNotOverridden.conf" );
-            Files.copy( confFile, confMount.resolve( "neo4j.conf" ) );
-            //Start the container
+            SetContainerUser.nonRootUser(container);
+            container.withEnv(JVM_ADDITIONAL_CONFIG.envName, jvmAdditionalEnv);
+            // Create JvmAdditionalNotOverridden.conf file
+            Path confFile = confFolder.resolve("JvmAdditionalNotOverridden.conf");
+            Files.copy(confFile, confMount.resolve("neo4j.conf"));
+            // Start the container
             container.start();
             // verify setting correctly loaded into neo4j
-            DatabaseIO dbio = new DatabaseIO( container );
-            dbio.verifyConfigurationSetting( "neo4j", PASSWORD, JVM_ADDITIONAL_CONFIG, expectedJvmAdditional);
+            DatabaseIO dbio = new DatabaseIO(container);
+            dbio.verifyConfigurationSetting("neo4j", PASSWORD, JVM_ADDITIONAL_CONFIG, expectedJvmAdditional);
         }
     }
 
     @Test
-    void testJVMAdditionalDefaultsNotOverwrittenByEnv() throws Exception
-    {
+    void testJVMAdditionalDefaultsNotOverwrittenByEnv() throws Exception {
         String expectedJvmAdditional = "-XX:+HeapDumpOnOutOfMemoryError";
-        try( GenericContainer container = createContainer())
-        {
-            container.withEnv( JVM_ADDITIONAL_CONFIG.envName, expectedJvmAdditional );
-            verifyJvmAdditional( container, expectedJvmAdditional, DEFAULT_JVM_CONF );
+        try (GenericContainer container = createContainer()) {
+            container.withEnv(JVM_ADDITIONAL_CONFIG.envName, expectedJvmAdditional);
+            verifyJvmAdditional(container, expectedJvmAdditional, DEFAULT_JVM_CONF);
         }
     }
 
     @Test
-    void testSpecialCharInJvmAdditional_space_conf() throws Exception
-    {
+    void testSpecialCharInJvmAdditional_space_conf() throws Exception {
         testJvmAdditionalSpecialCharacters_conf("space", "-XX:OnOutOfMemoryError=\"/usr/bin/echo oh no oom\"");
     }
 
     @Test
-    void testSpecialCharInJvmAdditional_space_env() throws Exception
-    {
-        testJvmAdditionalSpecialCharacters_env( "-XX:OnOutOfMemoryError=\"/usr/bin/echo oh no oom\"");
+    void testSpecialCharInJvmAdditional_space_env() throws Exception {
+        testJvmAdditionalSpecialCharacters_env("-XX:OnOutOfMemoryError=\"/usr/bin/echo oh no oom\"");
     }
 
     @Test
-    void testSpecialCharInJvmAdditional_dollar_conf() throws Exception
-    {
-        testJvmAdditionalSpecialCharacters_conf("dollar",
-                                                "-Dnot.a.real.parameter=\"beepbeep$boop1boop2\"" );
+    void testSpecialCharInJvmAdditional_dollar_conf() throws Exception {
+        testJvmAdditionalSpecialCharacters_conf("dollar", "-Dnot.a.real.parameter=\"beepbeep$boop1boop2\"");
     }
 
     @Test
     void testSpecialCharInJvmAdditional_dollar_env() throws Exception {
-        testJvmAdditionalSpecialCharacters_env( "-Dnot.a.real.parameter=\"bleepblorp$bleep1blorp4\"");
+        testJvmAdditionalSpecialCharacters_env("-Dnot.a.real.parameter=\"bleepblorp$bleep1blorp4\"");
     }
 
-    void testJvmAdditionalSpecialCharacters_conf(String charName, String expectedJvmAdditional) throws Exception
-    {
-        try(GenericContainer container = createContainer())
-        {
-            //Mount /conf
+    void testJvmAdditionalSpecialCharacters_conf(String charName, String expectedJvmAdditional) throws Exception {
+        try (GenericContainer container = createContainer()) {
+            // Mount /conf
             Path confMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/conf");
-            //copy test conf file
+            // copy test conf file
             String confContent = JVM_ADDITIONAL_CONFIG.name + "=" + expectedJvmAdditional;
-            Files.write( confMount.resolve( "neo4j.conf" ), confContent.getBytes() );
-            //Start the container
-            verifyJvmAdditional( container, expectedJvmAdditional );
+            Files.write(confMount.resolve("neo4j.conf"), confContent.getBytes());
+            // Start the container
+            verifyJvmAdditional(container, expectedJvmAdditional);
         }
     }
 
-    void testJvmAdditionalSpecialCharacters_env( String expectedJvmAdditional ) throws Exception
-    {
-        try(GenericContainer container = createContainer())
-        {
-            container.withEnv( JVM_ADDITIONAL_CONFIG.envName, expectedJvmAdditional);
-            verifyJvmAdditional( container, expectedJvmAdditional, DEFAULT_JVM_CONF );
+    void testJvmAdditionalSpecialCharacters_env(String expectedJvmAdditional) throws Exception {
+        try (GenericContainer container = createContainer()) {
+            container.withEnv(JVM_ADDITIONAL_CONFIG.envName, expectedJvmAdditional);
+            verifyJvmAdditional(container, expectedJvmAdditional, DEFAULT_JVM_CONF);
         }
     }
 
-    void verifyJvmAdditional( GenericContainer container, String... expectedValues )
-    {
-        SetContainerUser.nonRootUser( container );
-        //Start the container
+    void verifyJvmAdditional(GenericContainer container, String... expectedValues) {
+        SetContainerUser.nonRootUser(container);
+        // Start the container
         container.start();
         // verify setting correctly loaded into neo4j
-        DatabaseIO dbio = new DatabaseIO( container );
-        String actualConfValue = dbio.getConfigurationSettingAsString( "neo4j", PASSWORD, JVM_ADDITIONAL_CONFIG );
-        
-        for(String expectedJvmAdditional : expectedValues)
-        {
-            Assertions.assertTrue( actualConfValue.contains( expectedJvmAdditional ) );
+        DatabaseIO dbio = new DatabaseIO(container);
+        String actualConfValue = dbio.getConfigurationSettingAsString("neo4j", PASSWORD, JVM_ADDITIONAL_CONFIG);
+
+        for (String expectedJvmAdditional : expectedValues) {
+            Assertions.assertTrue(actualConfValue.contains(expectedJvmAdditional));
         }
     }
 }

--- a/src/test/java/com/neo4j/docker/coredb/plugins/Neo4jPluginEnv.java
+++ b/src/test/java/com/neo4j/docker/coredb/plugins/Neo4jPluginEnv.java
@@ -3,22 +3,17 @@ package com.neo4j.docker.coredb.plugins;
 import com.neo4j.docker.utils.Neo4jVersion;
 import com.neo4j.docker.utils.TestSettings;
 
-public class Neo4jPluginEnv
-{
+public class Neo4jPluginEnv {
     public static final String PLUGIN_ENV_4X = "NEO4JLABS_PLUGINS";
     public static final String PLUGIN_ENV_5X = "NEO4J_PLUGINS";
 
-    public static String get( )
-    {
+    public static String get() {
         return get(TestSettings.NEO4J_VERSION);
     }
 
-    public static String get( Neo4jVersion version )
-    {
-        if( version.isAtLeastVersion( Neo4jVersion.NEO4J_VERSION_500 ) )
-        {
+    public static String get(Neo4jVersion version) {
+        if (version.isAtLeastVersion(Neo4jVersion.NEO4J_VERSION_500)) {
             return PLUGIN_ENV_5X;
-        }
-        else return PLUGIN_ENV_4X;
+        } else return PLUGIN_ENV_4X;
     }
 }

--- a/src/test/java/com/neo4j/docker/coredb/plugins/StubPluginHelper.java
+++ b/src/test/java/com/neo4j/docker/coredb/plugins/StubPluginHelper.java
@@ -1,13 +1,12 @@
 package com.neo4j.docker.coredb.plugins;
 
+import static com.neo4j.docker.utils.TestSettings.NEO4J_VERSION;
+
 import com.google.gson.Gson;
 import com.neo4j.docker.utils.DatabaseIO;
 import com.neo4j.docker.utils.HostFileHttpHandler;
 import com.neo4j.docker.utils.HttpServerTestExtension;
 import com.neo4j.docker.utils.Neo4jVersion;
-import org.junit.jupiter.api.Assertions;
-import org.neo4j.driver.Record;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -16,25 +15,22 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.Assertions;
+import org.neo4j.driver.Record;
 
-import static com.neo4j.docker.utils.TestSettings.NEO4J_VERSION;
-
-public class StubPluginHelper
-{
+public class StubPluginHelper {
     public static final String PLUGIN_FILENAME = "myPlugin.jar";
     public static final String PLUGIN_ENV_NAME = "_testing";
     private final HttpServerTestExtension httpServer;
 
     /**Data class for each <code>versions.json</code> entry so that the GSON tool can convert it to json.
      * */
-    private class VersionsJsonEntry
-    {
+    private class VersionsJsonEntry {
         String neo4j;
         String jar;
         String _testing;
 
-        VersionsJsonEntry( String neo4j, String jar )
-        {
+        VersionsJsonEntry(String neo4j, String jar) {
             this.neo4j = neo4j;
             this._testing = "SNAPSHOT";
             this.jar = "http://host.testcontainers.internal:3000/" + jar;
@@ -45,8 +41,7 @@ public class StubPluginHelper
      * @param httpServer a {@link HttpServerTestExtension} object.
      *                  It must have ALREADY been registered as a JUnit5 extension with {@link org.junit.jupiter.api.extension.RegisterExtension}
      * */
-    public StubPluginHelper(HttpServerTestExtension httpServer)
-    {
+    public StubPluginHelper(HttpServerTestExtension httpServer) {
         this.httpServer = httpServer;
     }
 
@@ -56,9 +51,9 @@ public class StubPluginHelper
      * @param version a neo4j version, to map to the real testing jar.
      * @return File object of the versions.json file created.
      * */
-    public File createStubPluginForVersion(Path destinationFolder, Neo4jVersion version) throws IOException
-    {
-        return createStubPluginsForVersionMapping(destinationFolder, Collections.singletonMap(version.toString(), PLUGIN_FILENAME));
+    public File createStubPluginForVersion(Path destinationFolder, Neo4jVersion version) throws IOException {
+        return createStubPluginsForVersionMapping(
+                destinationFolder, Collections.singletonMap(version.toString(), PLUGIN_FILENAME));
     }
 
     /**Creates a versions.json in the destination folder mapping between the given neo4j versions and jar filenames.
@@ -67,9 +62,9 @@ public class StubPluginHelper
      * @param version a neo4j version, as a string, to map to the real testing jar.
      * @return File object of the versions.json file created.
      * */
-    public File createStubPluginForVersion(Path destinationFolder, String version) throws IOException
-    {
-        return createStubPluginsForVersionMapping(destinationFolder, Collections.singletonMap(version, PLUGIN_FILENAME));
+    public File createStubPluginForVersion(Path destinationFolder, String version) throws IOException {
+        return createStubPluginsForVersionMapping(
+                destinationFolder, Collections.singletonMap(version, PLUGIN_FILENAME));
     }
 
     /**Creates a versions.json in the destination folder mapping between the given neo4j versions and jar filenames.
@@ -81,26 +76,27 @@ public class StubPluginHelper
      *                      5.0.x  -> anotherNonexistantPlugin.jar
      * @return File object of the versions.json file created.
      * */
-    public File createStubPluginsForVersionMapping(Path destinationFolder, Map<String,String> versionAndJar ) throws IOException
-    {
+    public File createStubPluginsForVersionMapping(Path destinationFolder, Map<String, String> versionAndJar)
+            throws IOException {
         File versionsJson = createVersionsJson(destinationFolder, versionAndJar);
         try {
-            File myPluginJar = new File(getClass().getClassLoader().getResource("stubplugin/" + PLUGIN_FILENAME).toURI());
+            File myPluginJar = new File(getClass()
+                    .getClassLoader()
+                    .getResource("stubplugin/" + PLUGIN_FILENAME)
+                    .toURI());
 
-            httpServer.registerHandler(versionsJson.getName(), new HostFileHttpHandler(versionsJson, "application/json"));
-            httpServer.registerHandler(PLUGIN_FILENAME, new HostFileHttpHandler(myPluginJar, "application/java-archive"));
-        }
-        catch (URISyntaxException e)
-        {
+            httpServer.registerHandler(
+                    versionsJson.getName(), new HostFileHttpHandler(versionsJson, "application/json"));
+            httpServer.registerHandler(
+                    PLUGIN_FILENAME, new HostFileHttpHandler(myPluginJar, "application/java-archive"));
+        } catch (URISyntaxException e) {
             throw new IOException("Could not load test plugin from test resources file", e);
         }
         return versionsJson;
     }
 
-    private File createVersionsJson(Path destinationFolder, Map<String, String> versionAndJar) throws IOException
-    {
-        List<VersionsJsonEntry> jsonEntries = versionAndJar.keySet()
-                .stream()
+    private File createVersionsJson(Path destinationFolder, Map<String, String> versionAndJar) throws IOException {
+        List<VersionsJsonEntry> jsonEntries = versionAndJar.keySet().stream()
                 .map(key -> new VersionsJsonEntry(key, versionAndJar.get(key)))
                 .collect(Collectors.toList());
         Gson jsonBuilder = new Gson();
@@ -111,31 +107,30 @@ public class StubPluginHelper
         return outputJsonFile;
     }
 
-    public void verifyStubPluginLoaded(DatabaseIO db, String user, String password )
-    {
+    public void verifyStubPluginLoaded(DatabaseIO db, String user, String password) {
         // when we check the list of installed procedures...
-        String listProceduresCypherQuery = NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 4, 3, 0 ) ) ?
-                                           "SHOW PROCEDURES YIELD name, signature RETURN name, signature" :
-                                           "CALL dbms.procedures() YIELD name, signature RETURN name, signature";
-        List<Record> procedures = db.runCypherQuery( user, password, listProceduresCypherQuery );
+        String listProceduresCypherQuery = NEO4J_VERSION.isAtLeastVersion(new Neo4jVersion(4, 3, 0))
+                ? "SHOW PROCEDURES YIELD name, signature RETURN name, signature"
+                : "CALL dbms.procedures() YIELD name, signature RETURN name, signature";
+        List<Record> procedures = db.runCypherQuery(user, password, listProceduresCypherQuery);
         // Then the procedure from the test plugin should be listed
-        Assertions.assertTrue( procedures.stream()
-                                         .anyMatch( x -> x.get( "name" ).asString()
-                                                          .equals( "com.neo4j.docker.test.myplugin.defaultValues" ) ),
-                               "Missing procedure provided by our plugin" );
+        Assertions.assertTrue(
+                procedures.stream()
+                        .anyMatch(x -> x.get("name").asString().equals("com.neo4j.docker.test.myplugin.defaultValues")),
+                "Missing procedure provided by our plugin");
 
         // When we call the procedure from the plugin
-        List<Record> pluginResponse = db.runCypherQuery( user, password,
-                                                         "CALL com.neo4j.docker.test.myplugin.defaultValues" );
+        List<Record> pluginResponse =
+                db.runCypherQuery(user, password, "CALL com.neo4j.docker.test.myplugin.defaultValues");
 
         // Then we get the response we expect
-        Assertions.assertEquals( 1, pluginResponse.size(), "Our procedure should only return a single result" );
-        Record record = pluginResponse.get( 0 );
+        Assertions.assertEquals(1, pluginResponse.size(), "Our procedure should only return a single result");
+        Record record = pluginResponse.get(0);
 
         String message = "Result from calling our procedure doesnt match our expectations";
-        Assertions.assertEquals( "a string", record.get( "string" ).asString(), message );
-        Assertions.assertEquals( 42L, record.get( "integer" ).asInt(), message );
-        Assertions.assertEquals( 3.14d, record.get( "aFloat" ).asDouble(), 0.000001, message );
+        Assertions.assertEquals("a string", record.get("string").asString(), message);
+        Assertions.assertEquals(42L, record.get("integer").asInt(), message);
+        Assertions.assertEquals(3.14d, record.get("aFloat").asDouble(), 0.000001, message);
         Assertions.assertTrue(record.get("aBoolean").asBoolean(), message);
     }
 }

--- a/src/test/java/com/neo4j/docker/coredb/plugins/TestBundledPluginInstallation.java
+++ b/src/test/java/com/neo4j/docker/coredb/plugins/TestBundledPluginInstallation.java
@@ -5,6 +5,12 @@ import com.neo4j.docker.utils.Neo4jVersion;
 import com.neo4j.docker.utils.TemporaryFolderManager;
 import com.neo4j.docker.utils.TestSettings;
 import com.neo4j.docker.utils.WaitStrategies;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
@@ -23,189 +29,160 @@ import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.Duration;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 @Tag("BundleTest")
-public class TestBundledPluginInstallation
-{
-    private final Logger log = LoggerFactory.getLogger( TestBundledPluginInstallation.class );
+public class TestBundledPluginInstallation {
+    private final Logger log = LoggerFactory.getLogger(TestBundledPluginInstallation.class);
+
     @RegisterExtension
     public static TemporaryFolderManager temporaryFolderManager = new TemporaryFolderManager();
 
-    static class BundledPlugin
-    {
+    static class BundledPlugin {
         private final String name;
         private final Neo4jVersion bundledSince;
         private final Neo4jVersion bundledUntil;
         private final boolean isEnterpriseOnly;
 
-        public BundledPlugin(String name, Neo4jVersion bundledSince, @Nullable Neo4jVersion bundledUntil, boolean isEnterpriseOnly)
-        {
+        public BundledPlugin(
+                String name, Neo4jVersion bundledSince, @Nullable Neo4jVersion bundledUntil, boolean isEnterpriseOnly) {
             this.name = name;
             this.bundledSince = bundledSince;
             this.bundledUntil = bundledUntil;
             this.isEnterpriseOnly = isEnterpriseOnly;
         }
 
-        public boolean shouldBePresentInImage()
-        {
-            boolean shouldBeBundled = TestSettings.NEO4J_VERSION.isAtLeastVersion( bundledSince );
-            if(isEnterpriseOnly)
-            {
+        public boolean shouldBePresentInImage() {
+            boolean shouldBeBundled = TestSettings.NEO4J_VERSION.isAtLeastVersion(bundledSince);
+            if (isEnterpriseOnly) {
                 shouldBeBundled = shouldBeBundled && (TestSettings.EDITION == TestSettings.Edition.ENTERPRISE);
             }
-            if(bundledUntil != null)
-            {
-                shouldBeBundled = shouldBeBundled && TestSettings.NEO4J_VERSION.isOlderThan( bundledUntil );
+            if (bundledUntil != null) {
+                shouldBeBundled = shouldBeBundled && TestSettings.NEO4J_VERSION.isOlderThan(bundledUntil);
             }
             return shouldBeBundled;
         }
 
         @Override
-        public String toString()
-        {
+        public String toString() {
             return "BundledPlugin " + name;
         }
     }
 
-    private static final BundledPlugin APOC = new BundledPlugin("apoc",
-            new Neo4jVersion(5, 0, 0), null,false);
-    private static final BundledPlugin APOC_CORE = new BundledPlugin("apoc-core",
-            new Neo4jVersion(4, 3, 15),
-            new Neo4jVersion(5, 0, 0), false);
-    private static final BundledPlugin BLOOM = new BundledPlugin("bloom",
-            Neo4jVersion.NEO4J_VERSION_440, null, true);
-    private static final BundledPlugin GDS = new BundledPlugin("graph-data-science",
-            Neo4jVersion.NEO4J_VERSION_440, null, true );
-    private static final BundledPlugin GENAI = new BundledPlugin("genai",
-            new Neo4jVersion(5, 18, 0), null, false);
-    private static final BundledPlugin FLEET_MANAGEMENT = new BundledPlugin("fleet-management",
-            new Neo4jVersion(4,4,45), new Neo4jVersion(2026, 2, 3), false);
+    private static final BundledPlugin APOC = new BundledPlugin("apoc", new Neo4jVersion(5, 0, 0), null, false);
+    private static final BundledPlugin APOC_CORE =
+            new BundledPlugin("apoc-core", new Neo4jVersion(4, 3, 15), new Neo4jVersion(5, 0, 0), false);
+    private static final BundledPlugin BLOOM = new BundledPlugin("bloom", Neo4jVersion.NEO4J_VERSION_440, null, true);
+    private static final BundledPlugin GDS =
+            new BundledPlugin("graph-data-science", Neo4jVersion.NEO4J_VERSION_440, null, true);
+    private static final BundledPlugin GENAI = new BundledPlugin("genai", new Neo4jVersion(5, 18, 0), null, false);
+    private static final BundledPlugin FLEET_MANAGEMENT =
+            new BundledPlugin("fleet-management", new Neo4jVersion(4, 4, 45), new Neo4jVersion(2026, 2, 3), false);
 
     static Stream<Arguments> bundledPluginsArgs() {
         return Stream.of(
                 Arguments.arguments(APOC_CORE),
                 Arguments.arguments(APOC),
-                 Arguments.arguments(GDS),
+                Arguments.arguments(GDS),
                 Arguments.arguments(BLOOM),
                 Arguments.arguments(GENAI),
-                Arguments.arguments(FLEET_MANAGEMENT)
-        );
+                Arguments.arguments(FLEET_MANAGEMENT));
     }
 
-    private GenericContainer createContainer()
-    {
-        GenericContainer container = new GenericContainer( TestSettings.IMAGE_ID );
-        container.withEnv( "NEO4J_AUTH", "none" )
-                 .withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
-                 .withEnv("NEO4J_DEBUG", "yes")
-                 .withExposedPorts( 7474, 7687 )
-                 .withLogConsumer( new Slf4jLogConsumer( log ) )
-                 .waitingFor( WaitStrategies.waitForBoltReady() );
+    private GenericContainer createContainer() {
+        GenericContainer container = new GenericContainer(TestSettings.IMAGE_ID);
+        container
+                .withEnv("NEO4J_AUTH", "none")
+                .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+                .withEnv("NEO4J_DEBUG", "yes")
+                .withExposedPorts(7474, 7687)
+                .withLogConsumer(new Slf4jLogConsumer(log))
+                .waitingFor(WaitStrategies.waitForBoltReady());
         return container;
     }
 
-    private GenericContainer createContainerWithBundledPlugin(BundledPlugin plugin)
-    {
-        return createContainer().withEnv( Neo4jPluginEnv.get(), "[\"" +plugin.name+ "\"]" );
+    private GenericContainer createContainerWithBundledPlugin(BundledPlugin plugin) {
+        return createContainer().withEnv(Neo4jPluginEnv.get(), "[\"" + plugin.name + "\"]");
     }
 
     @ParameterizedTest(name = "testBundledPlugin_{0}")
     @MethodSource("bundledPluginsArgs")
-    public void testBundledPlugin(BundledPlugin plugin) throws Exception
-    {
-        Assumptions.assumeTrue(plugin.shouldBePresentInImage(),
-                "test only applies when the plugin "+plugin.name+" is present");
+    public void testBundledPlugin(BundledPlugin plugin) throws Exception {
+        Assumptions.assumeTrue(
+                plugin.shouldBePresentInImage(), "test only applies when the plugin " + plugin.name + " is present");
 
         GenericContainer container = null;
         Path pluginsMount = null;
-        try
-        {
+        try {
             container = createContainerWithBundledPlugin(plugin);
             pluginsMount = temporaryFolderManager.createFolderAndMountAsVolume(container, "/plugins");
             container.start();
-            DatabaseIO dbio = new DatabaseIO( container );
-            dbio.putInitialDataIntoContainer( "neo4j", "none" );
-        }
-        catch(ContainerLaunchException e)
-        {
+            DatabaseIO dbio = new DatabaseIO(container);
+            dbio.putInitialDataIntoContainer("neo4j", "none");
+        } catch (ContainerLaunchException e) {
             // we don't want this test to depend on the plugins actually working (that's outside the scope of
             // the docker tests), so we have to be robust to the container failing to start.
-            log.error( String.format("The bundled %s plugin caused Neo4j to fail to start.", plugin.name) );
-        }
-        finally
-        {
+            log.error(String.format("The bundled %s plugin caused Neo4j to fail to start.", plugin.name));
+        } finally {
             // verify the plugins were loaded.
             // This is done in the finally block because after stopping the container, the stdout cannot be retrieved.
-            if (pluginsMount != null)
-            {
-                List<String> plugins = Files.list(pluginsMount).map( fname -> fname.getFileName().toString() )
-                                            .filter( fname -> fname.endsWith( ".jar" ) )
-                                            .collect(Collectors.toList());
-                Assertions.assertEquals(1, plugins.size(), "expected only one plugin to be loaded" );
-                Assertions.assertTrue( plugins.get( 0 ).contains( plugin.name ) );
+            if (pluginsMount != null) {
+                List<String> plugins = Files.list(pluginsMount)
+                        .map(fname -> fname.getFileName().toString())
+                        .filter(fname -> fname.endsWith(".jar"))
+                        .collect(Collectors.toList());
+                Assertions.assertEquals(1, plugins.size(), "expected only one plugin to be loaded");
+                Assertions.assertTrue(plugins.get(0).contains(plugin.name));
                 // Verify from container logs, that the plugins were loaded locally rather than downloaded.
-                String logs = container.getLogs( OutputFrame.OutputType.STDOUT);
-                String errlogs = container.getLogs( OutputFrame.OutputType.STDERR);
+                String logs = container.getLogs(OutputFrame.OutputType.STDOUT);
+                String errlogs = container.getLogs(OutputFrame.OutputType.STDERR);
                 Assertions.assertTrue(
-                        Stream.of(logs.split( "\n" ))
-                              .anyMatch( line -> line.matches( "Installing Plugin '" + plugin.name + "' from /var/lib/neo4j/.*" ) ),
+                        Stream.of(logs.split("\n"))
+                                .anyMatch(line ->
+                                        line.matches("Installing Plugin '" + plugin.name + "' from /var/lib/neo4j/.*")),
                         "Plugin was not installed from neo4j home");
             }
-            if(container !=null)
-            {
+            if (container != null) {
                 container.stop();
-            }
-            else
-            {
+            } else {
                 Assertions.fail("Test failed before container could even be initialised");
             }
         }
     }
 
     @Test
-    void testPluginLoadsWithAuthentication() throws Exception
-    {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( Neo4jVersion.NEO4J_VERSION_500 ) );
+    void testPluginLoadsWithAuthentication() throws Exception {
+        Assumptions.assumeTrue(TestSettings.NEO4J_VERSION.isAtLeastVersion(Neo4jVersion.NEO4J_VERSION_500));
 
         final String PASSWORD = "12345678";
 
-        try( GenericContainer container = createContainerWithBundledPlugin(BLOOM))
-        {
-            container.withEnv( "NEO4J_AUTH", "neo4j/"+PASSWORD )
-                     .withEnv( "NEO4J_dbms_bloom_license__file", "/licenses/bloom.license" );
+        try (GenericContainer container = createContainerWithBundledPlugin(BLOOM)) {
+            container
+                    .withEnv("NEO4J_AUTH", "neo4j/" + PASSWORD)
+                    .withEnv("NEO4J_dbms_bloom_license__file", "/licenses/bloom.license");
             // mounting logs because it's useful for debugging
             temporaryFolderManager.createFolderAndMountAsVolume(container, "/logs");
             Path licenseFolder = temporaryFolderManager.createFolderAndMountAsVolume(container, "/licenses");
-            Files.writeString( licenseFolder.resolve("bloom.license"), "notareallicense" );
+            Files.writeString(licenseFolder.resolve("bloom.license"), "notareallicense");
             // make sure the container successfully starts and we can write to it without getting authentication errors
             container.start();
-            DatabaseIO dbio = new DatabaseIO( container );
-            dbio.putInitialDataIntoContainer( "neo4j", PASSWORD );
+            DatabaseIO dbio = new DatabaseIO(container);
+            dbio.putInitialDataIntoContainer("neo4j", PASSWORD);
         }
     }
 
     @Test
-    void testBrowserListensOn7474() throws Exception
-    {
-        try(GenericContainer container = createContainer())
-        {
-            container.waitingFor( new HttpWaitStrategy()
-                                          .forPort(7474)
-                                          .forStatusCode(200)
-                                          .withStartupTimeout(Duration.ofSeconds(60)) );
+    void testBrowserListensOn7474() throws Exception {
+        try (GenericContainer container = createContainer()) {
+            container.waitingFor(
+                    new HttpWaitStrategy().forPort(7474).forStatusCode(200).withStartupTimeout(Duration.ofSeconds(60)));
             container.start();
-            Assertions.assertTrue( container.isRunning() );
-            Container.ExecResult r = container.execInContainer( "wget", "-q", "-O", "-", "http://localhost:7474/browser/" );
-            Assertions.assertEquals( 0, r.getExitCode(), "Did not get http response from browser");
-            Assertions.assertFalse( r.getStdout().isEmpty(), "HTTP response from browser was empty." );
-            Assertions.assertTrue( r.getStdout().contains( "Neo4j Browser" ),
-                                   "HTTP response from browser did not contain expected information.\n"+r.getStdout());
+            Assertions.assertTrue(container.isRunning());
+            Container.ExecResult r =
+                    container.execInContainer("wget", "-q", "-O", "-", "http://localhost:7474/browser/");
+            Assertions.assertEquals(0, r.getExitCode(), "Did not get http response from browser");
+            Assertions.assertFalse(r.getStdout().isEmpty(), "HTTP response from browser was empty.");
+            Assertions.assertTrue(
+                    r.getStdout().contains("Neo4j Browser"),
+                    "HTTP response from browser did not contain expected information.\n" + r.getStdout());
         }
     }
 }

--- a/src/test/java/com/neo4j/docker/coredb/plugins/TestPluginInstallation.java
+++ b/src/test/java/com/neo4j/docker/coredb/plugins/TestPluginInstallation.java
@@ -1,5 +1,7 @@
 package com.neo4j.docker.coredb.plugins;
 
+import static com.neo4j.docker.utils.TestSettings.NEO4J_VERSION;
+
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.neo4j.docker.coredb.configurations.Configuration;
 import com.neo4j.docker.coredb.configurations.Setting;
@@ -10,6 +12,10 @@ import com.neo4j.docker.utils.SetContainerUser;
 import com.neo4j.docker.utils.TemporaryFolderManager;
 import com.neo4j.docker.utils.TestSettings;
 import com.neo4j.docker.utils.WaitStrategies;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
@@ -26,244 +32,234 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 
-import java.nio.file.Path;
-import java.time.Duration;
-import java.util.List;
-import java.util.function.Consumer;
-
-import static com.neo4j.docker.utils.TestSettings.NEO4J_VERSION;
-
-
-public class TestPluginInstallation
-{
+public class TestPluginInstallation {
     private static final String DB_USER = "neo4j";
     private static final String DB_PASSWORD = "qualityPassword";
 
-    private final Logger log = LoggerFactory.getLogger( TestPluginInstallation.class );
+    private final Logger log = LoggerFactory.getLogger(TestPluginInstallation.class);
+
     @RegisterExtension
     public static TemporaryFolderManager temporaryFolderManager = new TemporaryFolderManager();
+
     @RegisterExtension
     public HttpServerTestExtension httpServer = new HttpServerTestExtension();
+
     StubPluginHelper stubPluginHelper = new StubPluginHelper(httpServer);
 
+    private GenericContainer createContainerWithTestingPlugin(boolean asCurrentUser) {
+        Testcontainers.exposeHostPorts(httpServer.PORT);
+        GenericContainer container = new GenericContainer(TestSettings.IMAGE_ID);
 
-    private GenericContainer createContainerWithTestingPlugin(boolean asCurrentUser)
-    {
-        Testcontainers.exposeHostPorts( httpServer.PORT );
-        GenericContainer container = new GenericContainer( TestSettings.IMAGE_ID );
-
-        container.withEnv( "NEO4J_AUTH", DB_USER + "/" + DB_PASSWORD )
-                 .withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
-                 .withEnv( "NEO4J_DEBUG", "yes" )
-                 .withEnv( Neo4jPluginEnv.get(), "[\"" + stubPluginHelper.PLUGIN_ENV_NAME + "\"]" )
-                 .withExposedPorts( 7474, 7687 )
-                 .withLogConsumer( new Slf4jLogConsumer( log ) )
-                 .waitingFor( WaitStrategies.waitForNeo4jReady( DB_PASSWORD));
-        if(asCurrentUser) SetContainerUser.nonRootUser( container );
+        container
+                .withEnv("NEO4J_AUTH", DB_USER + "/" + DB_PASSWORD)
+                .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+                .withEnv("NEO4J_DEBUG", "yes")
+                .withEnv(Neo4jPluginEnv.get(), "[\"" + stubPluginHelper.PLUGIN_ENV_NAME + "\"]")
+                .withExposedPorts(7474, 7687)
+                .withLogConsumer(new Slf4jLogConsumer(log))
+                .waitingFor(WaitStrategies.waitForNeo4jReady(DB_PASSWORD));
+        if (asCurrentUser) SetContainerUser.nonRootUser(container);
         return container;
     }
 
     @ParameterizedTest(name = "as_current_user_{0}")
-    @ValueSource( booleans = {true, false} )
-    public void testPluginLoads(boolean asCurrentUser) throws Exception
-    {
+    @ValueSource(booleans = {true, false})
+    public void testPluginLoads(boolean asCurrentUser) throws Exception {
         Path pluginsDir = temporaryFolderManager.createFolder("plugins");
         stubPluginHelper.createStubPluginForVersion(pluginsDir, NEO4J_VERSION);
-        try ( GenericContainer container = createContainerWithTestingPlugin(asCurrentUser) )
-        {
+        try (GenericContainer container = createContainerWithTestingPlugin(asCurrentUser)) {
             container.start();
-            DatabaseIO db = new DatabaseIO( container );
-            stubPluginHelper.verifyStubPluginLoaded( db, DB_USER, DB_PASSWORD );
+            DatabaseIO db = new DatabaseIO(container);
+            stubPluginHelper.verifyStubPluginLoaded(db, DB_USER, DB_PASSWORD);
         }
     }
 
     @Test
-    public void test_NEO4JLABS_PLUGIN_envWorksIn5() throws Exception
-    {
-        Assumptions.assumeTrue( NEO4J_VERSION.isAtLeastVersion( Neo4jVersion.NEO4J_VERSION_500 ),
-                                "NEO4JLABS_PLUGIN backwards compatibility does not need checking pre 5.x" );
+    public void test_NEO4JLABS_PLUGIN_envWorksIn5() throws Exception {
+        Assumptions.assumeTrue(
+                NEO4J_VERSION.isAtLeastVersion(Neo4jVersion.NEO4J_VERSION_500),
+                "NEO4JLABS_PLUGIN backwards compatibility does not need checking pre 5.x");
 
         Path pluginsDir = temporaryFolderManager.createFolder("plugins");
         stubPluginHelper.createStubPluginForVersion(pluginsDir, NEO4J_VERSION);
-        try ( GenericContainer container = createContainerWithTestingPlugin(false) )
-        {
-            container.withEnv( Neo4jPluginEnv.PLUGIN_ENV_5X, "" );
-            container.withEnv( Neo4jPluginEnv.PLUGIN_ENV_4X, "[\"_testing\"]" );
+        try (GenericContainer container = createContainerWithTestingPlugin(false)) {
+            container.withEnv(Neo4jPluginEnv.PLUGIN_ENV_5X, "");
+            container.withEnv(Neo4jPluginEnv.PLUGIN_ENV_4X, "[\"_testing\"]");
             container.start();
-            DatabaseIO db = new DatabaseIO( container );
-            stubPluginHelper.verifyStubPluginLoaded( db, DB_USER, DB_PASSWORD );
+            DatabaseIO db = new DatabaseIO(container);
+            stubPluginHelper.verifyStubPluginLoaded(db, DB_USER, DB_PASSWORD);
         }
     }
 
     @Test
-    public void test_NEO4J_PLUGIN_envWorksIn44() throws Exception
-    {
-        Assumptions.assumeTrue( NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 4, 4, 18 ) ),
-                                "NEO4JLABS_PLUGIN did not work in 4.4 before 4.4.18" );
-        Assumptions.assumeTrue( NEO4J_VERSION.isOlderThan( Neo4jVersion.NEO4J_VERSION_500 ),
-                                "Only checking forwards compatibility in 4.4" );
+    public void test_NEO4J_PLUGIN_envWorksIn44() throws Exception {
+        Assumptions.assumeTrue(
+                NEO4J_VERSION.isAtLeastVersion(new Neo4jVersion(4, 4, 18)),
+                "NEO4JLABS_PLUGIN did not work in 4.4 before 4.4.18");
+        Assumptions.assumeTrue(
+                NEO4J_VERSION.isOlderThan(Neo4jVersion.NEO4J_VERSION_500),
+                "Only checking forwards compatibility in 4.4");
 
         Path pluginsDir = temporaryFolderManager.createFolder("plugins");
         stubPluginHelper.createStubPluginForVersion(pluginsDir, NEO4J_VERSION);
-        try ( GenericContainer container = createContainerWithTestingPlugin(false) )
-        {
-            container.withEnv( Neo4jPluginEnv.PLUGIN_ENV_5X, "[\"_testing\"]" );
-            container.withEnv( Neo4jPluginEnv.PLUGIN_ENV_4X, "" );
+        try (GenericContainer container = createContainerWithTestingPlugin(false)) {
+            container.withEnv(Neo4jPluginEnv.PLUGIN_ENV_5X, "[\"_testing\"]");
+            container.withEnv(Neo4jPluginEnv.PLUGIN_ENV_4X, "");
             container.start();
-            DatabaseIO db = new DatabaseIO( container );
-            stubPluginHelper.verifyStubPluginLoaded( db, DB_USER, DB_PASSWORD );
+            DatabaseIO db = new DatabaseIO(container);
+            stubPluginHelper.verifyStubPluginLoaded(db, DB_USER, DB_PASSWORD);
         }
     }
 
     @Test
-    public void testPluginConfigurationDoesNotOverrideUserSetValues() throws Exception
-    {
+    public void testPluginConfigurationDoesNotOverrideUserSetValues() throws Exception {
         Path pluginsDir = temporaryFolderManager.createFolder("plugins");
-        Configuration securityProcedures = Configuration.getConfigurationNameMap()
-                .get( Setting.SECURITY_PROCEDURES_UNRESTRICTED );
+        Configuration securityProcedures =
+                Configuration.getConfigurationNameMap().get(Setting.SECURITY_PROCEDURES_UNRESTRICTED);
         stubPluginHelper.createStubPluginForVersion(pluginsDir, NEO4J_VERSION);
-        try ( GenericContainer container = createContainerWithTestingPlugin(false) )
-        {
-            container.withEnv( securityProcedures.envName, "foo" );
+        try (GenericContainer container = createContainerWithTestingPlugin(false)) {
+            container.withEnv(securityProcedures.envName, "foo");
             container.start();
             // When we connect to the database with the plugin
             // Check that the config remains as set by our env var and is not overridden by the plugin defaults
-            DatabaseIO db = new DatabaseIO( container );
-            stubPluginHelper.verifyStubPluginLoaded( db, DB_USER, DB_PASSWORD );
-            db.verifyConfigurationSetting( DB_USER, DB_PASSWORD,
-                                           securityProcedures,
-                                           "foo",
-                                           "neo4j config should not be overridden by plugin" );
+            DatabaseIO db = new DatabaseIO(container);
+            stubPluginHelper.verifyStubPluginLoaded(db, DB_USER, DB_PASSWORD);
+            db.verifyConfigurationSetting(
+                    DB_USER, DB_PASSWORD, securityProcedures, "foo", "neo4j config should not be overridden by plugin");
         }
     }
 
     @Test
-    void invalidPluginNameShouldGiveOptionsAndError()
-    {
-        Assumptions.assumeTrue( NEO4J_VERSION.isAtLeastVersion( Neo4jVersion.NEO4J_VERSION_440 ) );
-        try ( GenericContainer container = new GenericContainer( TestSettings.IMAGE_ID ) )
-        {
+    void invalidPluginNameShouldGiveOptionsAndError() {
+        Assumptions.assumeTrue(NEO4J_VERSION.isAtLeastVersion(Neo4jVersion.NEO4J_VERSION_440));
+        try (GenericContainer container = new GenericContainer(TestSettings.IMAGE_ID)) {
             // if we try to set a plugin that doesn't exist
-            container.withEnv( Neo4jPluginEnv.get(), "[\"notarealplugin\"]" )
-                     .withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
-                     .withLogConsumer( new Slf4jLogConsumer( log ) );
-            WaitStrategies.waitUntilContainerFinished( container, Duration.ofSeconds( 30 ) );
-            Assertions.assertThrows( ContainerLaunchException.class, container::start );
+            container
+                    .withEnv(Neo4jPluginEnv.get(), "[\"notarealplugin\"]")
+                    .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+                    .withLogConsumer(new Slf4jLogConsumer(log));
+            WaitStrategies.waitUntilContainerFinished(container, Duration.ofSeconds(30));
+            Assertions.assertThrows(ContainerLaunchException.class, container::start);
             // the container should output a helpful message and quit
             String stdout = container.getLogs();
-            Assertions.assertTrue( stdout.contains( "\"notarealplugin\" is not a known Neo4j plugin. Options are:" ) );
-            Assertions.assertFalse( stdout.contains( "_testing" ), "Fake _testing plugin is exposed." );
+            Assertions.assertTrue(stdout.contains("\"notarealplugin\" is not a known Neo4j plugin. Options are:"));
+            Assertions.assertFalse(stdout.contains("_testing"), "Fake _testing plugin is exposed.");
         }
     }
 
     @Test
-    void invalidPluginNameShouldGiveOptionsAndError_mulitpleplugins()
-    {
-        Assumptions.assumeTrue( NEO4J_VERSION.isAtLeastVersion( Neo4jVersion.NEO4J_VERSION_440 ) );
-        try ( GenericContainer container = new GenericContainer( TestSettings.IMAGE_ID ) )
-        {
+    void invalidPluginNameShouldGiveOptionsAndError_mulitpleplugins() {
+        Assumptions.assumeTrue(NEO4J_VERSION.isAtLeastVersion(Neo4jVersion.NEO4J_VERSION_440));
+        try (GenericContainer container = new GenericContainer(TestSettings.IMAGE_ID)) {
             // if we try to set a plugin that doesn't exist
-            container.withEnv( Neo4jPluginEnv.get(), "[\"apoc\", \"notarealplugin\"]" )
-                     .withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
-                     .withLogConsumer( new Slf4jLogConsumer( log ) );
-            WaitStrategies.waitUntilContainerFinished( container, Duration.ofSeconds( 30 ) );
-            Assertions.assertThrows( ContainerLaunchException.class, container::start );
+            container
+                    .withEnv(Neo4jPluginEnv.get(), "[\"apoc\", \"notarealplugin\"]")
+                    .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+                    .withLogConsumer(new Slf4jLogConsumer(log));
+            WaitStrategies.waitUntilContainerFinished(container, Duration.ofSeconds(30));
+            Assertions.assertThrows(ContainerLaunchException.class, container::start);
             // the container should output a helpful message and quit
             String stdout = container.getLogs();
-            Assertions.assertTrue( stdout.contains( "\"notarealplugin\" is not a known Neo4j plugin. Options are:" ) );
-            Assertions.assertFalse( stdout.contains( StubPluginHelper.PLUGIN_ENV_NAME), "Fake _testing plugin is exposed." );
+            Assertions.assertTrue(stdout.contains("\"notarealplugin\" is not a known Neo4j plugin. Options are:"));
+            Assertions.assertFalse(
+                    stdout.contains(StubPluginHelper.PLUGIN_ENV_NAME), "Fake _testing plugin is exposed.");
         }
     }
 
     @Test
-    public void testBrokenVersionsJsonGivesWarning() throws Exception
-    {
-        Assumptions.assumeTrue( NEO4J_VERSION.isAtLeastVersion( Neo4jVersion.NEO4J_VERSION_440 ) );
+    public void testBrokenVersionsJsonGivesWarning() throws Exception {
+        Assumptions.assumeTrue(NEO4J_VERSION.isAtLeastVersion(Neo4jVersion.NEO4J_VERSION_440));
         Path pluginsDir = temporaryFolderManager.createFolder("plugins");
         // create a versions.json that DOES NOT contain the current neo4j version in its mapping
-        stubPluginHelper.createStubPluginForVersion(pluginsDir, new Neo4jVersion(50,0,0));
-        try ( GenericContainer container = createContainerWithTestingPlugin(true) )
-        {
+        stubPluginHelper.createStubPluginForVersion(pluginsDir, new Neo4jVersion(50, 0, 0));
+        try (GenericContainer container = createContainerWithTestingPlugin(true)) {
             container.start();
-            String startupErrors = container.getLogs( OutputFrame.OutputType.STDERR );
-            Assertions.assertTrue( startupErrors.contains( "No compatible \"_testing\" plugin found for Neo4j " + NEO4J_VERSION ),
-                                   "Did not error about plugin compatibility." );
-            DatabaseIO db = new DatabaseIO( container );
+            String startupErrors = container.getLogs(OutputFrame.OutputType.STDERR);
+            Assertions.assertTrue(
+                    startupErrors.contains("No compatible \"_testing\" plugin found for Neo4j " + NEO4J_VERSION),
+                    "Did not error about plugin compatibility.");
+            DatabaseIO db = new DatabaseIO(container);
             // make sure plugin did not load
-            List<Record> procedures = db.runCypherQuery( DB_USER, DB_PASSWORD,
-                                                         "SHOW PROCEDURES YIELD name, signature RETURN name, signature" );
-            Assertions.assertFalse( procedures.stream()
-                                              .anyMatch( x -> x.get( "name" ).asString()
-                                                               .equals( "com.neo4j.docker.test.myplugin.defaultValues" ) ),
-                                    "Incompatible test plugin was loaded." );
+            List<Record> procedures = db.runCypherQuery(
+                    DB_USER, DB_PASSWORD, "SHOW PROCEDURES YIELD name, signature RETURN name, signature");
+            Assertions.assertFalse(
+                    procedures.stream()
+                            .anyMatch(x ->
+                                    x.get("name").asString().equals("com.neo4j.docker.test.myplugin.defaultValues")),
+                    "Incompatible test plugin was loaded.");
         }
     }
 
-    //@Disabled("Test is flaky for unknown reasons. Needs further investigation.")
+    // @Disabled("Test is flaky for unknown reasons. Needs further investigation.")
     @Test
-    void testMissingVersionsJsonGivesWarning()
-    {
-        Configuration securityProcedures = Configuration.getConfigurationNameMap().get(Setting.SECURITY_PROCEDURES_UNRESTRICTED);
+    void testMissingVersionsJsonGivesWarning() {
+        Configuration securityProcedures =
+                Configuration.getConfigurationNameMap().get(Setting.SECURITY_PROCEDURES_UNRESTRICTED);
         // make double sure there are no versions.json files being served.
         httpServer.unregisterEndpoint("/versions.json");
-        try ( Network net = Network.newNetwork();
-              GenericContainer container = createContainerWithTestingPlugin(false)
-                      .withNetwork(net) ) {
+        try (Network net = Network.newNetwork();
+                GenericContainer container =
+                        createContainerWithTestingPlugin(false).withNetwork(net)) {
             container.start();
-            String startupErrors = container.getLogs( OutputFrame.OutputType.STDERR );
+            String startupErrors = container.getLogs(OutputFrame.OutputType.STDERR);
             Assertions.assertTrue(
-                    startupErrors.contains( "could not query http://host.testcontainers.internal:3000/versions.json for plugin compatibility information" ),
-                    "Did not error about missing versions.json. Actual errors:\n\"" + startupErrors + "\"" );
-            Assertions.assertFalse( startupErrors.contains( "No compatible \"_testing\" plugin found for Neo4j " + NEO4J_VERSION ),
-                                    "Should not have errored about incompatible versions in versions.json" );
+                    startupErrors.contains(
+                            "could not query http://host.testcontainers.internal:3000/versions.json for plugin compatibility information"),
+                    "Did not error about missing versions.json. Actual errors:\n\"" + startupErrors + "\"");
+            Assertions.assertFalse(
+                    startupErrors.contains("No compatible \"_testing\" plugin found for Neo4j " + NEO4J_VERSION),
+                    "Should not have errored about incompatible versions in versions.json");
             // make sure plugin did not load
-            DatabaseIO db = new DatabaseIO( container );
-            List<Record> procedures = db.runCypherQuery( DB_USER, DB_PASSWORD,
-                                                         "SHOW PROCEDURES YIELD name, signature RETURN name, signature" );
-            Assertions.assertFalse( procedures.stream()
-                                              .anyMatch( x -> x.get( "name" ).asString()
-                                                               .equals( "com.neo4j.docker.test.myplugin.defaultValues" ) ),
-                                    "Incompatible test plugin was loaded." );
+            DatabaseIO db = new DatabaseIO(container);
+            List<Record> procedures = db.runCypherQuery(
+                    DB_USER, DB_PASSWORD, "SHOW PROCEDURES YIELD name, signature RETURN name, signature");
+            Assertions.assertFalse(
+                    procedures.stream()
+                            .anyMatch(x ->
+                                    x.get("name").asString().equals("com.neo4j.docker.test.myplugin.defaultValues")),
+                    "Incompatible test plugin was loaded.");
             // make sure configuration did not set
             String securityConf = db.getConfigurationSettingAsString(DB_USER, DB_PASSWORD, securityProcedures);
-            Assertions.assertFalse(securityConf.contains("com.neo4j.docker.neo4jserver.plugins.*"),
+            Assertions.assertFalse(
+                    securityConf.contains("com.neo4j.docker.neo4jserver.plugins.*"),
                     "Test plugin configuration setting was set, even though the plugin did not load.");
         }
     }
 
     @ParameterizedTest(name = "as_current_user_{0}")
-    @ValueSource( booleans = {true, false} )
-    public void testPlugin_originalEntrypointLocation(boolean asCurrentUser) throws Exception
-    {
+    @ValueSource(booleans = {true, false})
+    public void testPlugin_originalEntrypointLocation(boolean asCurrentUser) throws Exception {
         // Older versions of Neo4j had docker-entrypoint.sh in / rather than /startup and sometimes
         // users use the old entrypoint location. This apparently caused problems loading plugins.
-        Assumptions.assumeTrue( NEO4J_VERSION.isOlderThan( Neo4jVersion.NEO4J_VERSION_500 ),
-                                "/docker-entrypoint.sh is permanently moved from 5.0 onwards" );
+        Assumptions.assumeTrue(
+                NEO4J_VERSION.isOlderThan(Neo4jVersion.NEO4J_VERSION_500),
+                "/docker-entrypoint.sh is permanently moved from 5.0 onwards");
         Path pluginsDir = temporaryFolderManager.createFolder("plugins");
         stubPluginHelper.createStubPluginForVersion(pluginsDir, NEO4J_VERSION);
-        try ( GenericContainer container = createContainerWithTestingPlugin(asCurrentUser) )
-        {
+        try (GenericContainer container = createContainerWithTestingPlugin(asCurrentUser)) {
             container.withCreateContainerCmdModifier(
-                    (Consumer<CreateContainerCmd>) cmd -> cmd.withEntrypoint( "/docker-entrypoint.sh", "neo4j" ) );
+                    (Consumer<CreateContainerCmd>) cmd -> cmd.withEntrypoint("/docker-entrypoint.sh", "neo4j"));
             container.start();
-            DatabaseIO db = new DatabaseIO( container );
-            stubPluginHelper.verifyStubPluginLoaded( db, DB_USER, DB_PASSWORD );
+            DatabaseIO db = new DatabaseIO(container);
+            stubPluginHelper.verifyStubPluginLoaded(db, DB_USER, DB_PASSWORD);
         }
     }
 
-    @ParameterizedTest( name = "as_current_user_{0}" )
-    @ValueSource( booleans = {true, false} )
-    void testPluginIsMovedToMountedFolderAndIsLoadedCorrectly( boolean asCurrentUser ) throws Exception
-    {
-        try ( GenericContainer container = createContainerWithTestingPlugin(asCurrentUser))
-        {
+    @ParameterizedTest(name = "as_current_user_{0}")
+    @ValueSource(booleans = {true, false})
+    void testPluginIsMovedToMountedFolderAndIsLoadedCorrectly(boolean asCurrentUser) throws Exception {
+        try (GenericContainer container = createContainerWithTestingPlugin(asCurrentUser)) {
             Path pluginsFolder = temporaryFolderManager.createFolderAndMountAsVolume(container, "/plugins");
             stubPluginHelper.createStubPluginForVersion(pluginsFolder, NEO4J_VERSION);
             container.start();
-            Assertions.assertTrue( pluginsFolder.resolve( StubPluginHelper.PLUGIN_ENV_NAME +".jar" ).toFile().exists(),
+            Assertions.assertTrue(
+                    pluginsFolder
+                            .resolve(StubPluginHelper.PLUGIN_ENV_NAME + ".jar")
+                            .toFile()
+                            .exists(),
                     "Did not find _testing.jar in plugins folder");
 
-            DatabaseIO databaseIO = new DatabaseIO( container );
+            DatabaseIO databaseIO = new DatabaseIO(container);
             stubPluginHelper.verifyStubPluginLoaded(databaseIO, DB_USER, DB_PASSWORD);
         }
     }

--- a/src/test/java/com/neo4j/docker/coredb/plugins/TestSemVerPluginMatching.java
+++ b/src/test/java/com/neo4j/docker/coredb/plugins/TestSemVerPluginMatching.java
@@ -1,11 +1,19 @@
 package com.neo4j.docker.coredb.plugins;
 
+import static com.neo4j.docker.utils.TestSettings.NEO4J_VERSION;
+
 import com.neo4j.docker.utils.DatabaseIO;
 import com.neo4j.docker.utils.HttpServerTestExtension;
 import com.neo4j.docker.utils.Neo4jVersion;
 import com.neo4j.docker.utils.TemporaryFolderManager;
 import com.neo4j.docker.utils.TestSettings;
 import com.neo4j.docker.utils.WaitStrategies;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -16,174 +24,159 @@ import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import static com.neo4j.docker.utils.TestSettings.NEO4J_VERSION;
-
-public class TestSemVerPluginMatching
-{
+public class TestSemVerPluginMatching {
     private static final String DB_USER = "neo4j";
     private static final String DB_PASSWORD = "qualityPassword123";
     private final Logger log = LoggerFactory.getLogger(TestSemVerPluginMatching.class);
 
     @RegisterExtension
     public static TemporaryFolderManager temporaryFolderManager = new TemporaryFolderManager();
+
     @RegisterExtension
     public HttpServerTestExtension httpServer = new HttpServerTestExtension();
+
     StubPluginHelper stubPluginHelper = new StubPluginHelper(httpServer);
 
+    private GenericContainer<?> createContainerWithTestPlugin() {
+        Testcontainers.exposeHostPorts(httpServer.PORT);
+        GenericContainer<?> container = new GenericContainer<>(TestSettings.IMAGE_ID);
 
-    private GenericContainer<?> createContainerWithTestPlugin()
-    {
-        Testcontainers.exposeHostPorts( httpServer.PORT );
-        GenericContainer<?> container = new GenericContainer<>( TestSettings.IMAGE_ID );
-
-        container.withEnv( "NEO4J_AUTH", DB_USER + "/" + DB_PASSWORD )
-                .withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
-                .withEnv( "NEO4J_DEBUG", "yes" )
-                .withEnv( Neo4jPluginEnv.get(), "[\"" + StubPluginHelper.PLUGIN_ENV_NAME + "\"]" )
-                .withExposedPorts( 7474, 7687 )
-                .withLogConsumer( new Slf4jLogConsumer( log ) )
-                .waitingFor( WaitStrategies.waitForNeo4jReady(DB_PASSWORD));
+        container
+                .withEnv("NEO4J_AUTH", DB_USER + "/" + DB_PASSWORD)
+                .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+                .withEnv("NEO4J_DEBUG", "yes")
+                .withEnv(Neo4jPluginEnv.get(), "[\"" + StubPluginHelper.PLUGIN_ENV_NAME + "\"]")
+                .withExposedPorts(7474, 7687)
+                .withLogConsumer(new Slf4jLogConsumer(log))
+                .waitingFor(WaitStrategies.waitForNeo4jReady(DB_PASSWORD));
         return container;
     }
 
     @Test
-    void testSemanticVersioningLogic() throws Exception
-    {
+    void testSemanticVersioningLogic() throws Exception {
         // testing common neo4j name variants
-        List<String> neo4jVersions = new ArrayList<String>()
-        {{
-            add( NEO4J_VERSION.toReleaseString() );
-            add( NEO4J_VERSION.toReleaseString() + "-12345" );
-        }};
+        List<String> neo4jVersions = new ArrayList<String>() {
+            {
+                add(NEO4J_VERSION.toReleaseString());
+                add(NEO4J_VERSION.toReleaseString() + "-12345");
+            }
+        };
 
-        List<String> matchingCases = new ArrayList<String>()
-        {{
-            add( NEO4J_VERSION.toReleaseString() );
-            add( Neo4jVersion.makeVersionString( NEO4J_VERSION.major, NEO4J_VERSION.minor)+".x" );
-            add( Neo4jVersion.makeVersionString( NEO4J_VERSION.major, NEO4J_VERSION.minor)+".*" );
-            add( NEO4J_VERSION.major + ".x.x" );
-            add( NEO4J_VERSION.major + ".*.*" );
-            add( "x.x.x" );
-            add( "*.*.*" );
-        }};
+        List<String> matchingCases = new ArrayList<String>() {
+            {
+                add(NEO4J_VERSION.toReleaseString());
+                add(Neo4jVersion.makeVersionString(NEO4J_VERSION.major, NEO4J_VERSION.minor) + ".x");
+                add(Neo4jVersion.makeVersionString(NEO4J_VERSION.major, NEO4J_VERSION.minor) + ".*");
+                add(NEO4J_VERSION.major + ".x.x");
+                add(NEO4J_VERSION.major + ".*.*");
+                add("x.x.x");
+                add("*.*.*");
+            }
+        };
 
-        List<String> nonMatchingCases = new ArrayList<String>()
-        {{
-            add( Neo4jVersion.makeVersionString( NEO4J_VERSION.major+1, NEO4J_VERSION.minor)+".x" );
-            add( Neo4jVersion.makeVersionString( NEO4J_VERSION.major-1, NEO4J_VERSION.minor)+".x" );
-            add( Neo4jVersion.makeVersionString( NEO4J_VERSION.major, NEO4J_VERSION.minor+1)+".x" );
-            add( Neo4jVersion.makeVersionString( NEO4J_VERSION.major, NEO4J_VERSION.minor-1)+".x" );
-            add( Neo4jVersion.makeVersionString( NEO4J_VERSION.major+1, NEO4J_VERSION.minor)+".*" );
-            add( Neo4jVersion.makeVersionString( NEO4J_VERSION.major-1, NEO4J_VERSION.minor)+".*" );
-            add( Neo4jVersion.makeVersionString( NEO4J_VERSION.major, NEO4J_VERSION.minor+1)+".*" );
-            add( Neo4jVersion.makeVersionString( NEO4J_VERSION.major, NEO4J_VERSION.minor-1)+".*" );
-        }};
+        List<String> nonMatchingCases = new ArrayList<String>() {
+            {
+                add(Neo4jVersion.makeVersionString(NEO4J_VERSION.major + 1, NEO4J_VERSION.minor) + ".x");
+                add(Neo4jVersion.makeVersionString(NEO4J_VERSION.major - 1, NEO4J_VERSION.minor) + ".x");
+                add(Neo4jVersion.makeVersionString(NEO4J_VERSION.major, NEO4J_VERSION.minor + 1) + ".x");
+                add(Neo4jVersion.makeVersionString(NEO4J_VERSION.major, NEO4J_VERSION.minor - 1) + ".x");
+                add(Neo4jVersion.makeVersionString(NEO4J_VERSION.major + 1, NEO4J_VERSION.minor) + ".*");
+                add(Neo4jVersion.makeVersionString(NEO4J_VERSION.major - 1, NEO4J_VERSION.minor) + ".*");
+                add(Neo4jVersion.makeVersionString(NEO4J_VERSION.major, NEO4J_VERSION.minor + 1) + ".*");
+                add(Neo4jVersion.makeVersionString(NEO4J_VERSION.major, NEO4J_VERSION.minor - 1) + ".*");
+            }
+        };
 
         // Asserting every test case means that if there's a failure, all further tests won't run.
         // Instead we're running all tests and saving any failed cases for reporting at the end of the test.
         List<String> failedTests = new ArrayList<String>();
 
-        try ( GenericContainer container = createContainerWithTestPlugin() )
-        {
-            container.withEnv( Neo4jPluginEnv.get(), "" ); // don't need the _testing plugin for this
+        try (GenericContainer container = createContainerWithTestPlugin()) {
+            container.withEnv(Neo4jPluginEnv.get(), ""); // don't need the _testing plugin for this
             container.start();
 
-            String semverQuery = "echo \"{\\\"neo4j\\\":\\\"%s\\\"}\" | " +
-                    "jq -L/startup --raw-output \"import \\\"semver\\\" as lib; " +
-                    ".neo4j | lib::semver(\\\"%s\\\")\"";
-            for ( String verToBeMatched : neo4jVersions )
-            {
-                for ( String verRegex : matchingCases )
-                {
-                    Container.ExecResult out = container.execInContainer( "sh", "-c", String.format( semverQuery, verRegex, verToBeMatched ) );
-                    if ( !out.getStdout().trim().equals( "true" ) )
-                    {
-                        failedTests.add( String.format( "%s should match %s but did not", verRegex, verToBeMatched ) );
+            String semverQuery = "echo \"{\\\"neo4j\\\":\\\"%s\\\"}\" | "
+                    + "jq -L/startup --raw-output \"import \\\"semver\\\" as lib; "
+                    + ".neo4j | lib::semver(\\\"%s\\\")\"";
+            for (String verToBeMatched : neo4jVersions) {
+                for (String verRegex : matchingCases) {
+                    Container.ExecResult out =
+                            container.execInContainer("sh", "-c", String.format(semverQuery, verRegex, verToBeMatched));
+                    if (!out.getStdout().trim().equals("true")) {
+                        failedTests.add(String.format("%s should match %s but did not", verRegex, verToBeMatched));
                     }
                 }
-                for ( String verRegex : nonMatchingCases )
-                {
-                    Container.ExecResult out = container.execInContainer( "sh", "-c", String.format( semverQuery, verRegex, verToBeMatched ) );
-                    if ( !out.getStdout().trim().equals( "false" ) )
-                    {
-                        failedTests.add( String.format( "%s should NOT match %s but did", verRegex, verToBeMatched ) );
+                for (String verRegex : nonMatchingCases) {
+                    Container.ExecResult out =
+                            container.execInContainer("sh", "-c", String.format(semverQuery, verRegex, verToBeMatched));
+                    if (!out.getStdout().trim().equals("false")) {
+                        failedTests.add(String.format("%s should NOT match %s but did", verRegex, verToBeMatched));
                     }
                 }
             }
-            if ( !failedTests.isEmpty() )
-            {
-                Assertions.fail( failedTests.stream().collect( Collectors.joining( "\n" ) ) );
+            if (!failedTests.isEmpty()) {
+                Assertions.fail(failedTests.stream().collect(Collectors.joining("\n")));
             }
         }
     }
 
     @Test
-    void testSemanticVersioningPlugin_catchesMatchWithX() throws Exception
-    {
+    void testSemanticVersioningPlugin_catchesMatchWithX() throws Exception {
         Path pluginsDir = temporaryFolderManager.createFolder("plugins");
-        stubPluginHelper.createStubPluginForVersion(pluginsDir,
-            Neo4jVersion.makeVersionString( NEO4J_VERSION.major, NEO4J_VERSION.minor)+".x");
-        try ( GenericContainer container = createContainerWithTestPlugin() )
-        {
+        stubPluginHelper.createStubPluginForVersion(
+                pluginsDir, Neo4jVersion.makeVersionString(NEO4J_VERSION.major, NEO4J_VERSION.minor) + ".x");
+        try (GenericContainer container = createContainerWithTestPlugin()) {
             container.start();
-            DatabaseIO db = new DatabaseIO( container );
-            stubPluginHelper.verifyStubPluginLoaded( db, DB_USER, DB_PASSWORD );
+            DatabaseIO db = new DatabaseIO(container);
+            stubPluginHelper.verifyStubPluginLoaded(db, DB_USER, DB_PASSWORD);
         }
     }
 
     @Test
-    void testSemanticVersioningPlugin_catchesMatchWithStar() throws Exception
-    {
+    void testSemanticVersioningPlugin_catchesMatchWithStar() throws Exception {
         Path pluginsDir = temporaryFolderManager.createFolder("plugins");
-        stubPluginHelper.createStubPluginForVersion(pluginsDir,
-            Neo4jVersion.makeVersionString( NEO4J_VERSION.major, NEO4J_VERSION.minor)+".*");
-        try ( GenericContainer container = createContainerWithTestPlugin() )
-        {
+        stubPluginHelper.createStubPluginForVersion(
+                pluginsDir, Neo4jVersion.makeVersionString(NEO4J_VERSION.major, NEO4J_VERSION.minor) + ".*");
+        try (GenericContainer container = createContainerWithTestPlugin()) {
             container.start();
-            DatabaseIO db = new DatabaseIO( container );
-            stubPluginHelper.verifyStubPluginLoaded( db, DB_USER, DB_PASSWORD );
+            DatabaseIO db = new DatabaseIO(container);
+            stubPluginHelper.verifyStubPluginLoaded(db, DB_USER, DB_PASSWORD);
         }
     }
 
     @Test
-    void testSemanticVersioningPlugin_prefersExactMatch() throws Exception
-    {
-        verifySemanticVersioningPrefersBetterMatches(new HashMap<String,String>()
-            {{
-                put( "x.x.x", "notareal.jar" );
-                put( NEO4J_VERSION.major + ".x.x", "notareal.jar" );
-                put( Neo4jVersion.makeVersionString( NEO4J_VERSION.major, NEO4J_VERSION.minor) + ".x", "notareal.jar" );
-                put( NEO4J_VERSION.toString(), StubPluginHelper.PLUGIN_FILENAME);
-            }} );
+    void testSemanticVersioningPlugin_prefersExactMatch() throws Exception {
+        verifySemanticVersioningPrefersBetterMatches(new HashMap<String, String>() {
+            {
+                put("x.x.x", "notareal.jar");
+                put(NEO4J_VERSION.major + ".x.x", "notareal.jar");
+                put(Neo4jVersion.makeVersionString(NEO4J_VERSION.major, NEO4J_VERSION.minor) + ".x", "notareal.jar");
+                put(NEO4J_VERSION.toString(), StubPluginHelper.PLUGIN_FILENAME);
+            }
+        });
     }
 
     @Test
-    void testSemanticVersioningPlugin_prefersMajorMinorMatch() throws Exception
-    {
-        verifySemanticVersioningPrefersBetterMatches(new HashMap<String,String>()
-            {{
-                put( "x.x.x", "notareal.jar" );
-                put( NEO4J_VERSION.major + ".x.x", "notareal.jar" );
-                put( Neo4jVersion.makeVersionString( NEO4J_VERSION.major, NEO4J_VERSION.minor) + ".x",
-                     StubPluginHelper.PLUGIN_FILENAME);
-            }} );
+    void testSemanticVersioningPlugin_prefersMajorMinorMatch() throws Exception {
+        verifySemanticVersioningPrefersBetterMatches(new HashMap<String, String>() {
+            {
+                put("x.x.x", "notareal.jar");
+                put(NEO4J_VERSION.major + ".x.x", "notareal.jar");
+                put(
+                        Neo4jVersion.makeVersionString(NEO4J_VERSION.major, NEO4J_VERSION.minor) + ".x",
+                        StubPluginHelper.PLUGIN_FILENAME);
+            }
+        });
     }
 
     @Test
-    void testSemanticVersioningPlugin_prefersMajorMatch() throws Exception
-    {
-        verifySemanticVersioningPrefersBetterMatches(new HashMap<String,String>()
-            {{
-                put( "x.x.x", "notareal.jar" );
-                put( NEO4J_VERSION.major + ".x.x", StubPluginHelper.PLUGIN_FILENAME);
-            }} );
+    void testSemanticVersioningPlugin_prefersMajorMatch() throws Exception {
+        verifySemanticVersioningPrefersBetterMatches(new HashMap<String, String>() {
+            {
+                put("x.x.x", "notareal.jar");
+                put(NEO4J_VERSION.major + ".x.x", StubPluginHelper.PLUGIN_FILENAME);
+            }
+        });
     }
 
     void verifySemanticVersioningPrefersBetterMatches(Map<String, String> versionsInJson) throws Exception {

--- a/src/test/java/com/neo4j/docker/neo4jadmin/TestAdminBasic.java
+++ b/src/test/java/com/neo4j/docker/neo4jadmin/TestAdminBasic.java
@@ -1,7 +1,8 @@
 package com.neo4j.docker.neo4jadmin;
 
-import com.neo4j.docker.utils.WaitStrategies;
 import com.neo4j.docker.utils.TestSettings;
+import com.neo4j.docker.utils.WaitStrategies;
+import java.time.Duration;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
@@ -11,45 +12,44 @@ import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 
-import java.time.Duration;
-
-public class TestAdminBasic
-{
-    private final Logger log = LoggerFactory.getLogger( TestAdminBasic.class );
+public class TestAdminBasic {
+    private final Logger log = LoggerFactory.getLogger(TestAdminBasic.class);
 
     @Test
-    void testCannotRunNeo4j()
-    {
-        GenericContainer admin = new GenericContainer( TestSettings.ADMIN_IMAGE_ID );
-        admin.withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
-             .withExposedPorts( 7474, 7687 )
-             .withLogConsumer( new Slf4jLogConsumer( log ) )
-             .withCommand( "neo4j", "console" );
-        WaitStrategies.waitUntilContainerFinished( admin, Duration.ofSeconds( 30) );
+    void testCannotRunNeo4j() {
+        GenericContainer admin = new GenericContainer(TestSettings.ADMIN_IMAGE_ID);
+        admin.withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+                .withExposedPorts(7474, 7687)
+                .withLogConsumer(new Slf4jLogConsumer(log))
+                .withCommand("neo4j", "console");
+        WaitStrategies.waitUntilContainerFinished(admin, Duration.ofSeconds(30));
 
-        Assertions.assertThrows( ContainerLaunchException.class, admin::start );
+        Assertions.assertThrows(ContainerLaunchException.class, admin::start);
         admin.stop();
     }
+
     @Test
-    void testLicenseAcceptanceRequired_Neo4jAdmin()
-    {
-        Assumptions.assumeTrue( TestSettings.EDITION == TestSettings.Edition.ENTERPRISE,
-                                "No license checks for community edition");
+    void testLicenseAcceptanceRequired_Neo4jAdmin() {
+        Assumptions.assumeTrue(
+                TestSettings.EDITION == TestSettings.Edition.ENTERPRISE, "No license checks for community edition");
 
         String logsOut;
-        try(GenericContainer container = new GenericContainer( TestSettings.ADMIN_IMAGE_ID )
-                .withLogConsumer( new Slf4jLogConsumer( log ) ) )
-        {
-            WaitStrategies.waitUntilContainerFinished( container, Duration.ofSeconds( 30) );
+        try (GenericContainer container =
+                new GenericContainer(TestSettings.ADMIN_IMAGE_ID).withLogConsumer(new Slf4jLogConsumer(log))) {
+            WaitStrategies.waitUntilContainerFinished(container, Duration.ofSeconds(30));
             // container start should fail due to licensing.
-            Assertions.assertThrows( ContainerLaunchException.class, container::start,
-                                     "Neo4j did not notify about accepting the license agreement" );
+            Assertions.assertThrows(
+                    ContainerLaunchException.class,
+                    container::start,
+                    "Neo4j did not notify about accepting the license agreement");
             logsOut = container.getLogs();
         }
         // double check the container didn't warn and start neo4j anyway
-        Assertions.assertTrue( logsOut.contains( "must accept the license" ),
-                               "Neo4j did not notify about accepting the license agreement" );
-        Assertions.assertFalse( logsOut.contains( "Remote interface available" ),
-                                "Neo4j was started even though the license was not accepted" );
+        Assertions.assertTrue(
+                logsOut.contains("must accept the license"),
+                "Neo4j did not notify about accepting the license agreement");
+        Assertions.assertFalse(
+                logsOut.contains("Remote interface available"),
+                "Neo4j was started even though the license was not accepted");
     }
 }

--- a/src/test/java/com/neo4j/docker/neo4jadmin/TestBackupRestore.java
+++ b/src/test/java/com/neo4j/docker/neo4jadmin/TestBackupRestore.java
@@ -5,9 +5,15 @@ import com.neo4j.docker.coredb.configurations.Setting;
 import com.neo4j.docker.utils.DatabaseIO;
 import com.neo4j.docker.utils.Neo4jVersion;
 import com.neo4j.docker.utils.SetContainerUser;
-import com.neo4j.docker.utils.WaitStrategies;
 import com.neo4j.docker.utils.TemporaryFolderManager;
 import com.neo4j.docker.utils.TestSettings;
+import com.neo4j.docker.utils.WaitStrategies;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
@@ -20,158 +26,145 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
 
-import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.Duration;
-import java.util.List;
-import java.util.Map;
-
-public class TestBackupRestore
-{
+public class TestBackupRestore {
     // with authentication
     // with non-default user
-    private final Logger log = LoggerFactory.getLogger( TestBackupRestore.class );
+    private final Logger log = LoggerFactory.getLogger(TestBackupRestore.class);
+
     @RegisterExtension
     public static TemporaryFolderManager temporaryFolderManager = new TemporaryFolderManager();
 
     @BeforeAll
-    static void beforeAll()
-    {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( Neo4jVersion.NEO4J_VERSION_500 ),
-                                "These tests only apply to neo4j-admin images of 5.0 and greater");
-        Assumptions.assumeTrue( TestSettings.EDITION == TestSettings.Edition.ENTERPRISE,
-                                "backup and restore only available in Neo4j Enterprise" );
+    static void beforeAll() {
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isAtLeastVersion(Neo4jVersion.NEO4J_VERSION_500),
+                "These tests only apply to neo4j-admin images of 5.0 and greater");
+        Assumptions.assumeTrue(
+                TestSettings.EDITION == TestSettings.Edition.ENTERPRISE,
+                "backup and restore only available in Neo4j Enterprise");
     }
 
-    private GenericContainer createDBContainer( boolean asDefaultUser, String password )
-    {
+    private GenericContainer createDBContainer(boolean asDefaultUser, String password) {
         String auth = "none";
-        if(!password.equalsIgnoreCase("none"))
-        {
-            auth = "neo4j/"+password;
+        if (!password.equalsIgnoreCase("none")) {
+            auth = "neo4j/" + password;
         }
-        Map<Setting,Configuration> confNames = Configuration.getConfigurationNameMap();
-        GenericContainer container = new GenericContainer( TestSettings.IMAGE_ID );
-        container.withEnv( "NEO4J_AUTH", auth )
-                 .withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
-                 .withEnv( confNames.get( Setting.BACKUP_ENABLED ).envName, "true" )
-                 .withEnv( confNames.get( Setting.BACKUP_LISTEN_ADDRESS ).envName, "0.0.0.0:6362" )
-                 .withExposedPorts( 7474, 7687, 6362 )
-                 .withLogConsumer( new Slf4jLogConsumer( log ) )
-                 .waitingFor(WaitStrategies.waitForNeo4jReady( password ));
-        if(!asDefaultUser)
-        {
-            SetContainerUser.nonRootUser( container );
+        Map<Setting, Configuration> confNames = Configuration.getConfigurationNameMap();
+        GenericContainer container = new GenericContainer(TestSettings.IMAGE_ID);
+        container
+                .withEnv("NEO4J_AUTH", auth)
+                .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+                .withEnv(confNames.get(Setting.BACKUP_ENABLED).envName, "true")
+                .withEnv(confNames.get(Setting.BACKUP_LISTEN_ADDRESS).envName, "0.0.0.0:6362")
+                .withExposedPorts(7474, 7687, 6362)
+                .withLogConsumer(new Slf4jLogConsumer(log))
+                .waitingFor(WaitStrategies.waitForNeo4jReady(password));
+        if (!asDefaultUser) {
+            SetContainerUser.nonRootUser(container);
         }
         return container;
     }
 
-    private GenericContainer createAdminContainer( boolean asDefaultUser )
-    {
-        GenericContainer container = new GenericContainer( TestSettings.ADMIN_IMAGE_ID );
-        container.withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
-                 .withLogConsumer( new Slf4jLogConsumer( log ) );
-        WaitStrategies.waitUntilContainerFinished( container, Duration.ofSeconds( 180) );
-        if(!asDefaultUser)
-        {
-            SetContainerUser.nonRootUser( container );
+    private GenericContainer createAdminContainer(boolean asDefaultUser) {
+        GenericContainer container = new GenericContainer(TestSettings.ADMIN_IMAGE_ID);
+        container.withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes").withLogConsumer(new Slf4jLogConsumer(log));
+        WaitStrategies.waitUntilContainerFinished(container, Duration.ofSeconds(180));
+        if (!asDefaultUser) {
+            SetContainerUser.nonRootUser(container);
         }
         return container;
     }
 
     @Test
-    void shouldBackupAndRestore_defaultUser_noAuth() throws Exception
-    {
-        testCanBackupAndRestore( true, "none" );
-    }
-    @Test
-    void shouldBackupAndRestore_nonDefaultUser_noAuth() throws Exception
-    {
-        testCanBackupAndRestore( false, "none" );
-    }
-    @Test
-    void shouldBackupAndRestore_defaultUser_withAuth() throws Exception
-    {
-        testCanBackupAndRestore( true, "secretpassword" );
-    }
-    @Test
-    void shouldBackupAndRestore_nonDefaultUser_withAuth() throws Exception
-    {
-        testCanBackupAndRestore( false, "secretpassword" );
+    void shouldBackupAndRestore_defaultUser_noAuth() throws Exception {
+        testCanBackupAndRestore(true, "none");
     }
 
-    private void testCanBackupAndRestore(boolean asDefaultUser, String password) throws Exception
-    {
+    @Test
+    void shouldBackupAndRestore_nonDefaultUser_noAuth() throws Exception {
+        testCanBackupAndRestore(false, "none");
+    }
+
+    @Test
+    void shouldBackupAndRestore_defaultUser_withAuth() throws Exception {
+        testCanBackupAndRestore(true, "secretpassword");
+    }
+
+    @Test
+    void shouldBackupAndRestore_nonDefaultUser_withAuth() throws Exception {
+        testCanBackupAndRestore(false, "secretpassword");
+    }
+
+    private void testCanBackupAndRestore(boolean asDefaultUser, String password) throws Exception {
         final String dbUser = "neo4j";
         Path backupDir;
 
         // BACKUP
         // start a database and populate data
-        try(GenericContainer neo4j = createDBContainer( asDefaultUser, password ))
-        {
+        try (GenericContainer neo4j = createDBContainer(asDefaultUser, password)) {
             Path dataDir = temporaryFolderManager.createFolderAndMountAsVolume(neo4j, "/data");
             neo4j.start();
-            DatabaseIO dbio = new DatabaseIO( neo4j );
-            dbio.putInitialDataIntoContainer( dbUser, password );
-            dbio.verifyInitialDataInContainer( dbUser, password );
+            DatabaseIO dbio = new DatabaseIO(neo4j);
+            dbio.putInitialDataIntoContainer(dbUser, password);
+            dbio.verifyInitialDataInContainer(dbUser, password);
 
             // start admin container to initiate backup
-            String neoDBAddress = neo4j.getHost() + ":" + neo4j.getMappedPort( 6362 );
-            try(GenericContainer adminBackup = createAdminContainer( asDefaultUser ))
-            {
-                adminBackup.withNetworkMode( "host" )
-                           .waitingFor( new LogMessageWaitStrategy().withRegEx( "^Backup command completed.*" ) )
-                           .withCommand( "neo4j-admin",
-                                         "database",
-                                         "backup",
-                                         "--to-path=/backups",
-                                         "--include-metadata=all",
-                                         "--from=" + neoDBAddress,
-                                         "neo4j" );
+            String neoDBAddress = neo4j.getHost() + ":" + neo4j.getMappedPort(6362);
+            try (GenericContainer adminBackup = createAdminContainer(asDefaultUser)) {
+                adminBackup
+                        .withNetworkMode("host")
+                        .waitingFor(new LogMessageWaitStrategy().withRegEx("^Backup command completed.*"))
+                        .withCommand(
+                                "neo4j-admin",
+                                "database",
+                                "backup",
+                                "--to-path=/backups",
+                                "--include-metadata=all",
+                                "--from=" + neoDBAddress,
+                                "neo4j");
 
                 backupDir = temporaryFolderManager.createFolderAndMountAsVolume(adminBackup, "/backups");
                 adminBackup.start();
 
-                Assertions.assertTrue( neo4j.isRunning(), "neo4j container should still be running" );
-                dbio.verifyInitialDataInContainer( dbUser, password );
-            } //adminBackup goes out of scope here
+                Assertions.assertTrue(neo4j.isRunning(), "neo4j container should still be running");
+                dbio.verifyInitialDataInContainer(dbUser, password);
+            } // adminBackup goes out of scope here
 
             // find backup file name and verify its existence.
-            List<Path> backupFolder = Files.list( backupDir )
-                                           .filter( p -> p.toFile().getName().startsWith( "neo4j" ) )
-                                           .toList();
-            Assertions.assertEquals( 1, backupFolder.size(), "No backup file was created" );
-            File backupFile = backupFolder.get( 0 ).toFile();
-
+            List<Path> backupFolder = Files.list(backupDir)
+                    .filter(p -> p.toFile().getName().startsWith("neo4j"))
+                    .toList();
+            Assertions.assertEquals(1, backupFolder.size(), "No backup file was created");
+            File backupFile = backupFolder.get(0).toFile();
 
             // RESTORE
 
             // write more stuff
-            dbio.putMoreDataIntoContainer( dbUser, password );
-            dbio.verifyMoreDataIntoContainer( dbUser, password, true );
+            dbio.putMoreDataIntoContainer(dbUser, password);
+            dbio.verifyMoreDataIntoContainer(dbUser, password, true);
             // stop database in preparation for restore
-            dbio.runCypherQuery( dbUser, password, "STOP DATABASE neo4j", "system" );
+            dbio.runCypherQuery(dbUser, password, "STOP DATABASE neo4j", "system");
 
             // do restore
-            try(GenericContainer adminRestore = createAdminContainer( asDefaultUser ))
-            {
-                adminRestore.waitingFor( Wait.forLogMessage( ".*Restore of database .* completed successfully.*", 1 )
-                                             .withStartupTimeout( Duration.ofSeconds( 180 ) ) )
-                            .withCommand( "neo4j-admin",
-                                          "database",
-                                          "restore",
-                                          "--overwrite-destination=true",
-                                          "--from-path=/backups/" + backupFile.getName(),
-                                          "neo4j" );
-                temporaryFolderManager.mountHostFolderAsVolume( adminRestore, backupDir, "/backups" );
-                temporaryFolderManager.mountHostFolderAsVolume( adminRestore, dataDir, "/data" );
+            try (GenericContainer adminRestore = createAdminContainer(asDefaultUser)) {
+                adminRestore
+                        .waitingFor(Wait.forLogMessage(".*Restore of database .* completed successfully.*", 1)
+                                .withStartupTimeout(Duration.ofSeconds(180)))
+                        .withCommand(
+                                "neo4j-admin",
+                                "database",
+                                "restore",
+                                "--overwrite-destination=true",
+                                "--from-path=/backups/" + backupFile.getName(),
+                                "neo4j");
+                temporaryFolderManager.mountHostFolderAsVolume(adminRestore, backupDir, "/backups");
+                temporaryFolderManager.mountHostFolderAsVolume(adminRestore, dataDir, "/data");
                 adminRestore.start();
-                dbio.runCypherQuery( dbUser, password, "START DATABASE neo4j", "system" );
+                dbio.runCypherQuery(dbUser, password, "START DATABASE neo4j", "system");
 
                 // verify new stuff is missing
-                dbio.verifyMoreDataIntoContainer( dbUser, password, false );
-            } //adminRestore out of scope here
+                dbio.verifyMoreDataIntoContainer(dbUser, password, false);
+            } // adminRestore out of scope here
         } // neo4j container goes out of scope here
     }
 }

--- a/src/test/java/com/neo4j/docker/neo4jadmin/TestBackupRestore44.java
+++ b/src/test/java/com/neo4j/docker/neo4jadmin/TestBackupRestore44.java
@@ -5,9 +5,12 @@ import com.neo4j.docker.coredb.configurations.Setting;
 import com.neo4j.docker.utils.DatabaseIO;
 import com.neo4j.docker.utils.Neo4jVersion;
 import com.neo4j.docker.utils.SetContainerUser;
-import com.neo4j.docker.utils.WaitStrategies;
 import com.neo4j.docker.utils.TemporaryFolderManager;
 import com.neo4j.docker.utils.TestSettings;
+import com.neo4j.docker.utils.WaitStrategies;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
@@ -19,131 +22,123 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 
-import java.nio.file.Path;
-import java.time.Duration;
-import java.util.Map;
-
-public class TestBackupRestore44
-{
+public class TestBackupRestore44 {
     // with authentication
     // with non-default user
-    private final Logger log = LoggerFactory.getLogger( TestBackupRestore44.class );
+    private final Logger log = LoggerFactory.getLogger(TestBackupRestore44.class);
+
     @RegisterExtension
     public static TemporaryFolderManager temporaryFolderManager = new TemporaryFolderManager();
 
     @BeforeAll
-    static void beforeAll()
-    {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( Neo4jVersion.NEO4J_VERSION_440),
-                                "Neo4j admin image not available before 4.4.0");
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isOlderThan( Neo4jVersion.NEO4J_VERSION_500 ),
-                                "These Neo4j admin tests are only for 4.4");
-        Assumptions.assumeTrue( TestSettings.EDITION == TestSettings.Edition.ENTERPRISE,
-                                "backup and restore only available in Neo4j Enterprise" );
+    static void beforeAll() {
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isAtLeastVersion(Neo4jVersion.NEO4J_VERSION_440),
+                "Neo4j admin image not available before 4.4.0");
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isOlderThan(Neo4jVersion.NEO4J_VERSION_500),
+                "These Neo4j admin tests are only for 4.4");
+        Assumptions.assumeTrue(
+                TestSettings.EDITION == TestSettings.Edition.ENTERPRISE,
+                "backup and restore only available in Neo4j Enterprise");
     }
 
-    private GenericContainer createDBContainer( boolean asDefaultUser, String password )
-    {
+    private GenericContainer createDBContainer(boolean asDefaultUser, String password) {
         String auth = "none";
-        if(!password.equalsIgnoreCase("none"))
-        {
-            auth = "neo4j/"+password;
+        if (!password.equalsIgnoreCase("none")) {
+            auth = "neo4j/" + password;
         }
-        Map<Setting,Configuration> confNames = Configuration.getConfigurationNameMap();
-        GenericContainer container = new GenericContainer( TestSettings.IMAGE_ID );
-        container.withEnv( "NEO4J_AUTH", auth )
-                 .withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
-                 .withEnv( confNames.get( Setting.BACKUP_ENABLED ).envName, "true" )
-                 .withEnv( confNames.get( Setting.BACKUP_LISTEN_ADDRESS ).envName, "0.0.0.0:6362" )
-                 .withExposedPorts( 7474, 7687, 6362 )
-                 .withLogConsumer( new Slf4jLogConsumer( log ) )
-                 .waitingFor(WaitStrategies.waitForNeo4jReady( password ));
-        if(!asDefaultUser)
-        {
-            SetContainerUser.nonRootUser( container );
+        Map<Setting, Configuration> confNames = Configuration.getConfigurationNameMap();
+        GenericContainer container = new GenericContainer(TestSettings.IMAGE_ID);
+        container
+                .withEnv("NEO4J_AUTH", auth)
+                .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+                .withEnv(confNames.get(Setting.BACKUP_ENABLED).envName, "true")
+                .withEnv(confNames.get(Setting.BACKUP_LISTEN_ADDRESS).envName, "0.0.0.0:6362")
+                .withExposedPorts(7474, 7687, 6362)
+                .withLogConsumer(new Slf4jLogConsumer(log))
+                .waitingFor(WaitStrategies.waitForNeo4jReady(password));
+        if (!asDefaultUser) {
+            SetContainerUser.nonRootUser(container);
         }
         return container;
     }
 
-    private GenericContainer createAdminContainer( boolean asDefaultUser )
-    {
-        GenericContainer container = new GenericContainer( TestSettings.ADMIN_IMAGE_ID );
-        container.withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
-                 .withLogConsumer( new Slf4jLogConsumer( log ) );
-        WaitStrategies.waitUntilContainerFinished( container, Duration.ofSeconds( 180) );
-        if(!asDefaultUser)
-        {
-            SetContainerUser.nonRootUser( container );
+    private GenericContainer createAdminContainer(boolean asDefaultUser) {
+        GenericContainer container = new GenericContainer(TestSettings.ADMIN_IMAGE_ID);
+        container.withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes").withLogConsumer(new Slf4jLogConsumer(log));
+        WaitStrategies.waitUntilContainerFinished(container, Duration.ofSeconds(180));
+        if (!asDefaultUser) {
+            SetContainerUser.nonRootUser(container);
         }
         return container;
     }
 
     @Test
-    void shouldBackupAndRestore_defaultUser_noAuth() throws Exception
-    {
-        testCanBackupAndRestore( true, "none" );
-    }
-    @Test
-    void shouldBackupAndRestore_nonDefaultUser_noAuth() throws Exception
-    {
-        testCanBackupAndRestore( false, "none" );
-    }
-    @Test
-    void shouldBackupAndRestore_defaultUser_withAuth() throws Exception
-    {
-        testCanBackupAndRestore( true, "secretpassword" );
-    }
-    @Test
-    void shouldBackupAndRestore_nonDefaultUser_withAuth() throws Exception
-    {
-        testCanBackupAndRestore( false, "secretpassword" );
+    void shouldBackupAndRestore_defaultUser_noAuth() throws Exception {
+        testCanBackupAndRestore(true, "none");
     }
 
-    private void testCanBackupAndRestore(boolean asDefaultUser, String password) throws Exception
-    {
+    @Test
+    void shouldBackupAndRestore_nonDefaultUser_noAuth() throws Exception {
+        testCanBackupAndRestore(false, "none");
+    }
+
+    @Test
+    void shouldBackupAndRestore_defaultUser_withAuth() throws Exception {
+        testCanBackupAndRestore(true, "secretpassword");
+    }
+
+    @Test
+    void shouldBackupAndRestore_nonDefaultUser_withAuth() throws Exception {
+        testCanBackupAndRestore(false, "secretpassword");
+    }
+
+    private void testCanBackupAndRestore(boolean asDefaultUser, String password) throws Exception {
         final String dbUser = "neo4j";
 
         // BACKUP
         // start a database and populate data
-        GenericContainer neo4j = createDBContainer( asDefaultUser, password );
+        GenericContainer neo4j = createDBContainer(asDefaultUser, password);
         Path dataDir = temporaryFolderManager.createFolderAndMountAsVolume(neo4j, "/data");
         neo4j.start();
-        DatabaseIO dbio = new DatabaseIO( neo4j );
-        dbio.putInitialDataIntoContainer( dbUser, password );
-        dbio.verifyInitialDataInContainer( dbUser, password );
+        DatabaseIO dbio = new DatabaseIO(neo4j);
+        dbio.putInitialDataIntoContainer(dbUser, password);
+        dbio.verifyInitialDataInContainer(dbUser, password);
 
         // start admin container to initiate backup
-        String neoDBAddress = neo4j.getHost()+":"+neo4j.getMappedPort( 6362 );
-        GenericContainer adminBackup = createAdminContainer( asDefaultUser )
-                .withNetworkMode( "host" )
-                .waitingFor( new LogMessageWaitStrategy().withRegEx( "^Backup complete successful.*" ) )
-                .withCommand( "neo4j-admin", "backup", "--database=neo4j", "--backup-dir=/backups", "--from="+neoDBAddress);
+        String neoDBAddress = neo4j.getHost() + ":" + neo4j.getMappedPort(6362);
+        GenericContainer adminBackup = createAdminContainer(asDefaultUser)
+                .withNetworkMode("host")
+                .waitingFor(new LogMessageWaitStrategy().withRegEx("^Backup complete successful.*"))
+                .withCommand(
+                        "neo4j-admin", "backup", "--database=neo4j", "--backup-dir=/backups", "--from=" + neoDBAddress);
 
         Path backupDir = temporaryFolderManager.createFolderAndMountAsVolume(adminBackup, "/backups");
         adminBackup.start();
 
-        Assertions.assertTrue( neo4j.isRunning(), "neo4j container should still be running" );
-        dbio.verifyInitialDataInContainer( dbUser, password );
+        Assertions.assertTrue(neo4j.isRunning(), "neo4j container should still be running");
+        dbio.verifyInitialDataInContainer(dbUser, password);
         adminBackup.stop();
 
         // RESTORE
 
         // write more stuff
-        dbio.putMoreDataIntoContainer( dbUser, password );
-        dbio.verifyMoreDataIntoContainer( dbUser, password, true );
+        dbio.putMoreDataIntoContainer(dbUser, password);
+        dbio.verifyMoreDataIntoContainer(dbUser, password, true);
 
         // do restore
-        dbio.runCypherQuery( dbUser, password, "STOP DATABASE neo4j", "system" );
-        GenericContainer adminRestore = createAdminContainer( asDefaultUser )
-                .waitingFor( new LogMessageWaitStrategy().withRegEx( "^.*restoreStatus=successful.*" ) )
-                .withCommand( "neo4j-admin", "restore", "--database=neo4j", "--from=/backups/neo4j", "--force");
-        temporaryFolderManager.mountHostFolderAsVolume( adminRestore, backupDir, "/backups" );
-        temporaryFolderManager.mountHostFolderAsVolume( adminRestore, dataDir, "/data" );
+        dbio.runCypherQuery(dbUser, password, "STOP DATABASE neo4j", "system");
+        GenericContainer adminRestore = createAdminContainer(asDefaultUser)
+                .waitingFor(new LogMessageWaitStrategy().withRegEx("^.*restoreStatus=successful.*"))
+                .withCommand("neo4j-admin", "restore", "--database=neo4j", "--from=/backups/neo4j", "--force");
+        temporaryFolderManager.mountHostFolderAsVolume(adminRestore, backupDir, "/backups");
+        temporaryFolderManager.mountHostFolderAsVolume(adminRestore, dataDir, "/data");
         adminRestore.start();
-        dbio.runCypherQuery( dbUser, password, "START DATABASE neo4j", "system" );
+        dbio.runCypherQuery(dbUser, password, "START DATABASE neo4j", "system");
 
         // verify new stuff is missing
-        dbio.verifyMoreDataIntoContainer( dbUser, password, false );
+        dbio.verifyMoreDataIntoContainer(dbUser, password, false);
 
         // clean up
         adminRestore.stop();

--- a/src/test/java/com/neo4j/docker/neo4jadmin/TestDumpLoad.java
+++ b/src/test/java/com/neo4j/docker/neo4jadmin/TestDumpLoad.java
@@ -3,9 +3,11 @@ package com.neo4j.docker.neo4jadmin;
 import com.neo4j.docker.utils.DatabaseIO;
 import com.neo4j.docker.utils.Neo4jVersion;
 import com.neo4j.docker.utils.SetContainerUser;
-import com.neo4j.docker.utils.WaitStrategies;
 import com.neo4j.docker.utils.TemporaryFolderManager;
 import com.neo4j.docker.utils.TestSettings;
+import com.neo4j.docker.utils.WaitStrategies;
+import java.nio.file.Path;
+import java.time.Duration;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
@@ -18,126 +20,115 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 
-import java.nio.file.Path;
-import java.time.Duration;
+public class TestDumpLoad {
+    private static Logger log = LoggerFactory.getLogger(TestDumpLoad.class);
 
-public class TestDumpLoad
-{
-    private static Logger log = LoggerFactory.getLogger( TestDumpLoad.class );
     @RegisterExtension
     public static TemporaryFolderManager temporaryFolderManager = new TemporaryFolderManager();
 
     @BeforeAll
-    static void beforeAll()
-    {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( Neo4jVersion.NEO4J_VERSION_500 ),
-                                "These tests only apply to neo4j-admin images of 5.0 and greater");
+    static void beforeAll() {
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isAtLeastVersion(Neo4jVersion.NEO4J_VERSION_500),
+                "These tests only apply to neo4j-admin images of 5.0 and greater");
     }
 
-    private GenericContainer createDBContainer( boolean asDefaultUser, String password )
-    {
+    private GenericContainer createDBContainer(boolean asDefaultUser, String password) {
         String auth = "none";
-        if(!password.equalsIgnoreCase("none"))
-        {
-            auth = "neo4j/"+password;
+        if (!password.equalsIgnoreCase("none")) {
+            auth = "neo4j/" + password;
         }
 
-        GenericContainer container = new GenericContainer( TestSettings.IMAGE_ID );
-        container.withEnv( "NEO4J_AUTH", auth )
-                 .withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
-                 .withExposedPorts( 7474, 7687 )
-                 .withLogConsumer( new Slf4jLogConsumer( log ) )
-                 .waitingFor( WaitStrategies.waitForNeo4jReady( password) );
-        if(!asDefaultUser)
-        {
-            SetContainerUser.nonRootUser( container );
-        }
-        return container;
-    }
-
-    private GenericContainer createAdminContainer( boolean asDefaultUser )
-    {
-        GenericContainer container = new GenericContainer( TestSettings.ADMIN_IMAGE_ID );
-        container.withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
-                 .withExposedPorts( 7474, 7687 )
-                 .withLogConsumer( new Slf4jLogConsumer( log ) )
-                 .waitingFor( new LogMessageWaitStrategy().withRegEx( "^Done: \\d+ files, [\\d\\.,]+[KMGi]*B processed.*" ) )
-//                 .waitingFor( new LogMessageWaitStrategy().withRegEx( "^Done: .*" ) )
-                 .withStartupCheckStrategy( new OneShotStartupCheckStrategy().withTimeout( Duration.ofSeconds( 90 ) ) );
-        if(!asDefaultUser)
-        {
-            SetContainerUser.nonRootUser( container );
+        GenericContainer container = new GenericContainer(TestSettings.IMAGE_ID);
+        container
+                .withEnv("NEO4J_AUTH", auth)
+                .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+                .withExposedPorts(7474, 7687)
+                .withLogConsumer(new Slf4jLogConsumer(log))
+                .waitingFor(WaitStrategies.waitForNeo4jReady(password));
+        if (!asDefaultUser) {
+            SetContainerUser.nonRootUser(container);
         }
         return container;
     }
 
-    @Test
-    void shouldDumpAndLoad_defaultUser_noAuth() throws Exception
-    {
-        shouldCreateDumpAndLoadDump( true, "none" );
+    private GenericContainer createAdminContainer(boolean asDefaultUser) {
+        GenericContainer container = new GenericContainer(TestSettings.ADMIN_IMAGE_ID);
+        container
+                .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+                .withExposedPorts(7474, 7687)
+                .withLogConsumer(new Slf4jLogConsumer(log))
+                .waitingFor(new LogMessageWaitStrategy().withRegEx("^Done: \\d+ files, [\\d\\.,]+[KMGi]*B processed.*"))
+                //                 .waitingFor( new LogMessageWaitStrategy().withRegEx( "^Done: .*" ) )
+                .withStartupCheckStrategy(new OneShotStartupCheckStrategy().withTimeout(Duration.ofSeconds(90)));
+        if (!asDefaultUser) {
+            SetContainerUser.nonRootUser(container);
+        }
+        return container;
     }
 
     @Test
-    void shouldDumpAndLoad_nonDefaultUser_noAuth() throws Exception
-    {
-        shouldCreateDumpAndLoadDump( false, "none" );
+    void shouldDumpAndLoad_defaultUser_noAuth() throws Exception {
+        shouldCreateDumpAndLoadDump(true, "none");
     }
 
     @Test
-    void shouldDumpAndLoad_defaultUser_withAuth() throws Exception
-    {
-        shouldCreateDumpAndLoadDump( true, "verysecretpassword" );
+    void shouldDumpAndLoad_nonDefaultUser_noAuth() throws Exception {
+        shouldCreateDumpAndLoadDump(false, "none");
     }
 
     @Test
-    void shouldDumpAndLoad_nonDefaultUser_withAuth() throws Exception
-    {
-        shouldCreateDumpAndLoadDump( false, "verysecretpassword" );
+    void shouldDumpAndLoad_defaultUser_withAuth() throws Exception {
+        shouldCreateDumpAndLoadDump(true, "verysecretpassword");
     }
 
-    private void shouldCreateDumpAndLoadDump( boolean asDefaultUser, String password ) throws Exception
-    {
+    @Test
+    void shouldDumpAndLoad_nonDefaultUser_withAuth() throws Exception {
+        shouldCreateDumpAndLoadDump(false, "verysecretpassword");
+    }
+
+    private void shouldCreateDumpAndLoadDump(boolean asDefaultUser, String password) throws Exception {
         Path firstDataDir;
         Path secondDataDir;
         Path backupDir;
 
         // start a database and populate it
-        try(GenericContainer container = createDBContainer( asDefaultUser, password ))
-        {
-            firstDataDir = temporaryFolderManager.createNamedFolderAndMountAsVolume(container,"data1", "/data");
+        try (GenericContainer container = createDBContainer(asDefaultUser, password)) {
+            firstDataDir = temporaryFolderManager.createNamedFolderAndMountAsVolume(container, "data1", "/data");
             container.start();
-            DatabaseIO dbio = new DatabaseIO( container );
-            dbio.putInitialDataIntoContainer( "neo4j", password );
-            container.getDockerClient().stopContainerCmd( container.getContainerId() ).withTimeout(30).exec();
+            DatabaseIO dbio = new DatabaseIO(container);
+            dbio.putInitialDataIntoContainer("neo4j", password);
+            container
+                    .getDockerClient()
+                    .stopContainerCmd(container.getContainerId())
+                    .withTimeout(30)
+                    .exec();
         }
 
         // use admin container to create dump
-        try(GenericContainer admin = createAdminContainer( asDefaultUser ))
-        {
-            temporaryFolderManager.mountHostFolderAsVolume( admin, firstDataDir, "/data" );
+        try (GenericContainer admin = createAdminContainer(asDefaultUser)) {
+            temporaryFolderManager.mountHostFolderAsVolume(admin, firstDataDir, "/data");
             backupDir = temporaryFolderManager.createFolderAndMountAsVolume(admin, "/backups");
-            admin.withCommand( "neo4j-admin", "database", "dump", "neo4j", "--to-path=/backups" );
+            admin.withCommand("neo4j-admin", "database", "dump", "neo4j", "--to-path=/backups");
             admin.start();
         }
-        Assertions.assertTrue( backupDir.resolve( "neo4j.dump" ).toFile().exists(), "dump file not created");
+        Assertions.assertTrue(backupDir.resolve("neo4j.dump").toFile().exists(), "dump file not created");
 
         // dump file exists. Now try to load it into a new database.
         // use admin container to create dump
-        try(GenericContainer admin = createAdminContainer( asDefaultUser ))
-        {
+        try (GenericContainer admin = createAdminContainer(asDefaultUser)) {
             secondDataDir = temporaryFolderManager.createNamedFolderAndMountAsVolume(admin, "data2", "/data");
-            temporaryFolderManager.mountHostFolderAsVolume( admin, backupDir, "/backups" );
-            admin.withCommand( "neo4j-admin", "database", "load", "neo4j", "--from-path=/backups" );
+            temporaryFolderManager.mountHostFolderAsVolume(admin, backupDir, "/backups");
+            admin.withCommand("neo4j-admin", "database", "load", "neo4j", "--from-path=/backups");
             admin.start();
         }
 
         // verify data in 2nd data directory by starting a database and verifying data we populated earlier
-        try(GenericContainer container = createDBContainer( asDefaultUser, password ))
-        {
-            temporaryFolderManager.mountHostFolderAsVolume( container, secondDataDir, "/data" );
+        try (GenericContainer container = createDBContainer(asDefaultUser, password)) {
+            temporaryFolderManager.mountHostFolderAsVolume(container, secondDataDir, "/data");
             container.start();
-            DatabaseIO dbio = new DatabaseIO( container );
-            dbio.verifyInitialDataInContainer( "neo4j", password );
+            DatabaseIO dbio = new DatabaseIO(container);
+            dbio.verifyInitialDataInContainer("neo4j", password);
         }
     }
 }

--- a/src/test/java/com/neo4j/docker/neo4jadmin/TestDumpLoad44.java
+++ b/src/test/java/com/neo4j/docker/neo4jadmin/TestDumpLoad44.java
@@ -4,9 +4,12 @@ import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.neo4j.docker.utils.DatabaseIO;
 import com.neo4j.docker.utils.Neo4jVersion;
 import com.neo4j.docker.utils.SetContainerUser;
-import com.neo4j.docker.utils.WaitStrategies;
 import com.neo4j.docker.utils.TemporaryFolderManager;
 import com.neo4j.docker.utils.TestSettings;
+import com.neo4j.docker.utils.WaitStrategies;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
@@ -19,146 +22,126 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 
-import java.nio.file.Path;
-import java.time.Duration;
-import java.util.function.Consumer;
+public class TestDumpLoad44 {
+    private static Logger log = LoggerFactory.getLogger(TestDumpLoad44.class);
 
-public class TestDumpLoad44
-{
-    private static Logger log = LoggerFactory.getLogger( TestDumpLoad44.class );
     @RegisterExtension
     public static TemporaryFolderManager temporaryFolderManager = new TemporaryFolderManager();
 
     @BeforeAll
-    static void beforeAll()
-    {
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isAtLeastVersion( new Neo4jVersion( 4, 4, 0 )),
-                                "Neo4j admin image not available before 4.4.0");
-        Assumptions.assumeTrue( TestSettings.NEO4J_VERSION.isOlderThan( Neo4jVersion.NEO4J_VERSION_500 ),
-                                "These Neo4j admin tests are only for 4.4");
+    static void beforeAll() {
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isAtLeastVersion(new Neo4jVersion(4, 4, 0)),
+                "Neo4j admin image not available before 4.4.0");
+        Assumptions.assumeTrue(
+                TestSettings.NEO4J_VERSION.isOlderThan(Neo4jVersion.NEO4J_VERSION_500),
+                "These Neo4j admin tests are only for 4.4");
     }
 
-    private GenericContainer createDBContainer( boolean asDefaultUser, String password )
-    {
+    private GenericContainer createDBContainer(boolean asDefaultUser, String password) {
         String auth = "none";
-        if(!password.equalsIgnoreCase("none"))
-        {
-            auth = "neo4j/"+password;
+        if (!password.equalsIgnoreCase("none")) {
+            auth = "neo4j/" + password;
         }
 
-        GenericContainer container = new GenericContainer( TestSettings.IMAGE_ID );
-        container.withEnv( "NEO4J_AUTH", auth )
-                 .withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
-                 .withExposedPorts( 7474, 7687 )
-                 .withLogConsumer( new Slf4jLogConsumer( log ) )
-                 .waitingFor( WaitStrategies.waitForNeo4jReady( password ) )
-                 // the default testcontainer framework behaviour is to just stop the process entirely,
-                 // preventing clean shutdown. This means we can run the stop command and
-                 // it'll send a SIGTERM to initiate neo4j shutdown. See also stopContainer method.
-                 .withCreateContainerCmdModifier(
-                         (Consumer<CreateContainerCmd>) cmd -> cmd.withStopSignal( "SIGTERM" ).withStopTimeout( 20 ));
-        if(!asDefaultUser)
-        {
-            SetContainerUser.nonRootUser( container );
-        }
-        return container;
-    }
-
-    private GenericContainer createAdminContainer( boolean asDefaultUser )
-    {
-        GenericContainer container = new GenericContainer( TestSettings.ADMIN_IMAGE_ID );
-        container.withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" )
-                 .withExposedPorts( 7474, 7687 )
-                 .withLogConsumer( new Slf4jLogConsumer( log ) )
-                 .waitingFor( new LogMessageWaitStrategy().withRegEx( "^Done: \\d+ files, [\\d\\.,]+[KMGi]*B processed.*" ) )
-                 .withStartupCheckStrategy( new OneShotStartupCheckStrategy().withTimeout( Duration.ofSeconds( 90 ) ) );
-        if(!asDefaultUser)
-        {
-            SetContainerUser.nonRootUser( container );
+        GenericContainer container = new GenericContainer(TestSettings.IMAGE_ID);
+        container
+                .withEnv("NEO4J_AUTH", auth)
+                .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+                .withExposedPorts(7474, 7687)
+                .withLogConsumer(new Slf4jLogConsumer(log))
+                .waitingFor(WaitStrategies.waitForNeo4jReady(password))
+                // the default testcontainer framework behaviour is to just stop the process entirely,
+                // preventing clean shutdown. This means we can run the stop command and
+                // it'll send a SIGTERM to initiate neo4j shutdown. See also stopContainer method.
+                .withCreateContainerCmdModifier((Consumer<CreateContainerCmd>)
+                        cmd -> cmd.withStopSignal("SIGTERM").withStopTimeout(20));
+        if (!asDefaultUser) {
+            SetContainerUser.nonRootUser(container);
         }
         return container;
     }
 
-    @Test
-    void shouldDumpAndLoad_defaultUser_noAuth() throws Exception
-    {
-        shouldCreateDumpAndLoadDump( true, "none" );
+    private GenericContainer createAdminContainer(boolean asDefaultUser) {
+        GenericContainer container = new GenericContainer(TestSettings.ADMIN_IMAGE_ID);
+        container
+                .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+                .withExposedPorts(7474, 7687)
+                .withLogConsumer(new Slf4jLogConsumer(log))
+                .waitingFor(new LogMessageWaitStrategy().withRegEx("^Done: \\d+ files, [\\d\\.,]+[KMGi]*B processed.*"))
+                .withStartupCheckStrategy(new OneShotStartupCheckStrategy().withTimeout(Duration.ofSeconds(90)));
+        if (!asDefaultUser) {
+            SetContainerUser.nonRootUser(container);
+        }
+        return container;
     }
 
     @Test
-    void shouldDumpAndLoad_nonDefaultUser_noAuth() throws Exception
-    {
-        shouldCreateDumpAndLoadDump( false, "none" );
+    void shouldDumpAndLoad_defaultUser_noAuth() throws Exception {
+        shouldCreateDumpAndLoadDump(true, "none");
     }
 
     @Test
-    void shouldDumpAndLoad_defaultUser_withAuth() throws Exception
-    {
-        shouldCreateDumpAndLoadDump( true, "verysecretpassword" );
+    void shouldDumpAndLoad_nonDefaultUser_noAuth() throws Exception {
+        shouldCreateDumpAndLoadDump(false, "none");
     }
 
     @Test
-    void shouldDumpAndLoad_nonDefaultUser_withAuth() throws Exception
-    {
-        shouldCreateDumpAndLoadDump( false, "verysecretpassword" );
+    void shouldDumpAndLoad_defaultUser_withAuth() throws Exception {
+        shouldCreateDumpAndLoadDump(true, "verysecretpassword");
     }
 
-    //container.stop() actually runs the killContainer Command, preventing clean shutdown.
+    @Test
+    void shouldDumpAndLoad_nonDefaultUser_withAuth() throws Exception {
+        shouldCreateDumpAndLoadDump(false, "verysecretpassword");
+    }
+
+    // container.stop() actually runs the killContainer Command, preventing clean shutdown.
     // This runs the actual stop command. Which we set up in createDBContainer to send SIGTERM
-    private void stopContainer(GenericContainer container)
-    {
-        log.info( "issuing container stop command" );
-        container.getDockerClient().stopContainerCmd( container.getContainerId() ).exec();
-        log.info( "Container stopped" );
+    private void stopContainer(GenericContainer container) {
+        log.info("issuing container stop command");
+        container.getDockerClient().stopContainerCmd(container.getContainerId()).exec();
+        log.info("Container stopped");
     }
 
-    private void shouldCreateDumpAndLoadDump( boolean asDefaultUser, String password ) throws Exception
-    {
+    private void shouldCreateDumpAndLoadDump(boolean asDefaultUser, String password) throws Exception {
         Path firstDataDir;
         Path secondDataDir;
         Path backupDir;
 
         // start a database and populate it
-        try(GenericContainer container = createDBContainer( asDefaultUser, password ))
-        {
-            firstDataDir = temporaryFolderManager.createNamedFolderAndMountAsVolume( container,
-                                                                                     "data1",
-                                                                                     "/data" );
+        try (GenericContainer container = createDBContainer(asDefaultUser, password)) {
+            firstDataDir = temporaryFolderManager.createNamedFolderAndMountAsVolume(container, "data1", "/data");
             container.start();
-            DatabaseIO dbio = new DatabaseIO( container );
-            dbio.putInitialDataIntoContainer( "neo4j", password );
-            stopContainer( container );
+            DatabaseIO dbio = new DatabaseIO(container);
+            dbio.putInitialDataIntoContainer("neo4j", password);
+            stopContainer(container);
         }
 
         // use admin container to create dump
-        try(GenericContainer admin = createAdminContainer( asDefaultUser ))
-        {
-            temporaryFolderManager.mountHostFolderAsVolume( admin, firstDataDir, "/data" );
+        try (GenericContainer admin = createAdminContainer(asDefaultUser)) {
+            temporaryFolderManager.mountHostFolderAsVolume(admin, firstDataDir, "/data");
             backupDir = temporaryFolderManager.createFolderAndMountAsVolume(admin, "/backups");
-            admin.withCommand( "neo4j-admin", "dump", "--database=neo4j", "--to=/backups/neo4j.dump" );
+            admin.withCommand("neo4j-admin", "dump", "--database=neo4j", "--to=/backups/neo4j.dump");
             admin.start();
         }
-        Assertions.assertTrue( backupDir.resolve( "neo4j.dump" ).toFile().exists(), "dump file not created");
+        Assertions.assertTrue(backupDir.resolve("neo4j.dump").toFile().exists(), "dump file not created");
 
         // dump file exists. Now try to load it into a new database.
         // use admin container to create dump
-        try(GenericContainer admin = createAdminContainer( asDefaultUser ))
-        {
-            secondDataDir = temporaryFolderManager.createNamedFolderAndMountAsVolume( admin,
-                                                                                     "data2",
-                                                                                     "/data" );
-            temporaryFolderManager.mountHostFolderAsVolume( admin, backupDir, "/backups" );
-            admin.withCommand( "neo4j-admin", "load", "--database=neo4j", "--from=/backups/neo4j.dump" );
+        try (GenericContainer admin = createAdminContainer(asDefaultUser)) {
+            secondDataDir = temporaryFolderManager.createNamedFolderAndMountAsVolume(admin, "data2", "/data");
+            temporaryFolderManager.mountHostFolderAsVolume(admin, backupDir, "/backups");
+            admin.withCommand("neo4j-admin", "load", "--database=neo4j", "--from=/backups/neo4j.dump");
             admin.start();
         }
 
         // verify data in 2nd data directory by starting a database and verifying data we populated earlier
-        try(GenericContainer container = createDBContainer( asDefaultUser, password ))
-        {
-            temporaryFolderManager.mountHostFolderAsVolume( container, secondDataDir, "/data" );
+        try (GenericContainer container = createDBContainer(asDefaultUser, password)) {
+            temporaryFolderManager.mountHostFolderAsVolume(container, secondDataDir, "/data");
             container.start();
-            DatabaseIO dbio = new DatabaseIO( container );
-            dbio.verifyInitialDataInContainer( "neo4j", password );
+            DatabaseIO dbio = new DatabaseIO(container);
+            dbio.verifyInitialDataInContainer("neo4j", password);
         }
     }
 }

--- a/src/test/java/com/neo4j/docker/neo4jadmin/TestReport.java
+++ b/src/test/java/com/neo4j/docker/neo4jadmin/TestReport.java
@@ -1,7 +1,8 @@
 package com.neo4j.docker.neo4jadmin;
 
-import com.neo4j.docker.utils.WaitStrategies;
 import com.neo4j.docker.utils.TestSettings;
+import com.neo4j.docker.utils.WaitStrategies;
+import java.time.Duration;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -10,34 +11,31 @@ import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 
-import java.time.Duration;
+public class TestReport {
+    private final Logger log = LoggerFactory.getLogger(TestReport.class);
 
-public class TestReport
-{
-    private final Logger log = LoggerFactory.getLogger( TestReport.class );
-
-    private GenericContainer createAdminContainer()
-    {
-        GenericContainer container = new GenericContainer( TestSettings.ADMIN_IMAGE_ID )
-                .withEnv( "NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes" ).withEnv( "NEO4J_DEBUG", "yes" )
-                .withCommand( "neo4j-admin", "server", "report" )
-                .withLogConsumer( new Slf4jLogConsumer( log ) );
-        WaitStrategies.waitUntilContainerFinished( container, Duration.ofSeconds( 20 ) );
+    private GenericContainer createAdminContainer() {
+        GenericContainer container = new GenericContainer(TestSettings.ADMIN_IMAGE_ID)
+                .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+                .withEnv("NEO4J_DEBUG", "yes")
+                .withCommand("neo4j-admin", "server", "report")
+                .withLogConsumer(new Slf4jLogConsumer(log));
+        WaitStrategies.waitUntilContainerFinished(container, Duration.ofSeconds(20));
         return container;
     }
 
     @Test
-    void shouldErrorHelpfullyIfAdminReport()
-    {
-        try(GenericContainer container = createAdminContainer())
-        {
-            Assertions.assertThrows( ContainerLaunchException.class, container::start );
-            Assertions.assertTrue( container.getLogs().contains( "To run the report tool inside a neo4j container, do:" ),
-                                   "did not error about needing to run in the same container as the database." +
-                                   " Actual logs:"+container.getLogs() );
-            Assertions.assertTrue( container.getLogs().contains( "docker exec <CONTAINER NAME> neo4j-admin-report" ),
-                                   "did not error about needing to run in the same container as the database." +
-                                   " Actual logs:"+container.getLogs() );
+    void shouldErrorHelpfullyIfAdminReport() {
+        try (GenericContainer container = createAdminContainer()) {
+            Assertions.assertThrows(ContainerLaunchException.class, container::start);
+            Assertions.assertTrue(
+                    container.getLogs().contains("To run the report tool inside a neo4j container, do:"),
+                    "did not error about needing to run in the same container as the database." + " Actual logs:"
+                            + container.getLogs());
+            Assertions.assertTrue(
+                    container.getLogs().contains("docker exec <CONTAINER NAME> neo4j-admin-report"),
+                    "did not error about needing to run in the same container as the database." + " Actual logs:"
+                            + container.getLogs());
         }
     }
 }

--- a/src/test/java/com/neo4j/docker/utils/BaseOS.java
+++ b/src/test/java/com/neo4j/docker/utils/BaseOS.java
@@ -24,21 +24,21 @@ public enum BaseOS {
     }
 
     public boolean isDeprecatedOs() {
-        return switch(this) {
-        case UBI8, UBI9, BULLSEYE -> true;
-        default -> false;
+        return switch (this) {
+            case UBI8, UBI9, BULLSEYE -> true;
+            default -> false;
         };
     }
 
-    public boolean hasDeprecationWarningUntil( Neo4jVersion other) {
+    public boolean hasDeprecationWarningUntil(Neo4jVersion other) {
         Neo4jVersion deprecatedIn;
-        switch(other.major) {
-            case 4,3,2,1 -> deprecatedIn = null;
+        switch (other.major) {
+            case 4, 3, 2, 1 -> deprecatedIn = null;
             case 5 -> deprecatedIn = this.lastAppearsIn5x;
             default -> deprecatedIn = this.lastAppearsInCalver;
         }
-        if(deprecatedIn == null) return false;
-        return !other.isNewerThan( deprecatedIn );
+        if (deprecatedIn == null) return false;
+        return !other.isNewerThan(deprecatedIn);
     }
 
     public static BaseOS fromString(String name) {

--- a/src/test/java/com/neo4j/docker/utils/BaseOSTest.java
+++ b/src/test/java/com/neo4j/docker/utils/BaseOSTest.java
@@ -11,76 +11,88 @@ import org.junit.jupiter.params.provider.ValueSource;
 @Disabled
 class BaseOSTest {
     @ParameterizedTest
-    @ValueSource(strings = {"trixie", "bullseye", "ubi10", "ubi9", "ubi8",
-                            "Trixie", "Bullseye", "Ubi10", "Ubi9", "Ubi8"})
+    @ValueSource(
+            strings = {
+                "trixie", "bullseye", "ubi10", "ubi9", "ubi8",
+                "Trixie", "Bullseye", "Ubi10", "Ubi9", "Ubi8"
+            })
     void testFromString(String name) {
         BaseOS os = BaseOS.fromString(name);
-        Assertions.assertNotNull( os );
-        Assertions.assertEquals( name.toLowerCase(), os.osName,
-                                 "Did not get the correct BaseOS from name " + name );
+        Assertions.assertNotNull(os);
+        Assertions.assertEquals(name.toLowerCase(), os.osName, "Did not get the correct BaseOS from name " + name);
     }
 
     @ParameterizedTest(name = "{0}, {1}.{2}.{3}")
-    @CsvSource({"ubi8,5,19,0", "ubi9,5,26,20", "bullseye,5,26,20",
-                "ubi8,2023,12,0", "ubi9,2026,2,0", "bullseye,2026,2,0"
+    @CsvSource({
+        "ubi8,5,19,0", "ubi9,5,26,20", "bullseye,5,26,20",
+        "ubi8,2023,12,0", "ubi9,2026,2,0", "bullseye,2026,2,0"
     })
     void testHasDeprecationWarning_before(String name, int major, int minor, int patch) {
         BaseOS os = BaseOS.fromString(name);
-        Assertions.assertNotNull( os );
+        Assertions.assertNotNull(os);
         Neo4jVersion compareVersion = new Neo4jVersion(major, minor, patch);
-        Assertions.assertTrue( os.hasDeprecationWarningUntil( compareVersion ),
-                               "Should have flagged version %s as having a deprecation warning for  %s"
-                                       .formatted( compareVersion, name ));
+        Assertions.assertTrue(
+                os.hasDeprecationWarningUntil(compareVersion),
+                "Should have flagged version %s as having a deprecation warning for  %s"
+                        .formatted(compareVersion, name));
     }
 
     @ParameterizedTest(name = "{0}, {1}.{2}.{3}")
-    @CsvSource({"ubi8,5,20,0", "ubi9,5,26,23", "bullseye,5,26,23",
-                "ubi8,2024,1,0", "ubi9,2026,4,0","bullseye,2026,4,0"
+    @CsvSource({
+        "ubi8,5,20,0", "ubi9,5,26,23", "bullseye,5,26,23",
+        "ubi8,2024,1,0", "ubi9,2026,4,0", "bullseye,2026,4,0"
     })
     void testHasDeprecationWarning_equal(String name, int major, int minor, int patch) {
         BaseOS os = BaseOS.fromString(name);
-        Assertions.assertNotNull( os );
+        Assertions.assertNotNull(os);
         Neo4jVersion compareVersion = new Neo4jVersion(major, minor, patch);
-        Assertions.assertTrue( os.hasDeprecationWarningUntil( compareVersion ),
-                               "Should have flagged version %s as having a deprecation warning for %s"
-                                       .formatted( compareVersion, name ));
+        Assertions.assertTrue(
+                os.hasDeprecationWarningUntil(compareVersion),
+                "Should have flagged version %s as having a deprecation warning for %s"
+                        .formatted(compareVersion, name));
     }
 
     @ParameterizedTest(name = "{0}, {1}.{2}.{3}")
-    @CsvSource({"ubi8,5,26,0", "ubi9,5,26,50", "bullseye,5,26,50",
-            "ubi8,2027,1,0", "ubi9,2080,4,0", "bullseye,2080,4,0"
+    @CsvSource({"ubi8,5,26,0", "ubi9,5,26,50", "bullseye,5,26,50", "ubi8,2027,1,0", "ubi9,2080,4,0", "bullseye,2080,4,0"
     })
     void testHasDeprecationWarning_after(String name, int major, int minor, int patch) {
         BaseOS os = BaseOS.fromString(name);
-        Assertions.assertNotNull( os );
+        Assertions.assertNotNull(os);
         Neo4jVersion compareVersion = new Neo4jVersion(major, minor, patch);
-        Assertions.assertFalse( os.hasDeprecationWarningUntil( compareVersion ),
-                               "Should not have flagged version %s as having a deprecation warning for %s"
-                                       .formatted( compareVersion, name ));
+        Assertions.assertFalse(
+                os.hasDeprecationWarningUntil(compareVersion),
+                "Should not have flagged version %s as having a deprecation warning for %s"
+                        .formatted(compareVersion, name));
     }
 
     @ParameterizedTest(name = "{0}, {1}.{2}.{3}")
-    @CsvSource({"ubi10,2027,1,0", "ubi10,5,26,0",
-                "trixie,2024,4,0", "trixie,5,26,50"})
+    @CsvSource({
+        "ubi10,2027,1,0", "ubi10,5,26,0",
+        "trixie,2024,4,0", "trixie,5,26,50"
+    })
     void testHasDeprecationWarning_undeprecated(String name, int major, int minor, int patch) {
         BaseOS os = BaseOS.fromString(name);
-        Assertions.assertNotNull( os );
+        Assertions.assertNotNull(os);
         Neo4jVersion compareVersion = new Neo4jVersion(major, minor, patch);
-        Assertions.assertFalse( os.hasDeprecationWarningUntil( compareVersion ),
-                               "Should not have flagged version %s as having a deprecation warning for %s"
-                                       .formatted( compareVersion, name ));
+        Assertions.assertFalse(
+                os.hasDeprecationWarningUntil(compareVersion),
+                "Should not have flagged version %s as having a deprecation warning for %s"
+                        .formatted(compareVersion, name));
     }
 
     @ParameterizedTest(name = "{0}, {1}.{2}.{3}")
-    @CsvSource({"ubi8,4,1,0", "ubi8,3,2,0", "ubi8,1,10,0", "ubi8,4,4,50",
-                "ubi9,4,1,0", "ubi9,3,2,0", "ubi9,1,10,0", "ubi9,4,4,50",
-                "ubi10,4,1,0", "ubi10,3,2,0", "ubi10,1,10,0", "ubi10,4,4,50"})
+    @CsvSource({
+        "ubi8,4,1,0", "ubi8,3,2,0", "ubi8,1,10,0", "ubi8,4,4,50",
+        "ubi9,4,1,0", "ubi9,3,2,0", "ubi9,1,10,0", "ubi9,4,4,50",
+        "ubi10,4,1,0", "ubi10,3,2,0", "ubi10,1,10,0", "ubi10,4,4,50"
+    })
     void testHasDeprecationWarning_oldVersionsNoWarning(String name, int major, int minor, int patch) {
         BaseOS os = BaseOS.fromString(name);
-        Assertions.assertNotNull( os );
+        Assertions.assertNotNull(os);
         Neo4jVersion compareVersion = new Neo4jVersion(major, minor, patch);
-        Assertions.assertFalse( os.hasDeprecationWarningUntil( compareVersion ),
-                               "Should not have flagged version %s as having a deprecation warning for %s"
-                                       .formatted( compareVersion, name ));
+        Assertions.assertFalse(
+                os.hasDeprecationWarningUntil(compareVersion),
+                "Should not have flagged version %s as having a deprecation warning for %s"
+                        .formatted(compareVersion, name));
     }
 }

--- a/src/test/java/com/neo4j/docker/utils/DatabaseIO.java
+++ b/src/test/java/com/neo4j/docker/utils/DatabaseIO.java
@@ -1,6 +1,8 @@
 package com.neo4j.docker.utils;
 
 import com.neo4j.docker.coredb.configurations.Configuration;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Assertions;
 import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.AuthTokens;
@@ -15,154 +17,141 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 
-import java.util.List;
-import java.util.stream.Collectors;
+public class DatabaseIO {
+    private static final Config DEFAULT_DRIVER_CONFIG =
+            Config.builder().withoutEncryption().build();
+    private final Logger log = LoggerFactory.getLogger(DatabaseIO.class);
 
-public class DatabaseIO
-{
-	private static final Config DEFAULT_DRIVER_CONFIG = Config.builder().withoutEncryption().build();
-	private final Logger log = LoggerFactory.getLogger( DatabaseIO.class );
+    private GenericContainer container;
+    private String boltUri;
 
-	private GenericContainer container;
-	private String boltUri;
+    public DatabaseIO(GenericContainer container) {
+        this.container = container;
+        this.boltUri = "bolt://" + container.getHost() + ":" + container.getMappedPort(7687);
+    }
 
-	public DatabaseIO( GenericContainer container )
-	{
-		this.container = container;
-        this.boltUri = "bolt://"+container.getHost()+":"+container.getMappedPort( 7687 );
-	}
-
-    public DatabaseIO( String host, Integer boltPort )
-    {
+    public DatabaseIO(String host, Integer boltPort) {
         this.boltUri = "bolt://" + host + ":" + boltPort;
     }
 
-	public void putInitialDataIntoContainer( String user, String password )
-	{
-		log.info( "Writing data into database" );
-        List<Record> result = runCypherQuery( user, password,"CREATE (arne:dog {name:'Arne'})-[:SNIFFS]->(bosse:dog {name:'Bosse'}) RETURN arne.name" );
-        Assertions.assertEquals( "Arne", result.get( 0 ).get( "arne.name" ).asString(), "did not receive expected result from cypher CREATE query" );
-	}
-
-	public void verifyInitialDataInContainer( String user, String password )
-	{
-		log.info( "verifying data is present in the database" );		
-		List<Record> result = runCypherQuery( user, password,"MATCH (a:dog)-[:SNIFFS]->(b:dog) RETURN a.name");
-        Assertions.assertEquals( "Arne", result.get( 0 ).get("a.name").asString(), "did not receive expected result from cypher MATCH query" );
-	}
-
-	public void putMoreDataIntoContainer( String user, String password )
-	{
-		log.info( "Writing more data into database" );
-        List<Record> result = runCypherQuery( user, password,
-                      "MATCH (a:dog {name:'Arne'}) CREATE (armstrong:dog {name:'Armstrong'})-[:SNIFFS]->(a) return a.name, armstrong.name" );
-        Assertions.assertEquals( "Arne", result.get( 0 ).get("a.name").asString(),
-                                 "did not receive expected result from cypher MATCH query" );
-        Assertions.assertEquals( "Armstrong", result.get( 0 ).get( "armstrong.name" ).asString(),
-                                 "did not receive expected result from cypher CREATE query" );
-	}
-
-	public void verifyMoreDataIntoContainer( String user, String password, boolean extraDataShouldBeThere )
-	{
-		log.info( "Verifying extra data is {}in database", extraDataShouldBeThere? "":"not " );
-		List<Record> result = runCypherQuery( user, password,"MATCH (a:dog)-[:SNIFFS]->(b:dog) RETURN a.name");
-		String dogs = result.stream()
-                            .map( record -> record.get( 0 ).asString() )
-                            .sorted()
-                            .collect( Collectors.joining(","));
-		// dogs should now be a String which is a comma delimited list of dog names
-
-		if(extraDataShouldBeThere)
-        {
-            Assertions.assertEquals( "Armstrong,Arne", dogs, "cypher query did not return correct data" );
-        }
-		else
-        {
-            Assertions.assertEquals( "Arne", dogs, "cypher query did not return correct data" );
-        }
-	}
-
-    public String getConfigurationSettingAsString( String user, String password, Configuration conf)
-    {
-        List<Record> confRecord = runCypherQuery( user, password,
-                                                  "CALL dbms.listConfig() YIELD name, value " +
-                                                  "WHERE name='" + conf.name + "' " +
-                                                  "RETURN value" );
-        Assertions.assertEquals(1, confRecord.size(), "Configuration "+conf.name+" was not set." );
-        return confRecord.get( 0 ).get( 0 ).asString();
+    public void putInitialDataIntoContainer(String user, String password) {
+        log.info("Writing data into database");
+        List<Record> result = runCypherQuery(
+                user,
+                password,
+                "CREATE (arne:dog {name:'Arne'})-[:SNIFFS]->(bosse:dog {name:'Bosse'}) RETURN arne.name");
+        Assertions.assertEquals(
+                "Arne",
+                result.get(0).get("arne.name").asString(),
+                "did not receive expected result from cypher CREATE query");
     }
 
-    public void verifyConfigurationSetting( String user, String password, Configuration conf, String expectedValue)
-    {
+    public void verifyInitialDataInContainer(String user, String password) {
+        log.info("verifying data is present in the database");
+        List<Record> result = runCypherQuery(user, password, "MATCH (a:dog)-[:SNIFFS]->(b:dog) RETURN a.name");
+        Assertions.assertEquals(
+                "Arne",
+                result.get(0).get("a.name").asString(),
+                "did not receive expected result from cypher MATCH query");
+    }
+
+    public void putMoreDataIntoContainer(String user, String password) {
+        log.info("Writing more data into database");
+        List<Record> result = runCypherQuery(
+                user,
+                password,
+                "MATCH (a:dog {name:'Arne'}) CREATE (armstrong:dog {name:'Armstrong'})-[:SNIFFS]->(a) return a.name, armstrong.name");
+        Assertions.assertEquals(
+                "Arne",
+                result.get(0).get("a.name").asString(),
+                "did not receive expected result from cypher MATCH query");
+        Assertions.assertEquals(
+                "Armstrong",
+                result.get(0).get("armstrong.name").asString(),
+                "did not receive expected result from cypher CREATE query");
+    }
+
+    public void verifyMoreDataIntoContainer(String user, String password, boolean extraDataShouldBeThere) {
+        log.info("Verifying extra data is {}in database", extraDataShouldBeThere ? "" : "not ");
+        List<Record> result = runCypherQuery(user, password, "MATCH (a:dog)-[:SNIFFS]->(b:dog) RETURN a.name");
+        String dogs =
+                result.stream().map(record -> record.get(0).asString()).sorted().collect(Collectors.joining(","));
+        // dogs should now be a String which is a comma delimited list of dog names
+
+        if (extraDataShouldBeThere) {
+            Assertions.assertEquals("Armstrong,Arne", dogs, "cypher query did not return correct data");
+        } else {
+            Assertions.assertEquals("Arne", dogs, "cypher query did not return correct data");
+        }
+    }
+
+    public String getConfigurationSettingAsString(String user, String password, Configuration conf) {
+        List<Record> confRecord = runCypherQuery(
+                user,
+                password,
+                "CALL dbms.listConfig() YIELD name, value " + "WHERE name='" + conf.name + "' " + "RETURN value");
+        Assertions.assertEquals(1, confRecord.size(), "Configuration " + conf.name + " was not set.");
+        return confRecord.get(0).get(0).asString();
+    }
+
+    public void verifyConfigurationSetting(String user, String password, Configuration conf, String expectedValue) {
         verifyConfigurationSetting(user, password, conf, expectedValue, "");
     }
 
-    public void verifyConfigurationSetting( String user, String password, Configuration conf, String expectedValue, String extraFailureMsg)
-    {
-        String actualConf = getConfigurationSettingAsString( user, password, conf );
-        Assertions.assertEquals(expectedValue, actualConf,
-                                String.format("Expected %s to be %s but it was %s.%s",
-                                              conf.name, expectedValue, actualConf, extraFailureMsg));
+    public void verifyConfigurationSetting(
+            String user, String password, Configuration conf, String expectedValue, String extraFailureMsg) {
+        String actualConf = getConfigurationSettingAsString(user, password, conf);
+        Assertions.assertEquals(
+                expectedValue,
+                actualConf,
+                String.format(
+                        "Expected %s to be %s but it was %s.%s",
+                        conf.name, expectedValue, actualConf, extraFailureMsg));
     }
 
-	public void changePassword(String user, String oldPassword, String newPassword)
-	{
-		if(TestSettings.NEO4J_VERSION.isAtLeastVersion( Neo4jVersion.NEO4J_VERSION_400 ))
-		{
-		    String cypher = "ALTER CURRENT USER SET PASSWORD FROM '"+oldPassword+"' TO '"+newPassword+"'";
-		    runCypherQuery( user, oldPassword, cypher, "system" );
-		}
-		else
-		{
-		    runCypherQuery( user, oldPassword, "CALL dbms.changePassword('"+newPassword+"')" );
-		}
-	}
+    public void changePassword(String user, String oldPassword, String newPassword) {
+        if (TestSettings.NEO4J_VERSION.isAtLeastVersion(Neo4jVersion.NEO4J_VERSION_400)) {
+            String cypher = "ALTER CURRENT USER SET PASSWORD FROM '" + oldPassword + "' TO '" + newPassword + "'";
+            runCypherQuery(user, oldPassword, cypher, "system");
+        } else {
+            runCypherQuery(user, oldPassword, "CALL dbms.changePassword('" + newPassword + "')");
+        }
+    }
 
-	public List<Record> runCypherQuery( String user, String password, String cypher)
-    {
+    public List<Record> runCypherQuery(String user, String password, String cypher) {
         // we don't just do runCypherQuery( user, password, cypher, "neo4j")
         // because it breaks the upgrade tests from 3.5.x
         List<Record> records;
-		Driver driver = GraphDatabase.driver( boltUri, getToken( user, password ), DEFAULT_DRIVER_CONFIG);
-		try ( Session session = driver.session())
-		{
-			Result rs = session.run( cypher );
-			records = rs.list();
-		}
-		driver.close();
-		return records;
+        Driver driver = GraphDatabase.driver(boltUri, getToken(user, password), DEFAULT_DRIVER_CONFIG);
+        try (Session session = driver.session()) {
+            Result rs = session.run(cypher);
+            records = rs.list();
+        }
+        driver.close();
+        return records;
     }
 
-	public List<Record> runCypherQuery( String user, String password, String cypher, String database)
-    {
+    public List<Record> runCypherQuery(String user, String password, String cypher, String database) {
         List<Record> records;
-		Driver driver = GraphDatabase.driver( boltUri, getToken( user, password ), DEFAULT_DRIVER_CONFIG);
-		try ( Session session = driver.session(SessionConfig.forDatabase( database )))
-		{
-			Result rs = session.run( cypher );
-			records = rs.list();
-		}
-		driver.close();
-		return records;
+        Driver driver = GraphDatabase.driver(boltUri, getToken(user, password), DEFAULT_DRIVER_CONFIG);
+        try (Session session = driver.session(SessionConfig.forDatabase(database))) {
+            Result rs = session.run(cypher);
+            records = rs.list();
+        }
+        driver.close();
+        return records;
     }
 
-	public void verifyConnectivity( String user, String password )
-	{
-		GraphDatabase.driver( boltUri,
-							  getToken( user, password ),
-						DEFAULT_DRIVER_CONFIG)
-					 .verifyConnectivity();
-	}
+    public void verifyConnectivity(String user, String password) {
+        GraphDatabase.driver(boltUri, getToken(user, password), DEFAULT_DRIVER_CONFIG)
+                .verifyConnectivity();
+    }
 
-	private AuthToken getToken(String user, String password)
-	{
-		if(password.equals( "none" ))
-		{
-			return AuthTokens.none();
-		}
-		else
-		{
-			return AuthTokens.basic( user, password );
-		}
-	}
+    private AuthToken getToken(String user, String password) {
+        if (password.equals("none")) {
+            return AuthTokens.none();
+        } else {
+            return AuthTokens.basic(user, password);
+        }
+    }
 }

--- a/src/test/java/com/neo4j/docker/utils/HostFileHttpHandler.java
+++ b/src/test/java/com/neo4j/docker/utils/HostFileHttpHandler.java
@@ -2,7 +2,6 @@ package com.neo4j.docker.utils;
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -11,23 +10,20 @@ import java.nio.file.Files;
 /**
  * HttpHandler that responds to all http requests with the given file from the file system
  */
-public class HostFileHttpHandler implements HttpHandler
-{
+public class HostFileHttpHandler implements HttpHandler {
     private final File file;
     private final String contentType;
 
-    public HostFileHttpHandler( File fileToDownload, String contentType )
-    {
+    public HostFileHttpHandler(File fileToDownload, String contentType) {
         this.file = fileToDownload;
         this.contentType = contentType;
     }
 
     @Override
-    public void handle( HttpExchange exchange ) throws IOException
-    {
-        exchange.getResponseHeaders().add( "Content-Type", contentType );
-        exchange.sendResponseHeaders( HttpURLConnection.HTTP_OK, file.length() );
-        Files.copy( this.file.toPath(), exchange.getResponseBody() );
+    public void handle(HttpExchange exchange) throws IOException {
+        exchange.getResponseHeaders().add("Content-Type", contentType);
+        exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, file.length());
+        Files.copy(this.file.toPath(), exchange.getResponseBody());
         exchange.close();
     }
 }

--- a/src/test/java/com/neo4j/docker/utils/HttpServerTestExtension.java
+++ b/src/test/java/com/neo4j/docker/utils/HttpServerTestExtension.java
@@ -2,57 +2,47 @@ package com.neo4j.docker.utils;
 
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
+import java.net.InetSocketAddress;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-import java.net.InetSocketAddress;
-
 /**
  * Runs a HTTP Server with to allow integration testing
  */
-public class HttpServerTestExtension implements AfterEachCallback, BeforeEachCallback
-{
+public class HttpServerTestExtension implements AfterEachCallback, BeforeEachCallback {
     public final int PORT = 3000;
     private HttpServer server;
 
     @Override
-    public void beforeEach(ExtensionContext extensionContext) throws Exception
-    {
-        server = HttpServer.create( new InetSocketAddress( PORT ), 0 );
-        server.setExecutor( null ); // creates a default executor
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        server = HttpServer.create(new InetSocketAddress(PORT), 0);
+        server.setExecutor(null); // creates a default executor
         server.start();
     }
 
     @Override
-    public void afterEach(ExtensionContext extensionContext) throws Exception
-    {
-        if ( server != null )
-        {
-            server.stop( 5 ); // waits up to 5 seconds to stop serving http requests
+    public void afterEach(ExtensionContext extensionContext) throws Exception {
+        if (server != null) {
+            server.stop(5); // waits up to 5 seconds to stop serving http requests
         }
     }
 
     // Register a handler to provide desired behaviour on a specific uri path
-    public void registerHandler( String uriToHandle, HttpHandler httpHandler )
-    {
-        if (!uriToHandle.startsWith( "/" )){
+    public void registerHandler(String uriToHandle, HttpHandler httpHandler) {
+        if (!uriToHandle.startsWith("/")) {
             uriToHandle = '/' + uriToHandle;
         }
-        server.createContext( uriToHandle, httpHandler );
+        server.createContext(uriToHandle, httpHandler);
     }
 
-    public void unregisterEndpoint(String endpoint)
-    {
-        if (!endpoint.startsWith( "/" )){
+    public void unregisterEndpoint(String endpoint) {
+        if (!endpoint.startsWith("/")) {
             endpoint = '/' + endpoint;
         }
-        try
-        {
+        try {
             server.removeContext(endpoint);
-        }
-        catch (IllegalArgumentException iex)
-        {
+        } catch (IllegalArgumentException iex) {
             // there was nothing registered to that endpoint so action is a NOP.
         }
     }

--- a/src/test/java/com/neo4j/docker/utils/Neo4jVersion.java
+++ b/src/test/java/com/neo4j/docker/utils/Neo4jVersion.java
@@ -3,130 +3,104 @@ package com.neo4j.docker.utils;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class Neo4jVersion
-{
-    public static final Neo4jVersion NEO4J_VERSION_400 = new Neo4jVersion( 4, 0, 0 );
-    public static final Neo4jVersion NEO4J_VERSION_440 = new Neo4jVersion( 4, 4, 0 );
-    public static final Neo4jVersion NEO4J_VERSION_500 = new Neo4jVersion( 5, 0, 0 );
-    public static final Neo4jVersion NEO4J_VERSION_527 = new Neo4jVersion( 5, 27, 0 );
+public class Neo4jVersion {
+    public static final Neo4jVersion NEO4J_VERSION_400 = new Neo4jVersion(4, 0, 0);
+    public static final Neo4jVersion NEO4J_VERSION_440 = new Neo4jVersion(4, 4, 0);
+    public static final Neo4jVersion NEO4J_VERSION_500 = new Neo4jVersion(5, 0, 0);
+    public static final Neo4jVersion NEO4J_VERSION_527 = new Neo4jVersion(5, 27, 0);
 
     public final int major;
     public final int minor;
     public final int patch;
     public final String label;
 
-    public static Neo4jVersion fromVersionString( String version )
-    {
-        Pattern pattern = Pattern.compile( "(?<major>[\\d]+)\\.(?<minor>[\\d]+)\\.(?<patch>[\\d]+)(?<label>-(.*))?" );
-        Matcher x = pattern.matcher( version );
+    public static Neo4jVersion fromVersionString(String version) {
+        Pattern pattern = Pattern.compile("(?<major>[\\d]+)\\.(?<minor>[\\d]+)\\.(?<patch>[\\d]+)(?<label>-(.*))?");
+        Matcher x = pattern.matcher(version);
         x.find();
 
         return new Neo4jVersion(
-                Integer.parseInt( x.group( "major" ) ),
-                Integer.parseInt( x.group( "minor" ) ),
-                Integer.parseInt( x.group( "patch" ) ),
-                (x.group( "label" ) == null) ? "" : x.group( "label" )
-        );
+                Integer.parseInt(x.group("major")),
+                Integer.parseInt(x.group("minor")),
+                Integer.parseInt(x.group("patch")),
+                (x.group("label") == null) ? "" : x.group("label"));
     }
 
-    public static String makeVersionString(int major, int minor)
-    {
-        if ( major > 2023 )
-        {
-            return String.format( "%d.%02d", major, minor);
+    public static String makeVersionString(int major, int minor) {
+        if (major > 2023) {
+            return String.format("%d.%02d", major, minor);
         }
-        return String.format( "%d.%d", major, minor);
+        return String.format("%d.%d", major, minor);
     }
 
-    public static String makeVersionString(int major, int minor, int patch)
-    {
-        return makeVersionString( major, minor) + String.format(".%d", patch);
+    public static String makeVersionString(int major, int minor, int patch) {
+        return makeVersionString(major, minor) + String.format(".%d", patch);
     }
 
-    public Neo4jVersion( int major, int minor, int patch )
-    {
-        this( major, minor, patch, "" );
+    public Neo4jVersion(int major, int minor, int patch) {
+        this(major, minor, patch, "");
     }
 
-    public Neo4jVersion( int major, int minor, int patch, String label )
-    {
+    public Neo4jVersion(int major, int minor, int patch, String label) {
         this.major = major;
         this.minor = minor;
         this.patch = patch;
         this.label = label;
     }
 
-    public boolean isNewerThan(Neo4jVersion that)
-    {
-        if ( this.major != that.major )
-        {
+    public boolean isNewerThan(Neo4jVersion that) {
+        if (this.major != that.major) {
             return (this.major > that.major);
-        }
-        else
-        {
-            if ( this.minor != that.minor )
-            {
+        } else {
+            if (this.minor != that.minor) {
                 return (this.minor > that.minor);
-            }
-            else
-            {
+            } else {
                 return (this.patch > that.patch);
             }
         }
-        // Not comparing the alpha/beta label because it's still the *same* major minor patch version and a very unlikely upgrade path
+        // Not comparing the alpha/beta label because it's still the *same* major minor patch version and a very
+        // unlikely upgrade path
     }
 
-    public boolean isOlderThan( Neo4jVersion that )
-    {
-        return !isAtLeastVersion( that );
+    public boolean isOlderThan(Neo4jVersion that) {
+        return !isAtLeastVersion(that);
     }
 
-    public boolean isAtLeastVersion( Neo4jVersion that )
-    {
-        boolean isNewer = this.isNewerThan( that );
-        if ( !isNewer )
-        {
-            return isEqual( that );
-        }
-        else
-        {
+    public boolean isAtLeastVersion(Neo4jVersion that) {
+        boolean isNewer = this.isNewerThan(that);
+        if (!isNewer) {
+            return isEqual(that);
+        } else {
             return true;
         }
     }
 
-    public boolean isCalver()
-    {
-        return ( this.major > 2023 );
+    public boolean isCalver() {
+        return (this.major > 2023);
     }
 
-    public boolean isEqual( Neo4jVersion that )
-    {
+    public boolean isEqual(Neo4jVersion that) {
         return (major == that.major) && (minor == that.minor) && (patch == that.patch);
     }
 
     @Override
-    public String toString()
-    {
-        return makeVersionString( major, minor, patch ) + label;
+    public String toString() {
+        return makeVersionString(major, minor, patch) + label;
     }
 
-    public String toReleaseString()
-    {
-        return makeVersionString( major, minor, patch );
+    public String toReleaseString() {
+        return makeVersionString(major, minor, patch);
     }
 
     @Override
-    public boolean equals( Object o )
-    {
-        if ( this == o )
-        {
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
-        if ( o == null || getClass() != o.getClass() )
-        {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
 
-        return isEqual( (Neo4jVersion) o );
+        return isEqual((Neo4jVersion) o);
     }
 }

--- a/src/test/java/com/neo4j/docker/utils/Neo4jVersionTest.java
+++ b/src/test/java/com/neo4j/docker/utils/Neo4jVersionTest.java
@@ -8,174 +8,170 @@ import org.junit.jupiter.params.provider.CsvSource;
 public class Neo4jVersionTest {
 
     @Test
-    public void testIsOlderThan_majorDifferent()
-    {
-        Neo4jVersion newer = new Neo4jVersion( 3, 5, 1 );
-        Neo4jVersion older = new Neo4jVersion( 2, 0, 0 );
-        testOlderVsNewer( newer, older );
+    public void testIsOlderThan_majorDifferent() {
+        Neo4jVersion newer = new Neo4jVersion(3, 5, 1);
+        Neo4jVersion older = new Neo4jVersion(2, 0, 0);
+        testOlderVsNewer(newer, older);
     }
 
     @Test
-    public void testIsOlderThan_minorDifferent()
-    {
-        Neo4jVersion newer = new Neo4jVersion( 3, 5, 1 );
-        Neo4jVersion older = new Neo4jVersion( 3, 0, 0 );
-        testOlderVsNewer( newer, older );
+    public void testIsOlderThan_minorDifferent() {
+        Neo4jVersion newer = new Neo4jVersion(3, 5, 1);
+        Neo4jVersion older = new Neo4jVersion(3, 0, 0);
+        testOlderVsNewer(newer, older);
     }
 
     @Test
-    public void testIsOlderThan_patchDifferent()
-    {
-        Neo4jVersion newer = new Neo4jVersion( 3, 5, 1 );
-        Neo4jVersion older = new Neo4jVersion( 3, 5, 0 );
-        testOlderVsNewer( newer, older );
+    public void testIsOlderThan_patchDifferent() {
+        Neo4jVersion newer = new Neo4jVersion(3, 5, 1);
+        Neo4jVersion older = new Neo4jVersion(3, 5, 0);
+        testOlderVsNewer(newer, older);
     }
 
     @Test
-    public void testIsOlderThan_majorLessMinorMore()
-    {
-        Neo4jVersion newer = new Neo4jVersion( 3, 5, 1 );
-        Neo4jVersion older = new Neo4jVersion( 2, 7, 0 );
-        testOlderVsNewer( newer, older );
+    public void testIsOlderThan_majorLessMinorMore() {
+        Neo4jVersion newer = new Neo4jVersion(3, 5, 1);
+        Neo4jVersion older = new Neo4jVersion(2, 7, 0);
+        testOlderVsNewer(newer, older);
     }
 
     @Test
-    public void testIsOlderThan_minorLessPatchMore()
-    {
-        Neo4jVersion newer = new Neo4jVersion( 3, 5, 0 );
-        Neo4jVersion older = new Neo4jVersion( 3, 2, 12 );
-        testOlderVsNewer( newer, older );
+    public void testIsOlderThan_minorLessPatchMore() {
+        Neo4jVersion newer = new Neo4jVersion(3, 5, 0);
+        Neo4jVersion older = new Neo4jVersion(3, 2, 12);
+        testOlderVsNewer(newer, older);
     }
 
     @Test
-    public void testSamePatch_isEqualAndAtLeast()
-    {
-        Neo4jVersion newer = new Neo4jVersion( 3, 5, 0 );
-        Neo4jVersion older = new Neo4jVersion( 3, 5, 0 );
+    public void testSamePatch_isEqualAndAtLeast() {
+        Neo4jVersion newer = new Neo4jVersion(3, 5, 0);
+        Neo4jVersion older = new Neo4jVersion(3, 5, 0);
 
-        Assertions.assertFalse( newer.isOlderThan( older ) ,
-                                String.format( "Didn't detect that %s is newer than %s using isOlderThan", newer, older ) );
-        Assertions.assertFalse( older.isNewerThan( newer ) ,
-                     String.format( "Didn't detect that %s is older than %s using isNewerThan", older, newer ) );
-        Assertions.assertTrue( newer.isAtLeastVersion( older ),
-                    String.format( "Didn't detect that %s is at least %s using isAtLeastVersion", newer, older ) );
-        Assertions.assertTrue( newer.isEqual(older),
-                    String.format( "Didn't detect that %s is equal to %s using isEqual", newer, older ) );
+        Assertions.assertFalse(
+                newer.isOlderThan(older),
+                String.format("Didn't detect that %s is newer than %s using isOlderThan", newer, older));
+        Assertions.assertFalse(
+                older.isNewerThan(newer),
+                String.format("Didn't detect that %s is older than %s using isNewerThan", older, newer));
+        Assertions.assertTrue(
+                newer.isAtLeastVersion(older),
+                String.format("Didn't detect that %s is at least %s using isAtLeastVersion", newer, older));
+        Assertions.assertTrue(
+                newer.isEqual(older),
+                String.format("Didn't detect that %s is equal to %s using isEqual", newer, older));
     }
 
     @Test
-    public void testSamePatch_isEqualAndAtLeast_differentBuild()
-    {
-        Neo4jVersion newer = new Neo4jVersion( 3, 5, 0, "-11" );
-        Neo4jVersion older = new Neo4jVersion( 3, 5, 0, "-10" );
+    public void testSamePatch_isEqualAndAtLeast_differentBuild() {
+        Neo4jVersion newer = new Neo4jVersion(3, 5, 0, "-11");
+        Neo4jVersion older = new Neo4jVersion(3, 5, 0, "-10");
 
-        Assertions.assertFalse( newer.isOlderThan( older ) ,
-                     String.format( "Didn't detect that %s is newer than %s using isOlderThan", newer, older ) );
-        Assertions.assertFalse( older.isNewerThan( newer ) ,
-                     String.format( "Didn't detect that %s is older than %s using isNewerThan", older, newer ) );
-        Assertions.assertTrue( newer.isAtLeastVersion( older ),
-                    String.format( "Didn't detect that %s is at least %s using isAtLeastVersion", newer, older ) );
-        Assertions.assertTrue( newer.isEqual(older),
-                    String.format( "Didn't detect that %s is equal to %s using isEqual", newer, older ) );
+        Assertions.assertFalse(
+                newer.isOlderThan(older),
+                String.format("Didn't detect that %s is newer than %s using isOlderThan", newer, older));
+        Assertions.assertFalse(
+                older.isNewerThan(newer),
+                String.format("Didn't detect that %s is older than %s using isNewerThan", older, newer));
+        Assertions.assertTrue(
+                newer.isAtLeastVersion(older),
+                String.format("Didn't detect that %s is at least %s using isAtLeastVersion", newer, older));
+        Assertions.assertTrue(
+                newer.isEqual(older),
+                String.format("Didn't detect that %s is equal to %s using isEqual", newer, older));
     }
 
-    private void testOlderVsNewer( Neo4jVersion newer, Neo4jVersion older )
-    {
+    private void testOlderVsNewer(Neo4jVersion newer, Neo4jVersion older) {
         // isOlderThan
-        Assertions.assertTrue( older.isOlderThan( newer ) ,
-                    String.format( "Didn't detect that %s is older than %s using isOlderThan", older, newer ) );
-        Assertions.assertFalse( newer.isOlderThan( older ) ,
-                     String.format( "Didn't detect that %s is newer than %s using isOlderThan", newer, older ) );
+        Assertions.assertTrue(
+                older.isOlderThan(newer),
+                String.format("Didn't detect that %s is older than %s using isOlderThan", older, newer));
+        Assertions.assertFalse(
+                newer.isOlderThan(older),
+                String.format("Didn't detect that %s is newer than %s using isOlderThan", newer, older));
 
         // isNewerThan
-        Assertions.assertTrue( newer.isNewerThan( older ),
-                    String.format( "Didn't detect that %s is newer than %s using isNewerThan", newer, older ) );
-        Assertions.assertFalse( older.isNewerThan( newer ) ,
-                     String.format( "Didn't detect that %s is older than %s using isNewerThan", older, newer ) );
+        Assertions.assertTrue(
+                newer.isNewerThan(older),
+                String.format("Didn't detect that %s is newer than %s using isNewerThan", newer, older));
+        Assertions.assertFalse(
+                older.isNewerThan(newer),
+                String.format("Didn't detect that %s is older than %s using isNewerThan", older, newer));
 
         // isAtLeastVersion
-        Assertions.assertTrue( newer.isAtLeastVersion( older ),
-                    String.format( "Didn't detect that %s is newer than %s using isAtLeastVersion", newer, older ) );
-        Assertions.assertFalse( older.isAtLeastVersion( newer ) ,
-                     String.format( "Didn't detect that %s is older than %s using isAtLeastVersion", older, newer ) );
+        Assertions.assertTrue(
+                newer.isAtLeastVersion(older),
+                String.format("Didn't detect that %s is newer than %s using isAtLeastVersion", newer, older));
+        Assertions.assertFalse(
+                older.isAtLeastVersion(newer),
+                String.format("Didn't detect that %s is older than %s using isAtLeastVersion", older, newer));
 
-        Assertions.assertFalse( newer.isEqual(older),
-                                String.format( "%s incorrectly is equal to %s", newer, older ) );
-        Assertions.assertNotEquals( newer, older, String.format( "%s incorrectly is equal to %s", newer, older ) );
+        Assertions.assertFalse(newer.isEqual(older), String.format("%s incorrectly is equal to %s", newer, older));
+        Assertions.assertNotEquals(newer, older, String.format("%s incorrectly is equal to %s", newer, older));
     }
 
     @Test
-    public void testIsOlderThan_sameReleaseReturnsFalse()
-    {
-        Neo4jVersion version = new Neo4jVersion( 3, 5, 1 );
+    public void testIsOlderThan_sameReleaseReturnsFalse() {
+        Neo4jVersion version = new Neo4jVersion(3, 5, 1);
 
-        Assertions.assertFalse( version.isOlderThan( version ) ,
-                     "A release should not be older than itself" );
-        Assertions.assertFalse( version.isNewerThan( version ) ,
-                     "A release should not be newer than itself" );
+        Assertions.assertFalse(version.isOlderThan(version), "A release should not be older than itself");
+        Assertions.assertFalse(version.isNewerThan(version), "A release should not be newer than itself");
     }
 
     @Test
-    public void testFromVersionString_releaseFormat()
-    {
-        Neo4jVersion version = Neo4jVersion.fromVersionString( "4.4.7" );
-        Assertions.assertEquals( 4, version.major, "Did not parse major number from " + version );
-        Assertions.assertEquals( 4, version.minor, "Did not parse minor number from " + version );
-        Assertions.assertEquals( 7, version.patch, "Did not parse patch number from " + version );
+    public void testFromVersionString_releaseFormat() {
+        Neo4jVersion version = Neo4jVersion.fromVersionString("4.4.7");
+        Assertions.assertEquals(4, version.major, "Did not parse major number from " + version);
+        Assertions.assertEquals(4, version.minor, "Did not parse minor number from " + version);
+        Assertions.assertEquals(7, version.patch, "Did not parse patch number from " + version);
     }
 
     @Test
-    public void testFromVersionString_BSPFormat()
-    {
-        Neo4jVersion version = Neo4jVersion.fromVersionString( "4.4.7-12345" );
-        Assertions.assertEquals( 4, version.major, "Did not parse major number from " + version );
-        Assertions.assertEquals( 4, version.minor, "Did not parse minor number from " + version );
-        Assertions.assertEquals( 7, version.patch, "Did not parse patch number from " + version );
-        Assertions.assertEquals( "-12345", version.label, "Did not build number from " + version );
+    public void testFromVersionString_BSPFormat() {
+        Neo4jVersion version = Neo4jVersion.fromVersionString("4.4.7-12345");
+        Assertions.assertEquals(4, version.major, "Did not parse major number from " + version);
+        Assertions.assertEquals(4, version.minor, "Did not parse minor number from " + version);
+        Assertions.assertEquals(7, version.patch, "Did not parse patch number from " + version);
+        Assertions.assertEquals("-12345", version.label, "Did not build number from " + version);
     }
 
     @Test
-    public void testFromVersionString_calver_releaseFormat()
-    {
-        Neo4jVersion version = Neo4jVersion.fromVersionString( "2024.10.0" );
-        Assertions.assertEquals( 2024, version.major, "Did not parse major number from " + version );
-        Assertions.assertEquals( 10, version.minor, "Did not parse minor number from " + version );
-        Assertions.assertEquals( 0, version.patch, "Did not parse patch number from " + version );
+    public void testFromVersionString_calver_releaseFormat() {
+        Neo4jVersion version = Neo4jVersion.fromVersionString("2024.10.0");
+        Assertions.assertEquals(2024, version.major, "Did not parse major number from " + version);
+        Assertions.assertEquals(10, version.minor, "Did not parse minor number from " + version);
+        Assertions.assertEquals(0, version.patch, "Did not parse patch number from " + version);
     }
 
     @Test
-    public void testFromVersionString_calver_BSPFormat()
-    {
-        Neo4jVersion version = Neo4jVersion.fromVersionString( "2024.10.0-1234" );
-        Assertions.assertEquals( 2024, version.major, "Did not parse major number from " + version );
-        Assertions.assertEquals( 10, version.minor, "Did not parse minor number from " + version );
-        Assertions.assertEquals( 0, version.patch, "Did not parse patch number from " + version );
-        Assertions.assertEquals( "-1234", version.label, "Did not build number from " + version );
+    public void testFromVersionString_calver_BSPFormat() {
+        Neo4jVersion version = Neo4jVersion.fromVersionString("2024.10.0-1234");
+        Assertions.assertEquals(2024, version.major, "Did not parse major number from " + version);
+        Assertions.assertEquals(10, version.minor, "Did not parse minor number from " + version);
+        Assertions.assertEquals(0, version.patch, "Did not parse patch number from " + version);
+        Assertions.assertEquals("-1234", version.label, "Did not build number from " + version);
     }
 
     @Test
-    public void testFromVersionString_calver_OneMonthDigit()
-    {
+    public void testFromVersionString_calver_OneMonthDigit() {
         // an incorrect format, but would be useful if it was handled correctly
-        Neo4jVersion version = Neo4jVersion.fromVersionString( "2027.1.5-99" );
-        Assertions.assertEquals( 2027, version.major, "Did not parse major number from " + version );
-        Assertions.assertEquals( 1, version.minor, "Did not parse minor number from " + version );
-        Assertions.assertEquals( 5, version.patch, "Did not parse patch number from " + version );
-        Assertions.assertEquals( "-99", version.label, "Did not build number from " + version );
+        Neo4jVersion version = Neo4jVersion.fromVersionString("2027.1.5-99");
+        Assertions.assertEquals(2027, version.major, "Did not parse major number from " + version);
+        Assertions.assertEquals(1, version.minor, "Did not parse minor number from " + version);
+        Assertions.assertEquals(5, version.patch, "Did not parse patch number from " + version);
+        Assertions.assertEquals("-99", version.label, "Did not build number from " + version);
     }
 
     @Test
-    void testToStringCalVer()
-    {
-        Neo4jVersion version = Neo4jVersion.fromVersionString( "2025.2.0-1234" );
+    void testToStringCalVer() {
+        Neo4jVersion version = Neo4jVersion.fromVersionString("2025.2.0-1234");
         String outStr = version.toString();
-        Assertions.assertEquals( "2025.02.0-1234", outStr );
+        Assertions.assertEquals("2025.02.0-1234", outStr);
     }
 
     @ParameterizedTest
     @CsvSource({"2025,11,0,true", "2026,2,4,true", "4,4,20,false", "5,26,0,false", "5,1,0,false"})
-    void testIsCalver(int major, int minor, int patch, boolean isCalver){
-        Neo4jVersion version = new Neo4jVersion(  major, minor, patch );
-        Assertions.assertEquals( isCalver, version.isCalver(), "Did not parse isCalver from " + version );
+    void testIsCalver(int major, int minor, int patch, boolean isCalver) {
+        Neo4jVersion version = new Neo4jVersion(major, minor, patch);
+        Assertions.assertEquals(isCalver, version.isCalver(), "Did not parse isCalver from " + version);
     }
 }

--- a/src/test/java/com/neo4j/docker/utils/Network.java
+++ b/src/test/java/com/neo4j/docker/utils/Network.java
@@ -1,22 +1,17 @@
 package com.neo4j.docker.utils;
 
+import static java.lang.String.format;
+
 import java.io.IOException;
 import java.net.ServerSocket;
 
-import static java.lang.String.format;
-
-public class Network
-{
-    public static ServerSocket getServerSocket() throws IOException
-    {
-        try ( ServerSocket socket = new ServerSocket( 0 ) )
-        {
-            socket.setReuseAddress( true );
+public class Network {
+    public static ServerSocket getServerSocket() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            socket.setReuseAddress(true);
             return socket;
-        }
-        catch ( IOException e )
-        {
-            throw new IOException( format( "Could not get a unique port : ", e.getMessage() ) );
+        } catch (IOException e) {
+            throw new IOException(format("Could not get a unique port : ", e.getMessage()));
         }
     }
 }

--- a/src/test/java/com/neo4j/docker/utils/SetContainerUser.java
+++ b/src/test/java/com/neo4j/docker/utils/SetContainerUser.java
@@ -2,33 +2,27 @@ package com.neo4j.docker.utils;
 
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.sun.security.auth.module.UnixSystem;
-import org.testcontainers.containers.GenericContainer;
 import java.util.function.Consumer;
+import org.testcontainers.containers.GenericContainer;
 
-public class SetContainerUser
-{
+public class SetContainerUser {
 
-    public static void nonRootUser( GenericContainer container )
-    {
-        container.withCreateContainerCmdModifier( (Consumer<CreateContainerCmd>) cmd -> cmd.withUser( getNonRootUserString() ) );
+    public static void nonRootUser(GenericContainer container) {
+        container.withCreateContainerCmdModifier(
+                (Consumer<CreateContainerCmd>) cmd -> cmd.withUser(getNonRootUserString()));
     }
 
-    public static String getNonRootUserString()
-    {
+    public static String getNonRootUserString() {
         // check if the non root user environment variable is set, if so use that. Otherwise use current user.
-        String user = System.getenv( "NON_ROOT_USER_ID" );
-        if(user == null)
-        {
+        String user = System.getenv("NON_ROOT_USER_ID");
+        if (user == null) {
             return getCurrentlyRunningUser();
-        }
-        else
-        {
+        } else {
             return user;
         }
     }
 
-    private static String getCurrentlyRunningUser()
-    {
+    private static String getCurrentlyRunningUser() {
         UnixSystem fs = new UnixSystem();
         return fs.getUid() + ":" + fs.getGid();
     }

--- a/src/test/java/com/neo4j/docker/utils/TemporaryFolderManager.java
+++ b/src/test/java/com/neo4j/docker/utils/TemporaryFolderManager.java
@@ -1,5 +1,16 @@
 package com.neo4j.docker.utils;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
@@ -15,18 +26,6 @@ import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.Duration;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Random;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**JUnit extension to create temporary folders and compress them after each test class runs.
  * <p>
@@ -54,16 +53,16 @@ import java.util.stream.Collectors;
  *
  * First, to get a TemporaryFolderManager instantiation do:
  * <pre>{@code
- @RegisterExtension
- public static TemporaryFolderManager temporaryFolderManager = new TemporaryFolderManager();
+ * @RegisterExtension
+ * public static TemporaryFolderManager temporaryFolderManager = new TemporaryFolderManager();
  * }</pre>
  *
  * <h3>SIMPLE: Just create one or two unrelated folders and mount them</h3>
  * Most of the time, this is all you'll need.
  * Assuming you already have a container...
  * <pre>{@code
-Path confpath = temporaryFolderManager.createFolderAndMountAsVolume(container, "/conf");
-Path logpath = temporaryFolderManager.createFolderAndMountAsVolume(container, "/logs");
+ * Path confpath = temporaryFolderManager.createFolderAndMountAsVolume(container, "/conf");
+ * Path logpath = temporaryFolderManager.createFolderAndMountAsVolume(container, "/logs");
  * }</pre>
  * This will create a folder in {@link TestSettings#TEST_TMP_FOLDER} with the name
  * <code>CLASSNAME_METHODNAME_RANDOMNUMBER</code> and inside it, there will be a folder called <code>conf</code> and
@@ -74,224 +73,197 @@ Path logpath = temporaryFolderManager.createFolderAndMountAsVolume(container, "/
  *
  * <h3>HARDER: Mount the same folder to two different (consecutive) containers</h3>
  * <pre>{@code
-Path confpath;
-try(container1 = makeAContainer())
-{
-    confpath = temporaryFolderManager.createFolderAndMountAsVolume(container1, "/conf");
-}
-try(container2 = makeAContainer())
-{
-    temporaryFolderManager.mountHostFolderAsVolume(container2, confpath, "/conf");
-}
+ * Path confpath;
+ * try(container1 = makeAContainer())
+ * {
+ * confpath = temporaryFolderManager.createFolderAndMountAsVolume(container1, "/conf");
+ * }
+ * try(container2 = makeAContainer())
+ * {
+ * temporaryFolderManager.mountHostFolderAsVolume(container2, confpath, "/conf");
+ * }
  * }</pre>
  *
  * <h3>HARDEST: Two containers, two different folders, same mount point each time</h3>
  * <pre>{@code
-try(container1 = makeAContainer())
-{
-    Path confpath1 = temporaryFolderManager.createNamedFolderAndMountAsVolume( container1, "conf1", "/conf" );
-}
-try(container2 = makeAContainer())
-{
-    Path confpath2 = temporaryFolderManager.createNamedFolderAndMountAsVolume( container2, "conf2", "/conf" );
-}
+ * try(container1 = makeAContainer())
+ * {
+ * Path confpath1 = temporaryFolderManager.createNamedFolderAndMountAsVolume( container1, "conf1", "/conf" );
+ * }
+ * try(container2 = makeAContainer())
+ * {
+ * Path confpath2 = temporaryFolderManager.createNamedFolderAndMountAsVolume( container2, "conf2", "/conf" );
+ * }
  * }</pre>
  * */
-public class TemporaryFolderManager implements AfterAllCallback, BeforeEachCallback
-{
-    private final Logger log = LoggerFactory.getLogger( TemporaryFolderManager.class );
+public class TemporaryFolderManager implements AfterAllCallback, BeforeEachCallback {
+    private final Logger log = LoggerFactory.getLogger(TemporaryFolderManager.class);
     // if we ever run parallel tests, random number generator and
     // list of folders to compress need to be made thread safe
-    private Random rng = new Random(  );
+    private Random rng = new Random();
     private final Path folderRoot;
-    protected Path methodOutputFolder;    // protected scope for testing
-    protected Set<Path> toCompressAfterAll = new HashSet<>();    // protected scope for testing
+    protected Path methodOutputFolder; // protected scope for testing
+    protected Set<Path> toCompressAfterAll = new HashSet<>(); // protected scope for testing
 
-    public TemporaryFolderManager( )
-    {
+    public TemporaryFolderManager() {
         this(TestSettings.TEST_TMP_FOLDER);
     }
-    public TemporaryFolderManager( Path testOutputParentFolder )
-    {
+
+    public TemporaryFolderManager(Path testOutputParentFolder) {
         this.folderRoot = testOutputParentFolder;
     }
 
     @Override
-    public void beforeEach( ExtensionContext extensionContext ) throws Exception
-    {
-        String methodOutputFolderName = extensionContext.getTestClass().get().getName() + "_" +
-                                 extensionContext.getTestMethod().get().getName();
-        if(!extensionContext.getDisplayName().startsWith( extensionContext.getTestMethod().get().getName() ))
-        {
-            methodOutputFolderName += "_" + extensionContext.getDisplayName()
-                                                            .replace( ' ', '_' );
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        String methodOutputFolderName = extensionContext.getTestClass().get().getName() + "_"
+                + extensionContext.getTestMethod().get().getName();
+        if (!extensionContext
+                .getDisplayName()
+                .startsWith(extensionContext.getTestMethod().get().getName())) {
+            methodOutputFolderName += "_" + extensionContext.getDisplayName().replace(' ', '_');
         }
         // finally add some salt so  that we can run the same test method twice and not get naming clashes.
-        methodOutputFolderName += String.format( "_%04d", rng.nextInt(10000 ) );
-        log.info( "Recommended folder prefix is " + methodOutputFolderName );
-        methodOutputFolder = folderRoot.resolve( methodOutputFolderName );
+        methodOutputFolderName += String.format("_%04d", rng.nextInt(10000));
+        log.info("Recommended folder prefix is " + methodOutputFolderName);
+        methodOutputFolder = folderRoot.resolve(methodOutputFolderName);
     }
 
     @Override
-    public void afterAll( ExtensionContext extensionContext ) throws Exception
-    {
+    public void afterAll(ExtensionContext extensionContext) throws Exception {
         triggerCleanup();
     }
 
-    public void triggerCleanup() throws Exception
-    {
-        if(TestSettings.SKIP_MOUNTED_FOLDER_TARBALLING)
-        {
-            log.info( "Cleanup of test artifacts skipped by request" );
+    public void triggerCleanup() throws Exception {
+        if (TestSettings.SKIP_MOUNTED_FOLDER_TARBALLING) {
+            log.info("Cleanup of test artifacts skipped by request");
             return;
         }
-        log.info( "Performing cleanup of {}", folderRoot );
+        log.info("Performing cleanup of {}", folderRoot);
         // create tar archive of data
-        for(Path p : toCompressAfterAll)
-        {
+        for (Path p : toCompressAfterAll) {
             String tarOutName = p.getFileName().toString() + ".tar.gz";
-            try ( OutputStream fo = Files.newOutputStream( p.getParent().resolve( tarOutName ) );
-                  OutputStream gzo = new GzipCompressorOutputStream( fo );
-                  TarArchiveOutputStream archiver = new TarArchiveOutputStream( gzo ) )
-            {
-                archiver.setLongFileMode( TarArchiveOutputStream.LONGFILE_POSIX );
-                List<Path> files = Files.walk( p ).toList();
-                for(Path fileToBeArchived : files)
-                {
+            try (OutputStream fo = Files.newOutputStream(p.getParent().resolve(tarOutName));
+                    OutputStream gzo = new GzipCompressorOutputStream(fo);
+                    TarArchiveOutputStream archiver = new TarArchiveOutputStream(gzo)) {
+                archiver.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+                List<Path> files = Files.walk(p).toList();
+                for (Path fileToBeArchived : files) {
                     // don't archive directories...
-                    if(fileToBeArchived.toFile().isDirectory()) continue;
-                    try( InputStream fileStream = Files.newInputStream( fileToBeArchived ))
-                    {
-                        TarArchiveEntry entry = archiver.createArchiveEntry( fileToBeArchived, folderRoot.relativize( fileToBeArchived ).toString() );
-                        archiver.putArchiveEntry( entry );
-                        IOUtils.copy( fileStream, archiver );
+                    if (fileToBeArchived.toFile().isDirectory()) continue;
+                    try (InputStream fileStream = Files.newInputStream(fileToBeArchived)) {
+                        TarArchiveEntry entry = archiver.createArchiveEntry(
+                                fileToBeArchived,
+                                folderRoot.relativize(fileToBeArchived).toString());
+                        archiver.putArchiveEntry(entry);
+                        IOUtils.copy(fileStream, archiver);
                         archiver.closeArchiveEntry();
-                    } catch (IOException ioe)
-                    {
+                    } catch (IOException ioe) {
                         // consume the error, because sometimes, file permissions won't let us copy
-                        log.warn( "Could not archive "+ fileToBeArchived, ioe);
+                        log.warn("Could not archive " + fileToBeArchived, ioe);
                     }
                 }
                 archiver.finish();
             }
         }
         // delete original folders
-        log.debug( "Re owning folders: {}", toCompressAfterAll.stream()
-                                                              .map( Path::toString )
-                                                              .collect( Collectors.joining(", ")));
-        setFolderOwnerTo( SetContainerUser.getNonRootUserString(),
-                          toCompressAfterAll.toArray(new Path[toCompressAfterAll.size()]) );
+        log.debug(
+                "Re owning folders: {}",
+                toCompressAfterAll.stream().map(Path::toString).collect(Collectors.joining(", ")));
+        setFolderOwnerTo(
+                SetContainerUser.getNonRootUserString(),
+                toCompressAfterAll.toArray(new Path[toCompressAfterAll.size()]));
 
-        for(Path p : toCompressAfterAll)
-        {
-            log.debug( "Deleting test output folder {}", p.getFileName().toString() );
-            FileUtils.deleteDirectory( p.toFile() );
+        for (Path p : toCompressAfterAll) {
+            log.debug("Deleting test output folder {}", p.getFileName().toString());
+            FileUtils.deleteDirectory(p.toFile());
         }
         toCompressAfterAll.clear();
     }
 
-    public Path createNamedFolderAndMountAsVolume( GenericContainer container, String hostFolderName, String containerMountPoint ) throws IOException
-    {
-        Path tempFolder = createFolder( hostFolderName );
-        mountHostFolderAsVolume( container, tempFolder, containerMountPoint );
+    public Path createNamedFolderAndMountAsVolume(
+            GenericContainer container, String hostFolderName, String containerMountPoint) throws IOException {
+        Path tempFolder = createFolder(hostFolderName);
+        mountHostFolderAsVolume(container, tempFolder, containerMountPoint);
         return tempFolder;
     }
 
-    public Path createFolderAndMountAsVolume( GenericContainer container, String containerMountPoint ) throws IOException
-    {
-        Path tempFolder = createFolder( getFolderNameFromMountPoint( containerMountPoint ) );
-        mountHostFolderAsVolume( container, tempFolder, containerMountPoint );
+    public Path createFolderAndMountAsVolume(GenericContainer container, String containerMountPoint)
+            throws IOException {
+        Path tempFolder = createFolder(getFolderNameFromMountPoint(containerMountPoint));
+        mountHostFolderAsVolume(container, tempFolder, containerMountPoint);
         return tempFolder;
     }
 
-//    public Path createNamedFolderAndMountAsVolume( GenericContainer container, String hostFolderName,
-//                                                   Path parentFolder, String containerMountPoint ) throws IOException
-//    {
-//        Path tempFolder = createFolder( hostFolderName, parentFolder );
-//        mountHostFolderAsVolume( container, tempFolder, containerMountPoint );
-//        return tempFolder;
-//    }
+    //    public Path createNamedFolderAndMountAsVolume( GenericContainer container, String hostFolderName,
+    //                                                   Path parentFolder, String containerMountPoint ) throws
+    // IOException
+    //    {
+    //        Path tempFolder = createFolder( hostFolderName, parentFolder );
+    //        mountHostFolderAsVolume( container, tempFolder, containerMountPoint );
+    //        return tempFolder;
+    //    }
 
-//    public Path createFolderAndMountAsVolume( GenericContainer container, String containerMountPoint, Path parentFolder ) throws IOException
-//    {
-//        return null;
-//        Path hostFolder = createTempFolder( hostFolderNamePrefix, parentFolder );
-//        mountHostFolderAsVolume( container, hostFolder, containerMountPoint );
-//        return hostFolder;
-//    }
+    //    public Path createFolderAndMountAsVolume( GenericContainer container, String containerMountPoint, Path
+    // parentFolder ) throws IOException
+    //    {
+    //        return null;
+    //        Path hostFolder = createTempFolder( hostFolderNamePrefix, parentFolder );
+    //        mountHostFolderAsVolume( container, hostFolder, containerMountPoint );
+    //        return hostFolder;
+    //    }
 
-    public void mountHostFolderAsVolume(GenericContainer container, Path hostFolder, String containerMountPoint)
-    {
-        container.withFileSystemBind( hostFolder.toAbsolutePath().toString(),
-                                      containerMountPoint,
-                                      BindMode.READ_WRITE );
+    public void mountHostFolderAsVolume(GenericContainer container, Path hostFolder, String containerMountPoint) {
+        container.withFileSystemBind(hostFolder.toAbsolutePath().toString(), containerMountPoint, BindMode.READ_WRITE);
     }
 
-    public Path createFolder( String folderName ) throws IOException
-    {
-    	return createFolder( folderName, methodOutputFolder );
+    public Path createFolder(String folderName) throws IOException {
+        return createFolder(folderName, methodOutputFolder);
     }
 
-    public Path createFolder( String folderName, Path parentFolder ) throws IOException
-    {
-        if(!parentFolder.startsWith( folderRoot ))
-        {
-            throw new IOException("Requested to create temp folder outside of " + folderRoot +". " +
-                                  "This is a problem with the test.");
+    public Path createFolder(String folderName, Path parentFolder) throws IOException {
+        if (!parentFolder.startsWith(folderRoot)) {
+            throw new IOException("Requested to create temp folder outside of " + folderRoot + ". "
+                    + "This is a problem with the test.");
         }
         Path hostFolder = parentFolder.resolve(folderName);
-        try
-        {
-            Files.createDirectories( hostFolder );
-        }
-        catch ( IOException e )
-        {
-            log.error( "could not create directory: {}", hostFolder.toAbsolutePath() );
+        try {
+            Files.createDirectories(hostFolder);
+        } catch (IOException e) {
+            log.error("could not create directory: {}", hostFolder.toAbsolutePath());
             e.printStackTrace();
             throw e;
         }
-        log.info( "Created folder {}", hostFolder );
+        log.info("Created folder {}", hostFolder);
         // flag top level methodOutputFolder for cleanup
-        toCompressAfterAll.add( methodOutputFolder ); // toCompressAfterAll is a set, so automatically removes duplicates.
+        toCompressAfterAll.add(methodOutputFolder); // toCompressAfterAll is a set, so automatically removes duplicates.
         return hostFolder;
     }
 
-    public void setFolderOwnerToCurrentUser(Path file) throws Exception
-    {
-        setFolderOwnerTo( SetContainerUser.getNonRootUserString(), file );
+    public void setFolderOwnerToCurrentUser(Path file) throws Exception {
+        setFolderOwnerTo(SetContainerUser.getNonRootUserString(), file);
     }
 
-    public void setFolderOwnerToNeo4j(Path file) throws Exception
-    {
-        setFolderOwnerTo( "7474:7474", file );
+    public void setFolderOwnerToNeo4j(Path file) throws Exception {
+        setFolderOwnerTo("7474:7474", file);
     }
 
-    protected String getFolderNameFromMountPoint(String containerMountPoint)
-    {
-        return containerMountPoint.substring( 1 )
-                                  .replace( '/', '_' )
-                                  .replace( ' ', '_' );
+    protected String getFolderNameFromMountPoint(String containerMountPoint) {
+        return containerMountPoint.substring(1).replace('/', '_').replace(' ', '_');
     }
 
-    private void setFolderOwnerTo(String userAndGroup, Path... files) throws Exception
-    {
+    private void setFolderOwnerTo(String userAndGroup, Path... files) throws Exception {
         // uses docker privileges to set file owner, since probably the current user is not a sudoer.
 
         // Using nginx because it's easy to verify that the image started.
-        try(GenericContainer container = new GenericContainer( DockerImageName.parse( "nginx:latest")))
-        {
-            container.withExposedPorts( 80 )
-                     .waitingFor( Wait.forHttp( "/" ).withStartupTimeout( Duration.ofSeconds( 20 ) ) );
-            for(Path p : files)
-            {
-                mountHostFolderAsVolume( container, p, p.toAbsolutePath().toString() );
+        try (GenericContainer container = new GenericContainer(DockerImageName.parse("nginx:latest"))) {
+            container.withExposedPorts(80).waitingFor(Wait.forHttp("/").withStartupTimeout(Duration.ofSeconds(20)));
+            for (Path p : files) {
+                mountHostFolderAsVolume(container, p, p.toAbsolutePath().toString());
             }
             container.start();
-            for(Path p : files)
-            {
-                Container.ExecResult x =
-                        container.execInContainer( "chown", "-R", userAndGroup,
-                                                   p.toAbsolutePath().toString() );
+            for (Path p : files) {
+                Container.ExecResult x = container.execInContainer(
+                        "chown", "-R", userAndGroup, p.toAbsolutePath().toString());
             }
             container.stop();
         }

--- a/src/test/java/com/neo4j/docker/utils/TemporaryFolderManagerTest.java
+++ b/src/test/java/com/neo4j/docker/utils/TemporaryFolderManagerTest.java
@@ -1,5 +1,16 @@
 package com.neo4j.docker.utils;
 
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
@@ -20,34 +31,20 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
 // This is a test for a test utility. It does not actually test anything to do with the docker image.
 // This is disabled unless we're actually trying to develop/fix the TemporaryFolderManager utility.
 @Disabled
-class TemporaryFolderManagerTest
-{
-    @Order( 0 )
+class TemporaryFolderManagerTest {
+    @Order(0)
     @TempDir
     static Path outFolder;
 
-    @Order( 1 )
+    @Order(1)
     @RegisterExtension
     public TemporaryFolderManager manager = new TemporaryFolderManager(outFolder);
 
     @AfterEach
-    void clearAnyCleanupFlags()
-    {
+    void clearAnyCleanupFlags() {
         // some tests may leave folders remaining that are flagged for cleanup, which can affect the
         // tests that check that folders are flagged for cleanup. This will reset the flags after each test.
         manager.toCompressAfterAll.clear();
@@ -56,366 +53,374 @@ class TemporaryFolderManagerTest
     // TEST AUTOGENERATES SENSIBLE FOLDER NAME FOR EACH UNIT TEST METHOD
 
     @Test
-    void shouldDeriveFolderNameFromTestMethodName()
-    {
+    void shouldDeriveFolderNameFromTestMethodName() {
         String expectedMethodNameFolderPrefix = this.getClass().getName() + "_shouldDeriveFolderNameFromTestMethodName";
         String actualMethodFolderName = manager.methodOutputFolder.getFileName().toString();
-        // should generate folder with similar/the same name as the method's reference and add 4 random digits to the end
-        Assertions.assertTrue( actualMethodFolderName.startsWith( expectedMethodNameFolderPrefix ),
-                               "Did not generate correct temporary folder name from unit test method");
+        // should generate folder with similar/the same name as the method's reference and add 4 random digits to the
+        // end
+        Assertions.assertTrue(
+                actualMethodFolderName.startsWith(expectedMethodNameFolderPrefix),
+                "Did not generate correct temporary folder name from unit test method");
 
         // verify salt is added to foldername like <NAME>_1234
-        Assertions.assertEquals( expectedMethodNameFolderPrefix.length()+5, actualMethodFolderName.length(),
-                                 "Did not correctly add 4 random digits to the expected folder name");
-        String salt = actualMethodFolderName.substring( expectedMethodNameFolderPrefix.length() + 1 );
-        Assertions.assertDoesNotThrow( ()->Integer.parseInt( salt ),
-                                       "Folder name salt was not digits. Actual: " + actualMethodFolderName );
+        Assertions.assertEquals(
+                expectedMethodNameFolderPrefix.length() + 5,
+                actualMethodFolderName.length(),
+                "Did not correctly add 4 random digits to the expected folder name");
+        String salt = actualMethodFolderName.substring(expectedMethodNameFolderPrefix.length() + 1);
+        Assertions.assertDoesNotThrow(
+                () -> Integer.parseInt(salt), "Folder name salt was not digits. Actual: " + actualMethodFolderName);
 
         // folder should not exist until we call a createTempFolder* method
-        Assertions.assertFalse( manager.methodOutputFolder.toFile().exists(),
-                                "Unit test method folder was created before requesting any folder creation.");
+        Assertions.assertFalse(
+                manager.methodOutputFolder.toFile().exists(),
+                "Unit test method folder was created before requesting any folder creation.");
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {4,5,6})
-    void parameterisedTestMethodsCreateDifferentFolders_unnamedInt(int parameter) throws IOException
-    {
-        String expectedMethodNameFolderRegex = this.getClass().getName() +
-                                               "_parameterisedTestMethodsCreateDifferentFolders_unnamedInt" +
-                                               "_\\[" + (parameter-3) + "\\]_" + parameter + "_\\d{4}";
+    @ValueSource(ints = {4, 5, 6})
+    void parameterisedTestMethodsCreateDifferentFolders_unnamedInt(int parameter) throws IOException {
+        String expectedMethodNameFolderRegex =
+                this.getClass().getName() + "_parameterisedTestMethodsCreateDifferentFolders_unnamedInt"
+                        + "_\\["
+                        + (parameter - 3) + "\\]_" + parameter + "_\\d{4}";
         verifyParameterisedFolderNaming(expectedMethodNameFolderRegex);
     }
 
     @ParameterizedTest(name = "name={0}")
-    @ValueSource(ints = {7,8,9})
-    void parameterisedTestMethodsCreateDifferentFolders_namedInt(int parameter) throws IOException
-    {
-        String expectedMethodNameFolderRegex = this.getClass().getName() +
-                                               "_parameterisedTestMethodsCreateDifferentFolders_namedInt_name="
-                                               + parameter + "_\\d{4}";
+    @ValueSource(ints = {7, 8, 9})
+    void parameterisedTestMethodsCreateDifferentFolders_namedInt(int parameter) throws IOException {
+        String expectedMethodNameFolderRegex = this.getClass().getName()
+                + "_parameterisedTestMethodsCreateDifferentFolders_namedInt_name=" + parameter + "_\\d{4}";
         verifyParameterisedFolderNaming(expectedMethodNameFolderRegex);
     }
 
     @ParameterizedTest(name = "name={0}")
     @ValueSource(booleans = {true, false})
-    void parameterisedTestMethodsCreateDifferentFolders_namedBoolean(boolean parameter) throws IOException
-    {
-        String expectedMethodNameFolderRegex = this.getClass().getName() +
-                                               "_parameterisedTestMethodsCreateDifferentFolders" +
-                                               "_namedBoolean_name=" + parameter + "_\\d{4}";
+    void parameterisedTestMethodsCreateDifferentFolders_namedBoolean(boolean parameter) throws IOException {
+        String expectedMethodNameFolderRegex =
+                this.getClass().getName() + "_parameterisedTestMethodsCreateDifferentFolders"
+                        + "_namedBoolean_name="
+                        + parameter + "_\\d{4}";
         verifyParameterisedFolderNaming(expectedMethodNameFolderRegex);
     }
 
-    @ParameterizedTest( name = "bool1={0} bool2={1}" )
+    @ParameterizedTest(name = "bool1={0} bool2={1}")
     @CsvSource({"true,true", "true,false", "false,true", "false,false"})
-    void parameterisedTestMethodsCreateDifferentFolders_twoNamedBooleans(boolean parameter1, boolean parameter2) throws IOException
-    {
-        String expectedMethodNameFolderRegex = this.getClass().getName() +
-                                               "_parameterisedTestMethodsCreateDifferentFolders" +
-                                               "_twoNamedBooleans_bool1=" + parameter1 +
-                                               "_bool2=" + parameter2 + "_\\d{4}";
+    void parameterisedTestMethodsCreateDifferentFolders_twoNamedBooleans(boolean parameter1, boolean parameter2)
+            throws IOException {
+        String expectedMethodNameFolderRegex =
+                this.getClass().getName() + "_parameterisedTestMethodsCreateDifferentFolders"
+                        + "_twoNamedBooleans_bool1="
+                        + parameter1 + "_bool2="
+                        + parameter2 + "_\\d{4}";
         verifyParameterisedFolderNaming(expectedMethodNameFolderRegex);
     }
 
-    private void verifyParameterisedFolderNaming(String expectedMethodNameFolderRegex) throws IOException
-    {
+    private void verifyParameterisedFolderNaming(String expectedMethodNameFolderRegex) throws IOException {
         // get methodFolderName from TemporaryFolderManager
         String actualMethodFolderName = manager.methodOutputFolder.getFileName().toString();
-        Assertions.assertTrue( Pattern.matches( expectedMethodNameFolderRegex, actualMethodFolderName ),
-                               "Folder \"" + actualMethodFolderName +
-                               "\" does not match expected regex \"" + expectedMethodNameFolderRegex + "\"");
+        Assertions.assertTrue(
+                Pattern.matches(expectedMethodNameFolderRegex, actualMethodFolderName),
+                "Folder \"" + actualMethodFolderName + "\" does not match expected regex \""
+                        + expectedMethodNameFolderRegex + "\"");
         // folder should not yet exist
-        Path expectedUnitTestMethodFolder = outFolder.resolve( manager.methodOutputFolder );
-        Assertions.assertFalse( expectedUnitTestMethodFolder.toFile().exists(),
-                                "Folder "+expectedUnitTestMethodFolder + " should not have been created" );
+        Path expectedUnitTestMethodFolder = outFolder.resolve(manager.methodOutputFolder);
+        Assertions.assertFalse(
+                expectedUnitTestMethodFolder.toFile().exists(),
+                "Folder " + expectedUnitTestMethodFolder + " should not have been created");
         // now create folder
-        manager.createFolder( "somename" );
-        Assertions.assertTrue( expectedUnitTestMethodFolder.toFile().exists(),
-                               "Folder "+expectedUnitTestMethodFolder + " should have been created" );
+        manager.createFolder("somename");
+        Assertions.assertTrue(
+                expectedUnitTestMethodFolder.toFile().exists(),
+                "Folder " + expectedUnitTestMethodFolder + " should have been created");
     }
 
     @ParameterizedTest
-    @CsvSource({"/conf,conf", "/data,data", "/import,import", "/logs,logs", "/metrics,metrics", "/plugins,plugins",
-            "/run/something,run_something", "/place/with space,place_with_space", "/with space,with_space"})
-    void autoGeneratesSensibleFolderNameFromMountPoint(String mountPoint, String expectedFolderName)
-    {
-        Assertions.assertEquals( expectedFolderName, manager.getFolderNameFromMountPoint( mountPoint),
-                                 "Did not autogenerate expected name from given mount point");
+    @CsvSource({
+        "/conf,conf",
+        "/data,data",
+        "/import,import",
+        "/logs,logs",
+        "/metrics,metrics",
+        "/plugins,plugins",
+        "/run/something,run_something",
+        "/place/with space,place_with_space",
+        "/with space,with_space"
+    })
+    void autoGeneratesSensibleFolderNameFromMountPoint(String mountPoint, String expectedFolderName) {
+        Assertions.assertEquals(
+                expectedFolderName,
+                manager.getFolderNameFromMountPoint(mountPoint),
+                "Did not autogenerate expected name from given mount point");
     }
 
     // TEST ACTUAL FOLDER CREATION AND MOUNTING
 
     @Test
-    void shouldMountAnyFolderToContainer(@TempDir Path tempFolder) throws Exception
-    {
-        try(GenericContainer container = makeContainer())
-        {
-            manager.mountHostFolderAsVolume( container, tempFolder, "/root" );
+    void shouldMountAnyFolderToContainer(@TempDir Path tempFolder) throws Exception {
+        try (GenericContainer container = makeContainer()) {
+            manager.mountHostFolderAsVolume(container, tempFolder, "/root");
             container.start();
-            container.execInContainer( "touch", "/root/testout" );
-            String files = container.execInContainer( "ls", "/root" ).getStdout();
+            container.execInContainer("touch", "/root/testout");
+            String files = container.execInContainer("ls", "/root").getStdout();
             // sanity check that /root/testout actually was created
-            Assertions.assertTrue( files.contains( "testout" ),
-                                   "did not manage to create file inside container in the mounted folder." );
+            Assertions.assertTrue(
+                    files.contains("testout"), "did not manage to create file inside container in the mounted folder.");
         }
-        Assertions.assertTrue( tempFolder.resolve( "testout" ).toFile().exists(),
-                               "Test file was created in container but not in mounted folder. " +
-                               "Probably it was unsuccessfully mounted" );
+        Assertions.assertTrue(
+                tempFolder.resolve("testout").toFile().exists(),
+                "Test file was created in container but not in mounted folder. "
+                        + "Probably it was unsuccessfully mounted");
     }
 
     @Test
-    void createsFolder() throws Exception
-    {
+    void createsFolder() throws Exception {
         String expectedMethodNameFolderRegex = this.getClass().getName() + "_createsFolder_\\d{4}";
         String folderName = "somefolder";
         // first verify that no folder exists until we create something
-        List<Path> allFolders = Files.list( outFolder )
-                                     .filter( path -> path.getFileName()
-                                                          .toString()
-                                                          .matches( expectedMethodNameFolderRegex ))
-                                     .toList();
-        Assertions.assertEquals( 0, allFolders.size(), "A folder matching " + expectedMethodNameFolderRegex +
-                                                       " was created when it should not have been");
+        List<Path> allFolders = Files.list(outFolder)
+                .filter(path -> path.getFileName().toString().matches(expectedMethodNameFolderRegex))
+                .toList();
+        Assertions.assertEquals(
+                0,
+                allFolders.size(),
+                "A folder matching " + expectedMethodNameFolderRegex + " was created when it should not have been");
 
         // now create a folder
-        Path p = manager.createFolder( folderName );
+        Path p = manager.createFolder(folderName);
         // verify folder exists, and is located at outFolder > METHODNAME > somefolder
-        Path methodNameFolder = verifyMethodNameFolderExistsAndIsUnique( expectedMethodNameFolderRegex );
-        verifyTempFolder( p, folderName, methodNameFolder );
+        Path methodNameFolder = verifyMethodNameFolderExistsAndIsUnique(expectedMethodNameFolderRegex);
+        verifyTempFolder(p, folderName, methodNameFolder);
     }
 
     @Test
-    void createsFolderUnderGivenParent() throws Exception
-    {
+    void createsFolderUnderGivenParent() throws Exception {
         String expectedMethodNameFolderRegex = this.getClass().getName() + "_createsFolderUnderGivenParent_\\d{4}";
-        Path unusedFolder = manager.createFolder( "somefolder1" );
-        Path expectedParent = manager.createFolder( "somefolder2" );
-        Path p = manager.createFolder( "somefolder3", expectedParent);
+        Path unusedFolder = manager.createFolder("somefolder1");
+        Path expectedParent = manager.createFolder("somefolder2");
+        Path p = manager.createFolder("somefolder3", expectedParent);
 
-        Path methodNameFolder = verifyMethodNameFolderExistsAndIsUnique( expectedMethodNameFolderRegex );
-        verifyTempFolder( unusedFolder, "somefolder1", methodNameFolder );
-        verifyTempFolder( expectedParent, "somefolder2", methodNameFolder );
-        verifyTempFolder( p, "somefolder3", expectedParent );
+        Path methodNameFolder = verifyMethodNameFolderExistsAndIsUnique(expectedMethodNameFolderRegex);
+        verifyTempFolder(unusedFolder, "somefolder1", methodNameFolder);
+        verifyTempFolder(expectedParent, "somefolder2", methodNameFolder);
+        verifyTempFolder(p, "somefolder3", expectedParent);
 
         // should NOT have created something under unusedFolder
-        List<Path> f = Files.list( unusedFolder ).toList();
-        Assertions.assertEquals( 0, f.size(),
-                                 "Folder should not have been created under "+unusedFolder );
+        List<Path> f = Files.list(unusedFolder).toList();
+        Assertions.assertEquals(0, f.size(), "Folder should not have been created under " + unusedFolder);
     }
 
     @Test
-    void doesNotCreateFolderOutsideRoot(@TempDir Path nonRootFolder)
-    {
-        Assertions.assertThrows( IOException.class,
-                                 () -> manager.createFolder( "somefolder", nonRootFolder),
-                                 "Created a test folder outside the expected area");
+    void doesNotCreateFolderOutsideRoot(@TempDir Path nonRootFolder) {
+        Assertions.assertThrows(
+                IOException.class,
+                () -> manager.createFolder("somefolder", nonRootFolder),
+                "Created a test folder outside the expected area");
     }
 
     @Test
-    void createNamedFolderAndMount() throws Exception
-    {
+    void createNamedFolderAndMount() throws Exception {
         String expectedMethodNameFolderRegex = this.getClass().getName() + "_createNamedFolderAndMount_\\d{4}";
         String expectedFolderName = "aFolder";
         Path actualTempFolder;
-        try(GenericContainer container = makeContainer())
-        {
-            actualTempFolder = manager.createNamedFolderAndMountAsVolume( container, expectedFolderName, "/root" );
+        try (GenericContainer container = makeContainer()) {
+            actualTempFolder = manager.createNamedFolderAndMountAsVolume(container, expectedFolderName, "/root");
             container.start();
-            container.execInContainer( "touch", "/root/testout" );
-            String files = container.execInContainer( "ls", "/root" ).getStdout();
+            container.execInContainer("touch", "/root/testout");
+            String files = container.execInContainer("ls", "/root").getStdout();
             // sanity check that /root/testout actually was created
-            Assertions.assertTrue( files.contains( "testout" ),
-                                   "did not manage to create file inside container in the mounted folder." );
+            Assertions.assertTrue(
+                    files.contains("testout"), "did not manage to create file inside container in the mounted folder.");
         }
-        Path methodFolder = verifyMethodNameFolderExistsAndIsUnique( expectedMethodNameFolderRegex );
-        Path expectedTempFolder = methodFolder.resolve( expectedFolderName );
-        verifyTempFolder( expectedTempFolder, expectedFolderName, methodFolder );
-        Assertions.assertEquals( expectedTempFolder, actualTempFolder,
-                                 "Temporary folder was not created in the expected location");
-        Assertions.assertTrue( expectedTempFolder.resolve( "testout" ).toFile().exists(),
-                               "Test file was created in container but not in mounted folder. " +
-                               "Probably it was unsuccessfully mounted" );
+        Path methodFolder = verifyMethodNameFolderExistsAndIsUnique(expectedMethodNameFolderRegex);
+        Path expectedTempFolder = methodFolder.resolve(expectedFolderName);
+        verifyTempFolder(expectedTempFolder, expectedFolderName, methodFolder);
+        Assertions.assertEquals(
+                expectedTempFolder, actualTempFolder, "Temporary folder was not created in the expected location");
+        Assertions.assertTrue(
+                expectedTempFolder.resolve("testout").toFile().exists(),
+                "Test file was created in container but not in mounted folder. "
+                        + "Probably it was unsuccessfully mounted");
     }
 
     @Test
-    void createAutomaticallyNamedFolderAndMount() throws Exception
-    {
-        String expectedMethodNameFolderRegex = this.getClass().getName() + "_createAutomaticallyNamedFolderAndMount_\\d{4}";
+    void createAutomaticallyNamedFolderAndMount() throws Exception {
+        String expectedMethodNameFolderRegex =
+                this.getClass().getName() + "_createAutomaticallyNamedFolderAndMount_\\d{4}";
         String expectedFolderName = "root";
         Path actualTempFolder;
-        try(GenericContainer container = makeContainer())
-        {
-            actualTempFolder = manager.createFolderAndMountAsVolume( container, "/root" );
+        try (GenericContainer container = makeContainer()) {
+            actualTempFolder = manager.createFolderAndMountAsVolume(container, "/root");
             container.start();
-            container.execInContainer( "touch", "/root/testout" );
-            String files = container.execInContainer( "ls", "/root" ).getStdout();
+            container.execInContainer("touch", "/root/testout");
+            String files = container.execInContainer("ls", "/root").getStdout();
             // sanity check that /root/testout actually was created
-            Assertions.assertTrue( files.contains( "testout" ),
-                                   "did not manage to create file inside container in the mounted folder." );
+            Assertions.assertTrue(
+                    files.contains("testout"), "did not manage to create file inside container in the mounted folder.");
         }
-        Path methodFolder = verifyMethodNameFolderExistsAndIsUnique( expectedMethodNameFolderRegex );
-        Path expectedTempFolder = methodFolder.resolve( expectedFolderName );
-        verifyTempFolder( expectedTempFolder, expectedFolderName, methodFolder );
-        Assertions.assertEquals( expectedTempFolder, actualTempFolder,
-                                 "Temporary folder was not created in the expected location");
-        Assertions.assertTrue( expectedTempFolder.resolve( "testout" ).toFile().exists(),
-                               "Test file was created in container but not in mounted folder. " +
-                               "Probably it was unsuccessfully mounted" );
+        Path methodFolder = verifyMethodNameFolderExistsAndIsUnique(expectedMethodNameFolderRegex);
+        Path expectedTempFolder = methodFolder.resolve(expectedFolderName);
+        verifyTempFolder(expectedTempFolder, expectedFolderName, methodFolder);
+        Assertions.assertEquals(
+                expectedTempFolder, actualTempFolder, "Temporary folder was not created in the expected location");
+        Assertions.assertTrue(
+                expectedTempFolder.resolve("testout").toFile().exists(),
+                "Test file was created in container but not in mounted folder. "
+                        + "Probably it was unsuccessfully mounted");
     }
 
-    private Path verifyMethodNameFolderExistsAndIsUnique(String expectedMethodNameFolderRegex) throws Exception
-    {
+    private Path verifyMethodNameFolderExistsAndIsUnique(String expectedMethodNameFolderRegex) throws Exception {
         // get methodFolderName from TemporaryFolderManager
         String actualMethodFolderName = manager.methodOutputFolder.getFileName().toString();
-        Assertions.assertTrue( Pattern.matches( expectedMethodNameFolderRegex, actualMethodFolderName ),
-                               "Folder \"" + manager.methodOutputFolder +
-                               "\" does not match expected regex \"" + expectedMethodNameFolderRegex + "\"");
+        Assertions.assertTrue(
+                Pattern.matches(expectedMethodNameFolderRegex, actualMethodFolderName),
+                "Folder \"" + manager.methodOutputFolder + "\" does not match expected regex \""
+                        + expectedMethodNameFolderRegex + "\"");
 
         // verify <METHODNAME> folder was created under the root folder store.
-        List<Path> methodNameFolders = Files.list( outFolder )
-                                            .filter( path -> path.getFileName()
-                                                                 .toString()
-                                                                 .matches( expectedMethodNameFolderRegex ) )
-                                            .toList();
-        Assertions.assertEquals( 1, methodNameFolders.size(), "Expected only one folder called " +
-                                                              expectedMethodNameFolderRegex + ". Actual: " +
-                                                              methodNameFolders.stream()
-                                                                               .map(Path::toString)
-                                                                               .collect( Collectors.joining( ",")));
-        Path methodFolder = methodNameFolders.get( 0 ); // previous assertion guarantees this to work
-        Assertions.assertEquals( methodFolder, manager.methodOutputFolder,
-                                 "Folder found in TestTemp is not the same as the one in the folder manager" );
+        List<Path> methodNameFolders = Files.list(outFolder)
+                .filter(path -> path.getFileName().toString().matches(expectedMethodNameFolderRegex))
+                .toList();
+        Assertions.assertEquals(
+                1,
+                methodNameFolders.size(),
+                "Expected only one folder called " + expectedMethodNameFolderRegex
+                        + ". Actual: "
+                        + methodNameFolders.stream().map(Path::toString).collect(Collectors.joining(",")));
+        Path methodFolder = methodNameFolders.get(0); // previous assertion guarantees this to work
+        Assertions.assertEquals(
+                methodFolder,
+                manager.methodOutputFolder,
+                "Folder found in TestTemp is not the same as the one in the folder manager");
         // make sure the <METHODNAME> folder is marked for cleanup
-        Assertions.assertTrue( manager.toCompressAfterAll.contains( methodFolder ),
-                               "Did not flag " + methodFolder.getFileName() + " for cleanup. Flagged files are: " +
-                               manager.toCompressAfterAll.stream()
-                                                         .map(Path::toString)
-                                                         .collect( Collectors.joining( ",")));
+        Assertions.assertTrue(
+                manager.toCompressAfterAll.contains(methodFolder),
+                "Did not flag " + methodFolder.getFileName() + " for cleanup. Flagged files are: "
+                        + manager.toCompressAfterAll.stream()
+                                .map(Path::toString)
+                                .collect(Collectors.joining(",")));
 
         return methodFolder;
     }
 
-    private void verifyTempFolder(Path tempFolder, String expectedFolderName, Path expectedParent)
-    {
-        Assertions.assertTrue( tempFolder.toFile().exists(), "createTempFolder did not create anything" );
-        Assertions.assertTrue( tempFolder.toFile().isDirectory(), "Did not create a directory" );
-        Assertions.assertEquals(expectedFolderName, tempFolder.toFile().getName(),
-                                "Did not give temp directory the expected name" );
-        Assertions.assertTrue( tempFolder.getParent().equals( expectedParent ),
-                               "Did not create temp folder under expected parent location. Actual: "+tempFolder.getParent() );
+    private void verifyTempFolder(Path tempFolder, String expectedFolderName, Path expectedParent) {
+        Assertions.assertTrue(tempFolder.toFile().exists(), "createTempFolder did not create anything");
+        Assertions.assertTrue(tempFolder.toFile().isDirectory(), "Did not create a directory");
+        Assertions.assertEquals(
+                expectedFolderName, tempFolder.toFile().getName(), "Did not give temp directory the expected name");
+        Assertions.assertTrue(
+                tempFolder.getParent().equals(expectedParent),
+                "Did not create temp folder under expected parent location. Actual: " + tempFolder.getParent());
     }
-
 
     // TEST FOLDER IS CLEANED UP
 
-    private File verifyTarIsCreatedAndUnique(String expectedTarRegex) throws Exception
-    {
+    private File verifyTarIsCreatedAndUnique(String expectedTarRegex) throws Exception {
         // verify outFolder contains ONE tar matching our regex
-        List<Path> tarredFiles = Files.list( outFolder )
-                                      .filter( path -> path.getFileName()
-                                                           .toString()
-                                                           .matches( expectedTarRegex ) )
-                                      .toList();
-        Assertions.assertEquals( 1, tarredFiles.size(), "Expected only one folder called " +
-                                                        expectedTarRegex + ". Actual: " +
-                                                        tarredFiles.stream()
-                                                                   .map(Path::toString)
-                                                                   .collect( Collectors.joining( ",")));
-        return tarredFiles.get( 0 ).toFile();
+        List<Path> tarredFiles = Files.list(outFolder)
+                .filter(path -> path.getFileName().toString().matches(expectedTarRegex))
+                .toList();
+        Assertions.assertEquals(
+                1,
+                tarredFiles.size(),
+                "Expected only one folder called " + expectedTarRegex
+                        + ". Actual: "
+                        + tarredFiles.stream().map(Path::toString).collect(Collectors.joining(",")));
+        return tarredFiles.get(0).toFile();
     }
 
     @Test
-    void createsTarOfFolder() throws Exception
-    {
-        Assumptions.assumeFalse( TestSettings.SKIP_MOUNTED_FOLDER_TARBALLING, "Temporary folder zipping disabled" );
+    void createsTarOfFolder() throws Exception {
+        Assumptions.assumeFalse(TestSettings.SKIP_MOUNTED_FOLDER_TARBALLING, "Temporary folder zipping disabled");
         String expectedTarRegex = this.getClass().getName() + "_createsTarOfFolder_\\d{4}\\.tar\\.gz";
         String expectedFileContents = "words words words";
 
         // create one folder with one file to be zipped.
-        Path tempFolder = manager.createFolder( "tozip" );
-        Files.writeString( tempFolder.resolve( "testfile" ), expectedFileContents );
-        Assertions.assertTrue( tempFolder.resolve( "testfile" ).toFile().exists(),
-                               "Test failure. Did not successfully write to "+tempFolder);
+        Path tempFolder = manager.createFolder("tozip");
+        Files.writeString(tempFolder.resolve("testfile"), expectedFileContents);
+        Assertions.assertTrue(
+                tempFolder.resolve("testfile").toFile().exists(),
+                "Test failure. Did not successfully write to " + tempFolder);
 
         manager.triggerCleanup();
 
-        File actualTar = verifyTarIsCreatedAndUnique( expectedTarRegex );
-        List<String> files = listFilesInTar( actualTar );
-        Assertions.assertEquals( 1, files.size(),
-                               "Tar file "+actualTar+" exists but is empty." );
-        String writtenFile = readFileInTar( actualTar, "/tozip/testfile" );
-        Assertions.assertEquals( expectedFileContents, writtenFile );
+        File actualTar = verifyTarIsCreatedAndUnique(expectedTarRegex);
+        List<String> files = listFilesInTar(actualTar);
+        Assertions.assertEquals(1, files.size(), "Tar file " + actualTar + " exists but is empty.");
+        String writtenFile = readFileInTar(actualTar, "/tozip/testfile");
+        Assertions.assertEquals(expectedFileContents, writtenFile);
         // all temporary folder should now be deleted
-        Assertions.assertFalse( tempFolder.toFile().exists(), "Temporary folder should have been deleted" );
+        Assertions.assertFalse(tempFolder.toFile().exists(), "Temporary folder should have been deleted");
     }
 
     @Test
-    void createsTarOfFolder_2Files() throws Exception
-    {
-        Assumptions.assumeFalse( TestSettings.SKIP_MOUNTED_FOLDER_TARBALLING, "Temporary folder zipping disabled" );
+    void createsTarOfFolder_2Files() throws Exception {
+        Assumptions.assumeFalse(TestSettings.SKIP_MOUNTED_FOLDER_TARBALLING, "Temporary folder zipping disabled");
         String expectedTarRegex = this.getClass().getName() + "_createsTarOfFolder_2Files_\\d{4}\\.tar\\.gz";
         String expectedFileContents1 = "words1 words1 words1";
         String expectedFileContents2 = "words2 words2 words2";
 
         // create one folder with one file to be zipped.
-        Path tempFolder = manager.createFolder( "tozip" );
-        Files.writeString( tempFolder.resolve( "testfile1" ), expectedFileContents1 );
-        Assertions.assertTrue( tempFolder.resolve( "testfile1" ).toFile().exists(),
-                               "Test failure. Did not successfully write to "+tempFolder);
-        Files.writeString( tempFolder.resolve( "testfile2" ), expectedFileContents2 );
-        Assertions.assertTrue( tempFolder.resolve( "testfile2" ).toFile().exists(),
-                               "Test failure. Did not successfully write to "+tempFolder);
+        Path tempFolder = manager.createFolder("tozip");
+        Files.writeString(tempFolder.resolve("testfile1"), expectedFileContents1);
+        Assertions.assertTrue(
+                tempFolder.resolve("testfile1").toFile().exists(),
+                "Test failure. Did not successfully write to " + tempFolder);
+        Files.writeString(tempFolder.resolve("testfile2"), expectedFileContents2);
+        Assertions.assertTrue(
+                tempFolder.resolve("testfile2").toFile().exists(),
+                "Test failure. Did not successfully write to " + tempFolder);
 
         manager.triggerCleanup();
 
-        File actualTar = verifyTarIsCreatedAndUnique( expectedTarRegex );
-        List<String> files = listFilesInTar( actualTar );
-        Assertions.assertEquals( 2, files.size(),
-                                 "Tar file "+actualTar+" exists but is empty." );
-        String writtenFile1 = readFileInTar( actualTar, "/tozip/testfile1" );
-        String writtenFile2 = readFileInTar( actualTar, "/tozip/testfile2" );
-        Assertions.assertEquals( expectedFileContents1, writtenFile1 );
-        Assertions.assertEquals( expectedFileContents2, writtenFile2 );
-        Assertions.assertFalse( tempFolder.toFile().exists(), "Temporary folder should have been deleted" );
+        File actualTar = verifyTarIsCreatedAndUnique(expectedTarRegex);
+        List<String> files = listFilesInTar(actualTar);
+        Assertions.assertEquals(2, files.size(), "Tar file " + actualTar + " exists but is empty.");
+        String writtenFile1 = readFileInTar(actualTar, "/tozip/testfile1");
+        String writtenFile2 = readFileInTar(actualTar, "/tozip/testfile2");
+        Assertions.assertEquals(expectedFileContents1, writtenFile1);
+        Assertions.assertEquals(expectedFileContents2, writtenFile2);
+        Assertions.assertFalse(tempFolder.toFile().exists(), "Temporary folder should have been deleted");
     }
 
     @Test
-    void createsTarOfFolder_2Folders() throws Exception
-    {
-        Assumptions.assumeFalse( TestSettings.SKIP_MOUNTED_FOLDER_TARBALLING, "Temporary folder zipping disabled" );
+    void createsTarOfFolder_2Folders() throws Exception {
+        Assumptions.assumeFalse(TestSettings.SKIP_MOUNTED_FOLDER_TARBALLING, "Temporary folder zipping disabled");
         String expectedTarRegex = this.getClass().getName() + "_createsTarOfFolder_2Folders_\\d{4}\\.tar\\.gz";
         String expectedFileContents1 = "words1 words1 words1";
         String expectedFileContents2 = "words2 words2 words2";
 
         // create one folder with one file to be zipped.
-        Path tempFolder1 = manager.createFolder( "tozip1" );
-        Files.writeString( tempFolder1.resolve( "testfile" ), expectedFileContents1 );
-        Assertions.assertTrue( tempFolder1.resolve( "testfile" ).toFile().exists(),
-                               "Test failure. Did not successfully write to "+tempFolder1);
-        Path tempFolder2 = manager.createFolder( "tozip2" );
-        Files.writeString( tempFolder2.resolve( "testfile" ), expectedFileContents2 );
-        Assertions.assertTrue( tempFolder2.resolve( "testfile" ).toFile().exists(),
-                               "Test failure. Did not successfully write to "+tempFolder2);
+        Path tempFolder1 = manager.createFolder("tozip1");
+        Files.writeString(tempFolder1.resolve("testfile"), expectedFileContents1);
+        Assertions.assertTrue(
+                tempFolder1.resolve("testfile").toFile().exists(),
+                "Test failure. Did not successfully write to " + tempFolder1);
+        Path tempFolder2 = manager.createFolder("tozip2");
+        Files.writeString(tempFolder2.resolve("testfile"), expectedFileContents2);
+        Assertions.assertTrue(
+                tempFolder2.resolve("testfile").toFile().exists(),
+                "Test failure. Did not successfully write to " + tempFolder2);
 
         manager.triggerCleanup();
 
-        File actualTar = verifyTarIsCreatedAndUnique( expectedTarRegex );
-        List<String> files = listFilesInTar( actualTar );
+        File actualTar = verifyTarIsCreatedAndUnique(expectedTarRegex);
+        List<String> files = listFilesInTar(actualTar);
 
-        Assertions.assertEquals( 2, files.size(),
-                                 "Tar file "+actualTar+" exists but does not contain the expected files." );
-        String writtenFile1 = readFileInTar( actualTar, "/tozip1/testfile" );
-        Assertions.assertEquals( expectedFileContents1, writtenFile1 );
-        String writtenFile2 = readFileInTar( actualTar, "/tozip2/testfile" );
-        Assertions.assertEquals( expectedFileContents2, writtenFile2 );
-        Assertions.assertFalse( tempFolder1.toFile().exists(), "Temporary folder should have been deleted" );
-        Assertions.assertFalse( tempFolder2.toFile().exists(), "Temporary folder should have been deleted" );
+        Assertions.assertEquals(
+                2, files.size(), "Tar file " + actualTar + " exists but does not contain the expected files.");
+        String writtenFile1 = readFileInTar(actualTar, "/tozip1/testfile");
+        Assertions.assertEquals(expectedFileContents1, writtenFile1);
+        String writtenFile2 = readFileInTar(actualTar, "/tozip2/testfile");
+        Assertions.assertEquals(expectedFileContents2, writtenFile2);
+        Assertions.assertFalse(tempFolder1.toFile().exists(), "Temporary folder should have been deleted");
+        Assertions.assertFalse(tempFolder2.toFile().exists(), "Temporary folder should have been deleted");
     }
 
     @Test
-    void createsTarOfFolder_nestedFolders() throws Exception
-    {
-        Assumptions.assumeFalse( TestSettings.SKIP_MOUNTED_FOLDER_TARBALLING, "Temporary folder zipping disabled" );
+    void createsTarOfFolder_nestedFolders() throws Exception {
+        Assumptions.assumeFalse(TestSettings.SKIP_MOUNTED_FOLDER_TARBALLING, "Temporary folder zipping disabled");
         String expectedTarRegex = this.getClass().getName() + "_createsTarOfFolder_nestedFolders_\\d{4}\\.tar\\.gz";
         // creating folders:
         // tempFolder1
@@ -424,101 +429,90 @@ class TemporaryFolderManagerTest
         String expectedFileContents = "words words words";
 
         // create one folder with one file to be zipped.
-        Path tempFolder1 = manager.createFolder( "tozip1" );
-        Path tempFolder2 = manager.createFolder( "tozip2", tempFolder1 );
-        Files.writeString( tempFolder2.resolve( "testfile" ), expectedFileContents );
-        Assertions.assertTrue( tempFolder2.resolve( "testfile" ).toFile().exists(),
-                               "Test failure. Did not successfully write to "+tempFolder2);
+        Path tempFolder1 = manager.createFolder("tozip1");
+        Path tempFolder2 = manager.createFolder("tozip2", tempFolder1);
+        Files.writeString(tempFolder2.resolve("testfile"), expectedFileContents);
+        Assertions.assertTrue(
+                tempFolder2.resolve("testfile").toFile().exists(),
+                "Test failure. Did not successfully write to " + tempFolder2);
 
         manager.triggerCleanup();
-        File actualTar = verifyTarIsCreatedAndUnique( expectedTarRegex );
+        File actualTar = verifyTarIsCreatedAndUnique(expectedTarRegex);
 
-        List<String> files = listFilesInTar( actualTar );
-        Assertions.assertEquals( 1, files.size(),
-                               "Tar file "+actualTar+" exists but is empty." );
-        String writtenFile = readFileInTar( actualTar,"/tozip1/tozip2/testfile" );
-        Assertions.assertEquals( expectedFileContents, writtenFile );
-        Assertions.assertFalse( tempFolder1.toFile().exists(), "Temporary folder should have been deleted" );
+        List<String> files = listFilesInTar(actualTar);
+        Assertions.assertEquals(1, files.size(), "Tar file " + actualTar + " exists but is empty.");
+        String writtenFile = readFileInTar(actualTar, "/tozip1/tozip2/testfile");
+        Assertions.assertEquals(expectedFileContents, writtenFile);
+        Assertions.assertFalse(tempFolder1.toFile().exists(), "Temporary folder should have been deleted");
     }
 
     // TEST CODE CLEANUP WITH REOWNING
 
     @Test
-    void canSetFolderOwnerTo7474ThenCleanup() throws Exception
-    {
-        Assumptions.assumeFalse( TestSettings.SKIP_MOUNTED_FOLDER_TARBALLING, "Temporary folder zipping disabled" );
+    void canSetFolderOwnerTo7474ThenCleanup() throws Exception {
+        Assumptions.assumeFalse(TestSettings.SKIP_MOUNTED_FOLDER_TARBALLING, "Temporary folder zipping disabled");
         String expectedTarRegex = this.getClass().getName() + "_canSetFolderOwnerTo7474ThenCleanup_\\d{4}\\.tar\\.gz";
-        Path tempFolder = manager.createFolder( "tozip" );
-        Files.writeString ( tempFolder.resolve( "testfile" ), "words" );
+        Path tempFolder = manager.createFolder("tozip");
+        Files.writeString(tempFolder.resolve("testfile"), "words");
 
-        manager.setFolderOwnerToNeo4j( tempFolder );
+        manager.setFolderOwnerToNeo4j(tempFolder);
         // verify expected folder owner
-        Integer fileUID = (Integer) Files.getAttribute( tempFolder, "unix:uid" );
-        Assertions.assertEquals( 7474, fileUID.intValue(),
-                                 "Did not successfully set the owner of "+tempFolder );
+        Integer fileUID = (Integer) Files.getAttribute(tempFolder, "unix:uid");
+        Assertions.assertEquals(7474, fileUID.intValue(), "Did not successfully set the owner of " + tempFolder);
         // clean up and verify successfully cleaned up
         manager.triggerCleanup();
-        verifyTarIsCreatedAndUnique( expectedTarRegex );
-        Assertions.assertFalse( tempFolder.toFile().exists(), "Did not successfully delete "+tempFolder );
+        verifyTarIsCreatedAndUnique(expectedTarRegex);
+        Assertions.assertFalse(tempFolder.toFile().exists(), "Did not successfully delete " + tempFolder);
     }
 
     @Test
-    void canCreateAndCleanupFoldersWithDifferentOwners() throws Exception
-    {
-        Assumptions.assumeFalse( TestSettings.SKIP_MOUNTED_FOLDER_TARBALLING, "Temporary folder zipping disabled" );
-        String expectedTarRegex = this.getClass().getName() + "_canCreateAndCleanupFoldersWithDifferentOwners_\\d{4}\\.tar\\.gz";
-        Path tempFolder7474 = manager.createFolder( "tozip7474" );
-        Path tempFolderNormal = manager.createFolder( "tozipNormal" );
-        Files.writeString( tempFolder7474.resolve( "testfile" ), "words" );
-        Files.writeString( tempFolderNormal.resolve( "testfile" ), "words" );
+    void canCreateAndCleanupFoldersWithDifferentOwners() throws Exception {
+        Assumptions.assumeFalse(TestSettings.SKIP_MOUNTED_FOLDER_TARBALLING, "Temporary folder zipping disabled");
+        String expectedTarRegex =
+                this.getClass().getName() + "_canCreateAndCleanupFoldersWithDifferentOwners_\\d{4}\\.tar\\.gz";
+        Path tempFolder7474 = manager.createFolder("tozip7474");
+        Path tempFolderNormal = manager.createFolder("tozipNormal");
+        Files.writeString(tempFolder7474.resolve("testfile"), "words");
+        Files.writeString(tempFolderNormal.resolve("testfile"), "words");
 
-        manager.setFolderOwnerToNeo4j( tempFolder7474 );
-        Integer fileUID = (Integer) Files.getAttribute( tempFolder7474, "unix:uid" );
-        Assertions.assertEquals( 7474, fileUID.intValue(),
-                                 "Did not successfully set the owner of "+tempFolder7474 );
+        manager.setFolderOwnerToNeo4j(tempFolder7474);
+        Integer fileUID = (Integer) Files.getAttribute(tempFolder7474, "unix:uid");
+        Assertions.assertEquals(7474, fileUID.intValue(), "Did not successfully set the owner of " + tempFolder7474);
 
         manager.triggerCleanup();
-        verifyTarIsCreatedAndUnique( expectedTarRegex );
-        Assertions.assertFalse( tempFolderNormal.toFile().exists(), "Did not successfully delete "+tempFolderNormal );
-        Assertions.assertFalse( tempFolder7474.toFile().exists(), "Did not successfully delete "+tempFolder7474 );
+        verifyTarIsCreatedAndUnique(expectedTarRegex);
+        Assertions.assertFalse(tempFolderNormal.toFile().exists(), "Did not successfully delete " + tempFolderNormal);
+        Assertions.assertFalse(tempFolder7474.toFile().exists(), "Did not successfully delete " + tempFolder7474);
     }
 
-    private GenericContainer makeContainer()
-    {
+    private GenericContainer makeContainer() {
         // we don't want to test the neo4j container, just use a generic container debian to check mounting.
         // using nginx here just because there is a straightforward way of waiting for it to be ready
         GenericContainer container = new GenericContainer(DockerImageName.parse("nginx:latest"))
                 .withExposedPorts(80)
-                .waitingFor(Wait.forHttp("/").withStartupTimeout( Duration.ofSeconds( 5 ) ));
+                .waitingFor(Wait.forHttp("/").withStartupTimeout(Duration.ofSeconds(5)));
         return container;
     }
 
-    private List<String> listFilesInTar(File tar) throws IOException
-    {
+    private List<String> listFilesInTar(File tar) throws IOException {
         List<String> files = new ArrayList<>();
-        ArchiveInputStream in = new TarArchiveInputStream(
-                new GzipCompressorInputStream( new FileInputStream(tar) ));
+        ArchiveInputStream in = new TarArchiveInputStream(new GzipCompressorInputStream(new FileInputStream(tar)));
         ArchiveEntry entry = in.getNextEntry();
-        while(entry != null)
-        {
-            files.add( entry.getName() );
+        while (entry != null) {
+            files.add(entry.getName());
             entry = in.getNextEntry();
         }
         in.close();
         return files;
     }
 
-    private String readFileInTar(File tar, String internalFilePath) throws IOException
-    {
-        internalFilePath = tar.getName().split( "\\.tar\\.gz" )[0] + internalFilePath;
+    private String readFileInTar(File tar, String internalFilePath) throws IOException {
+        internalFilePath = tar.getName().split("\\.tar\\.gz")[0] + internalFilePath;
         String fileContents = null;
-        ArchiveInputStream in = new TarArchiveInputStream(
-                new GzipCompressorInputStream( new FileInputStream(tar) ));
+        ArchiveInputStream in = new TarArchiveInputStream(new GzipCompressorInputStream(new FileInputStream(tar)));
         ArchiveEntry entry = in.getNextEntry();
-        while(entry != null)
-        {
-            if(entry.getName().equals( internalFilePath ))
-            {
+        while (entry != null) {
+            if (entry.getName().equals(internalFilePath)) {
                 ByteArrayOutputStream outStream = new ByteArrayOutputStream();
                 IOUtils.copy(in, outStream);
                 fileContents = outStream.toString();
@@ -527,7 +521,7 @@ class TemporaryFolderManagerTest
             entry = in.getNextEntry();
         }
         in.close();
-        Assertions.assertNotNull( fileContents, "Could not extract file "+internalFilePath+" from "+tar);
+        Assertions.assertNotNull(fileContents, "Could not extract file " + internalFilePath + " from " + tar);
         return fileContents;
     }
 }

--- a/src/test/java/com/neo4j/docker/utils/TestSettings.java
+++ b/src/test/java/com/neo4j/docker/utils/TestSettings.java
@@ -1,82 +1,72 @@
 package com.neo4j.docker.utils;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.junit.jupiter.api.Assertions;
 import org.testcontainers.utility.DockerImageName;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
-public class TestSettings
-{
+public class TestSettings {
     public static final Neo4jVersion NEO4J_VERSION = getVersion();
     public static final DockerImageName IMAGE_ID = getImage();
     public static final DockerImageName ADMIN_IMAGE_ID = getNeo4jAdminImage();
-    public static final Path TEST_TMP_FOLDER = Paths.get("local-mounts" );
+    public static final Path TEST_TMP_FOLDER = Paths.get("local-mounts");
     public static final Edition EDITION = getEdition();
     public static final BaseOS BASE_OS = getBaseOS();
     public static final boolean SKIP_MOUNTED_FOLDER_TARBALLING = getSkipTarballingFromEnv();
 
-    public enum Edition
-    {
+    public enum Edition {
         COMMUNITY,
         ENTERPRISE;
     }
 
-    private static String getValueFromPropertyOrEnv(String propertyName, String envName)
-    {
-        String verStr = System.getProperty( propertyName );
-        if(verStr == null)
-        {
-            verStr = System.getenv( envName );
+    private static String getValueFromPropertyOrEnv(String propertyName, String envName) {
+        String verStr = System.getProperty(propertyName);
+        if (verStr == null) {
+            verStr = System.getenv(envName);
         }
-        Assertions.assertNotNull( String.format( "Neo4j %s has not been specified. " +
-                                                 "Either use mvn argument -D%s or set env %s",
-                                                 propertyName, propertyName, envName),
-                                  verStr);
+        Assertions.assertNotNull(
+                String.format(
+                        "Neo4j %s has not been specified. " + "Either use mvn argument -D%s or set env %s",
+                        propertyName, propertyName, envName),
+                verStr);
         return verStr;
     }
 
-    private static Neo4jVersion getVersion()
-    {
-        return Neo4jVersion.fromVersionString( getValueFromPropertyOrEnv( "version", "NEO4JVERSION" ));
+    private static Neo4jVersion getVersion() {
+        return Neo4jVersion.fromVersionString(getValueFromPropertyOrEnv("version", "NEO4JVERSION"));
     }
 
-    private static DockerImageName getImage()
-    {
+    private static DockerImageName getImage() {
         return DockerImageName.parse(getValueFromPropertyOrEnv("image", "NEO4J_IMAGE"));
     }
 
-    private static DockerImageName getNeo4jAdminImage()
-    {
+    private static DockerImageName getNeo4jAdminImage() {
         return DockerImageName.parse(getValueFromPropertyOrEnv("adminimage", "NEO4JADMIN_IMAGE"));
     }
 
-    private static Edition getEdition()
-    {
+    private static Edition getEdition() {
         String edition = getValueFromPropertyOrEnv("edition", "NEO4J_EDITION");
-        switch ( edition.toLowerCase() )
-        {
-        case "community":
-            return Edition.COMMUNITY;
-        case "enterprise":
-            return Edition.ENTERPRISE;
-        default:
-            Assertions.fail( edition + " is not a valid Neo4j edition. Options are \"community\" or \"enterprise\"." );
+        switch (edition.toLowerCase()) {
+            case "community":
+                return Edition.COMMUNITY;
+            case "enterprise":
+                return Edition.ENTERPRISE;
+            default:
+                Assertions.fail(
+                        edition + " is not a valid Neo4j edition. Options are \"community\" or \"enterprise\".");
         }
         return null;
     }
 
-    private static BaseOS getBaseOS()
-    {
+    private static BaseOS getBaseOS() {
         String os = getValueFromPropertyOrEnv("baseos", "BASE_OS");
-        return BaseOS.fromString( os );
+        return BaseOS.fromString(os);
     }
 
-    private static boolean getSkipTarballingFromEnv()
-    {
+    private static boolean getSkipTarballingFromEnv() {
         // defaults to false. Tarballing test artifacts must be opt-out not opt-in.
-        String skipTar = System.getenv( "NEO4J_SKIP_MOUNTED_FOLDER_TARBALLING" );
-        if(skipTar == null)  return false;
-        else return (skipTar.equals( "true" ));
+        String skipTar = System.getenv("NEO4J_SKIP_MOUNTED_FOLDER_TARBALLING");
+        if (skipTar == null) return false;
+        else return (skipTar.equals("true"));
     }
 }

--- a/src/test/java/com/neo4j/docker/utils/WaitStrategies.java
+++ b/src/test/java/com/neo4j/docker/utils/WaitStrategies.java
@@ -1,6 +1,9 @@
 package com.neo4j.docker.utils;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
+import java.time.Duration;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 import org.rnorth.ducttape.unreliables.Unreliables;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
@@ -9,42 +12,31 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;
 import org.testcontainers.utility.DockerStatus;
 
-import java.time.Duration;
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
+public class WaitStrategies {
 
-public class WaitStrategies
-{
-
-    private final static Duration STARTUP_TIMEOUT_SECONDS = Duration.ofSeconds(180);
+    private static final Duration STARTUP_TIMEOUT_SECONDS = Duration.ofSeconds(180);
 
     private WaitStrategies() {}
 
-    public static WaitStrategy waitForNeo4jReady( String username, String password, String database, Duration timeout )
-    {
-        if (TestSettings.EDITION == TestSettings.Edition.ENTERPRISE &&
-            TestSettings.NEO4J_VERSION.isAtLeastVersion(Neo4jVersion.NEO4J_VERSION_500)) {
+    public static WaitStrategy waitForNeo4jReady(String username, String password, String database, Duration timeout) {
+        if (TestSettings.EDITION == TestSettings.Edition.ENTERPRISE
+                && TestSettings.NEO4J_VERSION.isAtLeastVersion(Neo4jVersion.NEO4J_VERSION_500)) {
             return Wait.forHttp("/db/" + database + "/cluster/available")
-                       .withBasicCredentials(username, password)
-                       .forPort(7474)
-                       .forStatusCode(200)
-                       .withStartupTimeout(timeout);
-        } else
-        {
+                    .withBasicCredentials(username, password)
+                    .forPort(7474)
+                    .forStatusCode(200)
+                    .withStartupTimeout(timeout);
+        } else {
             return waitForBoltReady();
         }
     }
 
-    public static WaitStrategy waitForNeo4jReady( String password ) {
-        return waitForNeo4jReady( "neo4j", password, "neo4j", STARTUP_TIMEOUT_SECONDS);
+    public static WaitStrategy waitForNeo4jReady(String password) {
+        return waitForNeo4jReady("neo4j", password, "neo4j", STARTUP_TIMEOUT_SECONDS);
     }
 
-    public static WaitStrategy waitForBoltReady()
-    {
-        return Wait.forHttp("/")
-                   .forPort(7687)
-                   .forStatusCode(200)
-                   .withStartupTimeout(STARTUP_TIMEOUT_SECONDS);
+    public static WaitStrategy waitForBoltReady() {
+        return Wait.forHttp("/").forPort(7687).forStatusCode(200).withStartupTimeout(STARTUP_TIMEOUT_SECONDS);
     }
 
     /**For containers that will just run a command and exit automatically.
@@ -55,29 +47,27 @@ public class WaitStrategies
      * @param timeout how long to wait
      * @return container in the modified state.
      * */
-    public static GenericContainer waitUntilContainerFinished( GenericContainer container, Duration timeout)
-    {
-        container.setStartupCheckStrategy( new OneShotStartupCheckStrategy().withTimeout( timeout ) );
-        container.waitingFor( new WaitUntilFinished( timeout ));
+    public static GenericContainer waitUntilContainerFinished(GenericContainer container, Duration timeout) {
+        container.setStartupCheckStrategy(new OneShotStartupCheckStrategy().withTimeout(timeout));
+        container.waitingFor(new WaitUntilFinished(timeout));
         return container;
     }
 
-    private static class WaitUntilFinished extends AbstractWaitStrategy
-    {
+    private static class WaitUntilFinished extends AbstractWaitStrategy {
         Duration timeout;
 
-        WaitUntilFinished( Duration timeout )
-        {
+        WaitUntilFinished(Duration timeout) {
             this.timeout = timeout;
         }
+
         @Override
-        protected void waitUntilReady()
-        {
+        protected void waitUntilReady() {
             Callable<Boolean> isFinished = () -> {
-                InspectContainerResponse.ContainerState x = waitStrategyTarget.getCurrentContainerInfo().getState();
-                return DockerStatus.isContainerStopped( x );
+                InspectContainerResponse.ContainerState x =
+                        waitStrategyTarget.getCurrentContainerInfo().getState();
+                return DockerStatus.isContainerStopped(x);
             };
-            Unreliables.retryUntilTrue( (int)this.timeout.getSeconds(), TimeUnit.SECONDS, isFinished );
+            Unreliables.retryUntilTrue((int) this.timeout.getSeconds(), TimeUnit.SECONDS, isFinished);
         }
     }
 }


### PR DESCRIPTION
I've added a code formatting tool and a github workflow to (hopefully?) force code cleanup. 
The workflow might be overkill but we can always delete it if it starts causing problems on ancient PRs.

To get the pre-commit check working locally you'll need to run `pre-commit install` at repository root.

The only code to review is:
* .github/workflows/spotless.yml
* .pre-commit-config.yaml
* pom.xml

The rest is automatic re-formatting.

The code style is spotless+palantir format since that's what the rest of Neo4j uses.