### PR TITLE
Update tests to accept incubator warnings

### DIFF
--- a/src/test/java/com/neo4j/docker/coredb/TestAdminReport.java
+++ b/src/test/java/com/neo4j/docker/coredb/TestAdminReport.java
@@ -1,6 +1,7 @@
 package com.neo4j.docker.coredb;
 
 import com.neo4j.docker.utils.DatabaseIO;
+import com.neo4j.docker.utils.Neo4jAssertions;
 import com.neo4j.docker.utils.Neo4jVersion;
 import com.neo4j.docker.utils.SetContainerUser;
 import com.neo4j.docker.utils.TemporaryFolderManager;
@@ -150,7 +151,7 @@ public class TestAdminReport {
                     lines[0].startsWith("Selecting JVM"),
                     "There were unexpected error messages in the neo4j-admin report:\n" + reportExecOut.getStderr());
         } else {
-            Assertions.assertEquals("", reportExecOut.getStderr(), "There were errors during report generation");
+            Neo4jAssertions.assertNoUnexpectedErrors(reportExecOut.getStderr());
         }
         Assertions.assertEquals(1, reports.size(), "Expected exactly 1 report to be produced");
         Assertions.assertFalse(
@@ -170,7 +171,7 @@ public class TestAdminReport {
                     "Produces a zip/tar of the most common information needed for remote assessments."));
             Assertions.assertTrue(stdout.contains("USAGE"));
             Assertions.assertTrue(stdout.contains("OPTIONS"));
-            Assertions.assertEquals("", stderr, "There were errors when trying to get neo4j-admin-report help text");
+            Neo4jAssertions.assertNoUnexpectedErrors(stderr);
         }
     }
 }

--- a/src/test/java/com/neo4j/docker/coredb/TestBasic.java
+++ b/src/test/java/com/neo4j/docker/coredb/TestBasic.java
@@ -7,6 +7,7 @@ import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 import com.github.dockerjava.api.command.KillContainerCmd;
 import com.github.dockerjava.api.command.StopContainerCmd;
 import com.neo4j.docker.utils.DatabaseIO;
+import com.neo4j.docker.utils.Neo4jAssertions;
 import com.neo4j.docker.utils.Neo4jVersion;
 import com.neo4j.docker.utils.TemporaryFolderManager;
 import com.neo4j.docker.utils.TestSettings;
@@ -70,7 +71,8 @@ public class TestBasic {
             Assertions.assertTrue(container.isRunning());
 
             String stderr = container.getLogs(OutputFrame.OutputType.STDERR);
-            Assertions.assertEquals("", stderr, "Unexpected errors in stderr from container!\n" + stderr);
+
+            Neo4jAssertions.assertNoUnexpectedErrors(stderr);
         }
     }
 

--- a/src/test/java/com/neo4j/docker/utils/Neo4jAssertions.java
+++ b/src/test/java/com/neo4j/docker/utils/Neo4jAssertions.java
@@ -1,0 +1,27 @@
+package com.neo4j.docker.utils;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+
+public class Neo4jAssertions {
+    // An upcoming release bundles the incubator vector module by default, which makes the JVM emit
+    // this warning to stderr on startup. It is expected, so we tolerate it (but nothing else).
+    private static final String INCUBATOR_MODULE_WARNING = "WARNING: Using incubator modules: jdk.incubator.vector";
+
+    private Neo4jAssertions() {}
+
+    /**
+     * Asserts that the given stderr output contains no errors. It must either be empty or contain
+     * only the expected incubator module warning; any other non-blank line fails the assertion.
+     */
+    public static void assertNoUnexpectedErrors(String stderr) {
+        String unexpected = Stream.of(stderr.split("\n"))
+                .map(String::strip)
+                .filter(line -> !line.isEmpty())
+                .filter(line -> !line.equals(INCUBATOR_MODULE_WARNING))
+                .collect(Collectors.joining("\n"));
+
+        Assertions.assertEquals("", unexpected, "Unexpected errors in stderr from container!\n" + stderr);
+    }
+}


### PR DESCRIPTION
We will soon include the `jdk.incubator.vector` by default and must update tests to accept that, and only that, warning.